### PR TITLE
fix: Dispose delegates before peer connection closed

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -156,8 +156,6 @@ namespace WebRTC
     {
         if (connection != nullptr)
         {
-            connection->Close();
-
             //Cleanup delegates/callbacks
             onCreateSDSuccess = nullptr;
             onCreateSDFailure = nullptr;
@@ -169,6 +167,8 @@ namespace WebRTC
             onDataChannel = nullptr;
             onRenegotiationNeeded = nullptr;
             onTrack = nullptr;
+
+            connection->Close();
         }
     }
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -64,6 +64,7 @@ namespace Unity.WebRTC
                 self = IntPtr.Zero;
             }
             this.disposed = true;
+            GC.SuppressFinalize(this);
         }
 
         public CodecInitializationResult GetCodecInitializationResult()


### PR DESCRIPTION
### Problem
Occur crash when called `WebRTC.Finalize()` with peer connection established.

### Cause
Calling delayed delegate when peer connection closed

### How to fix
Dispose delegates before peer connection closed as  ignore unintended delegate calling.