### PR TITLE
refactor: select encoder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,11 +13,10 @@ indent_style = space
 
 # Code files
 [*.{cs,csx,cpp,h,ts}]
-end_of_line = crlf
+end_of_line = lf
 indent_size = 4
-indent_style = space
 insert_final_newline = true
-charset = utf-8-bom
+charset = utf-8
 trim_trailing_whitespace = true
 
 ###############################

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -134,7 +134,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -pr ./utr/ bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc/
     - ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '/Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ editor_mac_version }} -c editor --wait --published'
     - |
-      ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP 'cd ~/com.unity.webrtc/WebRTC~ && ~/com.unity.webrtc/utr/utr --suite=editor --suite=playmode --scripting-backend={{ param.backend }} --loglevel=verbose --testproject=/Users/bokken/com.unity.webrtc/WebRTC~ --editor-location=/Users/bokken/.Editor --artifacts_path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results' 
+      ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP 'cd ~/com.unity.webrtc/WebRTC~ && ~/com.unity.webrtc/utr/utr --suite=editor --suite=playmode --scripting-backend={{ param.backend }} --testproject=/Users/bokken/com.unity.webrtc/WebRTC~ --editor-location=/Users/bokken/.Editor --artifacts_path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results' 
       UTR_RESULT=$?
       mkdir -p upm-ci~/test-results/
       scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r bokken@$BOKKEN_DEVICE_IP:/Users/bokken/com.unity.webrtc/WebRTC~/test-results/ upm-ci~/test-results/

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -134,7 +134,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
     - scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -pr ./utr/ bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc/
     - ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '/Users/bokken/Library/Python/3.7/bin/unity-downloader-cli -u {{ editor_mac_version }} -c editor --wait --published'
     - |
-      ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP 'cd ~/com.unity.webrtc/WebRTC~ && ~/com.unity.webrtc/utr/utr --suite=editor --suite=playmode --scripting-backend={{ param.backend }} --testproject=/Users/bokken/com.unity.webrtc/WebRTC~ --editor-location=/Users/bokken/.Editor --artifacts_path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results' 
+      ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP 'cd ~/com.unity.webrtc/WebRTC~ && ~/com.unity.webrtc/utr/utr --suite=editor --suite=playmode --scripting-backend={{ param.backend }} --loglevel=verbose --testproject=/Users/bokken/com.unity.webrtc/WebRTC~ --editor-location=/Users/bokken/.Editor --artifacts_path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results' 
       UTR_RESULT=$?
       mkdir -p upm-ci~/test-results/
       scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r bokken@$BOKKEN_DEVICE_IP:/Users/bokken/com.unity.webrtc/WebRTC~/test-results/ upm-ci~/test-results/

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -103,7 +103,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ platform.nam
       except:
       - "master"
   artifacts:
-    {{ package.name }}_il2cpp_{{ editor.version }}_{{ platform.name }}_test_results: 
+    {{ package.name }}_{{ param.backend }}_{{ editor.version }}_{{ platform.name }}_test_results: 
       paths:
         - "upm-ci~/test-results/**/*"
   dependencies:

--- a/Plugin~/WebRTCPlugin/Callback.cpp
+++ b/Plugin~/WebRTCPlugin/Callback.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "Context.h"
 #include "IUnityGraphics.h"
 #include "GraphicsDevice/GraphicsDevice.h"
@@ -58,6 +58,10 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 
 static void UNITY_INTERFACE_API OnRenderEvent(int eventID)
 {
+    if(s_context == nullptr)
+    {
+        return;
+    }
     switch(static_cast<VideoStreamRenderEventID>(eventID))
     {
         case VideoStreamRenderEventID::Initialize:

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -31,13 +31,13 @@ namespace WebRTC {
     }
 
     //Can throw exception. The caller is expected to catch it.
-    void EncoderFactory::Init(int width, int height, IGraphicsDevice* device)
+    void EncoderFactory::Init(int width, int height, IGraphicsDevice* device, UnityEncoderType encoderType)
     {
         const GraphicsDeviceType deviceType = device->GetDeviceType();
         switch (deviceType) {
 #if defined(SUPPORT_D3D11)
             case GRAPHICS_DEVICE_D3D11: {
-                if (!ContextManager::s_use_software_encoder)
+                if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
                     m_encoder = std::make_unique<NvEncoderD3D11>(width, height, device);
                 } else {

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.h
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.h
@@ -9,7 +9,7 @@ namespace WebRTC {
     public:
         static EncoderFactory& GetInstance();
         bool IsInitialized() const;
-        void Init(int width, int height, IGraphicsDevice* device); //Can throw exception. 
+        void Init(int width, int height, IGraphicsDevice* device, UnityEncoderType encoderType); //Can throw exception.
         void Shutdown();
         IEncoder *GetEncoder() const;
     private:

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -9,21 +9,24 @@
 namespace WebRTC
 {
     ContextManager ContextManager::s_instance;
-    bool ContextManager::s_use_software_encoder = false;
 
-    Context* ContextManager::GetContext(int uid)
+    Context* ContextManager::GetContext(int uid) const
     {
         auto it = s_instance.m_contexts.find(uid);
         if (it != s_instance.m_contexts.end()) {
             DebugLog("Using already created context with ID %d", uid);
             return it->second.get();
         }
+        return nullptr;
+    }
 
-        auto ctx = new Context(uid);
+    Context* ContextManager::CreateContext(int uid, UnityEncoderType encoderType)
+    {
+        auto ctx = new Context(uid, encoderType);
         s_instance.m_contexts[uid].reset(ctx);
-        DebugLog("Register context with ID %d", uid);
         return ctx;
     }
+
     CodecInitializationResult Context::GetCodecInitializationResult()
     {
         return nvVideoCapturer->GetCodecInitializationResult();
@@ -110,8 +113,9 @@ namespace WebRTC
     }
 #pragma warning(pop)
 
-    Context::Context(int uid)
+    Context::Context(int uid, UnityEncoderType encoderType)
         : m_uid(uid)
+        , m_encoderType(encoderType)
     {
         workerThread.reset(new rtc::Thread());
         workerThread->Start();
@@ -131,9 +135,12 @@ namespace WebRTC
         //Always use SoftwareEncoder on Mac for now.
         std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory = webrtc::CreateBuiltinVideoEncoderFactory();
 #else
-        std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory = ContextManager::s_use_software_encoder ? webrtc::CreateBuiltinVideoEncoderFactory() : std::make_unique<DummyVideoEncoderFactory>(nvVideoCapturer);
+        std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory =
+            m_encoderType == UnityEncoderType::UnityEncoderHardware ?
+            std::make_unique<DummyVideoEncoderFactory>(nvVideoCapturer) :
+            webrtc::CreateBuiltinVideoEncoderFactory();
 #endif
-        
+
         peerConnectionFactory = webrtc::CreatePeerConnectionFactory(
                                 workerThread.get(),
                                 workerThread.get(),
@@ -165,7 +172,7 @@ namespace WebRTC
 
     bool Context::InitializeEncoder(IGraphicsDevice* device)
     {
-        if(!nvVideoCapturer->InitializeEncoder(device))
+        if(!nvVideoCapturer->InitializeEncoder(device, m_encoderType))
         {
             return false;
         }
@@ -179,6 +186,11 @@ namespace WebRTC
     void Context::FinalizeEncoder()
     {
         nvVideoCapturer->FinalizeEncoder();
+    }
+
+    UnityEncoderType Context::GetEncoderType() const
+    {
+        return m_encoderType;
     }
 
     webrtc::MediaStreamInterface* Context::CreateVideoStream(void* frameBuffer, int width, int height)

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -14,7 +14,6 @@ namespace WebRTC
     {
         auto it = s_instance.m_contexts.find(uid);
         if (it != s_instance.m_contexts.end()) {
-            DebugLog("Using already created context with ID %d", uid);
             return it->second.get();
         }
         return nullptr;
@@ -22,6 +21,11 @@ namespace WebRTC
 
     Context* ContextManager::CreateContext(int uid, UnityEncoderType encoderType)
     {
+        auto it = s_instance.m_contexts.find(uid);
+        if(it != s_instance.m_contexts.end()) {
+            DebugLog("Using already created context with ID %d", uid);
+            return nullptr;
+        }
         auto ctx = new Context(uid, encoderType);
         s_instance.m_contexts[uid].reset(ctx);
         return ctx;
@@ -41,8 +45,8 @@ namespace WebRTC
     {
         auto it = s_instance.m_contexts.find(uid);
         if (it != s_instance.m_contexts.end()) {
-            DebugLog("Unregister context with ID %d", uid);
             s_instance.m_contexts.erase(it);
+            DebugLog("Unregistered context with ID %d", uid);
         }
     }
 

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -14,7 +14,8 @@ namespace WebRTC
     public:
         static ContextManager* GetInstance() { return &s_instance; }
      
-        Context* GetContext(int uid);
+        Context* GetContext(int uid) const;
+        Context* CreateContext(int uid, UnityEncoderType encoderType);
         void DestroyContext(int uid);
         void SetCurContext(Context*);
 
@@ -22,7 +23,6 @@ namespace WebRTC
         using ContextPtr = std::unique_ptr<Context>;
         Context* curContext = nullptr;
         void* hModule = nullptr;
-        static bool s_use_software_encoder;
     private:
         ~ContextManager();
         std::map<int, ContextPtr> m_contexts;
@@ -32,7 +32,7 @@ namespace WebRTC
     class Context
     {
     public:
-        explicit Context(int uid = -1);
+        explicit Context(int uid = -1, UnityEncoderType encoderType = UnityEncoderType::UnityEncoderHardware);
         ~Context();
 
         CodecInitializationResult GetCodecInitializationResult();
@@ -43,6 +43,7 @@ namespace WebRTC
         PeerConnectionObject* CreatePeerConnection();
         PeerConnectionObject* CreatePeerConnection(const std::string& conf);
         void DeletePeerConnection(PeerConnectionObject* obj) { clients.erase(obj); }
+        UnityEncoderType GetEncoderType() const;
 
         // You must call these methods on Rendering thread.
         bool InitializeEncoder(IGraphicsDevice* device);
@@ -60,6 +61,7 @@ namespace WebRTC
 
     private:
         int m_uid;
+        UnityEncoderType m_encoderType;
         std::unique_ptr<rtc::Thread> workerThread;
         std::unique_ptr<rtc::Thread> signalingThread;
         std::map<PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> clients;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -65,7 +65,6 @@ namespace WebRTC {
 
     bool MetalGraphicsDevice::CopyTexture(id<MTLTexture> dest, id<MTLTexture> src)
     {
-/*
         if(dest == src)
             return false;
 
@@ -100,7 +99,7 @@ namespace WebRTC {
         [blit endEncoding];
         blit = nil;
         m_unityGraphicsMetal->EndCurrentCommandEncoder();
-*/
+
         return true;
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -67,7 +67,10 @@ namespace WebRTC {
     {
         if(dest == src)
             return false;
-        
+
+        if(src.pixelFormat != dest.pixelFormat)
+            return false;
+
         m_unityGraphicsMetal->EndCurrentCommandEncoder();
 
         id<MTLCommandBuffer> commandBuffer = m_unityGraphicsMetal->CurrentCommandBuffer();
@@ -79,7 +82,7 @@ namespace WebRTC {
         MTLSize inTxtSize = MTLSizeMake(width, height, 1);
         MTLOrigin inTxtOrigin = MTLOriginMake(0, 0, 0);
         MTLOrigin outTxtOrigin = MTLOriginMake(0, 0, 0);
-            
+
         [blit copyFromTexture:src
                         sourceSlice:0
                         sourceLevel:0

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -65,6 +65,7 @@ namespace WebRTC {
 
     bool MetalGraphicsDevice::CopyTexture(id<MTLTexture> dest, id<MTLTexture> src)
     {
+/*
         if(dest == src)
             return false;
 
@@ -99,7 +100,7 @@ namespace WebRTC {
         [blit endEncoding];
         blit = nil;
         m_unityGraphicsMetal->EndCurrentCommandEncoder();
-
+*/
         return true;
     }
 

--- a/Plugin~/WebRTCPlugin/NvVideoCapturer.cpp
+++ b/Plugin~/WebRTCPlugin/NvVideoCapturer.cpp
@@ -74,11 +74,11 @@ namespace WebRTC
         encoder_->SetRate(rate);
     }
 
-    bool NvVideoCapturer::InitializeEncoder(IGraphicsDevice* device)
+    bool NvVideoCapturer::InitializeEncoder(IGraphicsDevice* device, UnityEncoderType encoderType)
     {
         try
         {
-            EncoderFactory::GetInstance().Init(width, height, device);
+            EncoderFactory::GetInstance().Init(width, height, device, encoderType);
         }
         catch(std::runtime_error& exception)
         {

--- a/Plugin~/WebRTCPlugin/NvVideoCapturer.h
+++ b/Plugin~/WebRTCPlugin/NvVideoCapturer.h
@@ -34,7 +34,7 @@ namespace WebRTC
         }
         void StartEncoder();
         void SetFrameBuffer(void* frameBuffer);
-        bool InitializeEncoder(IGraphicsDevice* device);
+        bool InitializeEncoder(IGraphicsDevice* device, UnityEncoderType encoderType);
         void FinalizeEncoder();
         void SetKeyFrame();
         void SetSize(int32 width, int32 height);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "WebRTCPlugin.h"
 #include "PeerConnectionObject.h"
 #include "Context.h"
@@ -31,19 +31,9 @@ namespace WebRTC
 
 extern "C"
 {
-    UNITY_INTERFACE_EXPORT void SetEncoderType(UnityEncoderType encoderType)
+    UNITY_INTERFACE_EXPORT UnityEncoderType ContextGetEncoderType(Context* context)
     {
-        switch (encoderType)
-        {
-        case UnityEncoderSoftware:
-            ContextManager::s_use_software_encoder = true;
-            break;
-        case UnityEncoderHardware:
-            ContextManager::s_use_software_encoder = false;
-            break;
-        default:
-            break;
-        }
+        return context->GetEncoderType();
     }
 
     UNITY_INTERFACE_EXPORT CodecInitializationResult ContextGetCodecInitializationResult(Context* context)
@@ -183,9 +173,14 @@ extern "C"
         delegateSetResolution = func;
     }
 
-    UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid)
+    UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid, UnityEncoderType encoderType)
     {
-        return ContextManager::GetInstance()->GetContext(uid);
+        auto ctx = ContextManager::GetInstance()->GetContext(uid);
+        if (ctx == nullptr)
+        {
+            ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType);
+        }
+        return ctx;
     }
 
     UNITY_INTERFACE_EXPORT void ContextDestroy(int uid)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -176,10 +176,12 @@ extern "C"
     UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid, UnityEncoderType encoderType)
     {
         auto ctx = ContextManager::GetInstance()->GetContext(uid);
-        if (ctx == nullptr)
+        if (ctx != nullptr)
         {
-            ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType);
+            DebugLog("Already created context with ID %d", uid);
+            return ctx;
         }
+        ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType);
         return ctx;
     }
 

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -19,7 +19,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width, height, m_device);
+        EncoderFactory::GetInstance().Init(width, height, m_device, UnityEncoderType::UnityEncoderHardware);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -17,7 +17,7 @@ protected:
 
         const auto width = 256;
         const auto height = 256;
-        EncoderFactory::GetInstance().Init(width, height, m_device);
+        EncoderFactory::GetInstance().Init(width, height, m_device, UnityEncoderType::UnityEncoderHardware);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
     }

--- a/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
@@ -20,7 +20,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width, height, m_device);
+        EncoderFactory::GetInstance().Init(width, height, m_device, UnityEncoderType::UnityEncoderHardware);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 
@@ -32,12 +32,12 @@ protected:
     }
 };
 TEST_P(VideoCapturerTest, InitializeAndFinalize) {
-    capturer->InitializeEncoder(m_device);
+    capturer->InitializeEncoder(m_device, WebRTC::UnityEncoderType::UnityEncoderHardware);
     capturer->FinalizeEncoder();
 }
 
 TEST_P(VideoCapturerTest, EncodeVideoData) {
-    capturer->InitializeEncoder(m_device);
+    capturer->InitializeEncoder(m_device, WebRTC::UnityEncoderType::UnityEncoderHardware);
     auto tex = m_device->CreateDefaultTextureV(width, height);
     capturer->SetFrameBuffer(tex->GetEncodeTexturePtrV());
     capturer->EncodeVideoData();

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -27,9 +27,9 @@ namespace Unity.WebRTC
             return v;
         }
 
-        public static Context Create(int id = 0)
+        public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware)
         {
-            var ptr = NativeMethods.ContextCreate(id);
+            var ptr = NativeMethods.ContextCreate(id, encoderType);
             return new Context(ptr, id);
         }
 
@@ -70,6 +70,11 @@ namespace Unity.WebRTC
         public CodecInitializationResult GetCodecInitializationResult()
         {
             return NativeMethods.ContextGetCodecInitializationResult(self);
+        }
+        
+        public EncoderType GetEncoderType()
+        {
+            return NativeMethods.ContextGetEncoderType(self);
         }
 
         public IntPtr CreatePeerConnection()

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -65,10 +65,9 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
-        public IEnumerator FinalizeEncoder()
+        public void FinalizeEncoder()
         {
             WebRTC.Context.FinalizeEncoder();
-            yield return new WaitForEndOfFrame();
         }
 
         private void StopTrack(MediaStreamTrack track)

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -66,7 +66,9 @@ namespace Unity.WebRTC
 
         public YieldInstruction FinalizeEncoder()
         {
+            Debug.Log("WebRTC.Context.FinalizeEncoder 0");
             WebRTC.Context.FinalizeEncoder();
+            Debug.Log("WebRTC.Context.FinalizeEncoder 1");
             return new WaitForEndOfFrame();
         }
 

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -44,13 +44,17 @@ namespace Unity.WebRTC
             }
             if(self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
+                var tracks = GetTracks();
+                foreach (var track in tracks)
+                {
+                    StopTrack(track);
+                }
                 switch (_streamType)
                 {
                     case MediaStreamType.Video:
                         WebRTC.Context.DeleteVideoStream(self);
                         break;
                     case MediaStreamType.Audio:
-                        Audio.Stop();
                         WebRTC.Context.DeleteAudioStream(self);
                         break;
                 }

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -240,6 +240,7 @@ namespace Unity.WebRTC
             rts[1].Create();
             camCopyRts.Add(rts);
             cam.targetTexture = rts[0];
+            /*
             cam.gameObject.AddCleanerCallback(() =>
             {
                 CameraExtension.RemoveRt(rts);
@@ -248,6 +249,7 @@ namespace Unity.WebRTC
                 UnityEngine.Object.Destroy(rts[0]);
                 UnityEngine.Object.Destroy(rts[1]);
             });
+            */
             started = true;
 
             var stream = WebRTC.Context.CaptureVideoStream(rts[1].GetNativeTexturePtr(), width, height);

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System;
+using System.Collections;
 using Unity.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -64,12 +65,10 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
-        public YieldInstruction FinalizeEncoder()
+        public IEnumerator FinalizeEncoder()
         {
-            Debug.Log("WebRTC.Context.FinalizeEncoder 0");
             WebRTC.Context.FinalizeEncoder();
-            Debug.Log("WebRTC.Context.FinalizeEncoder 1");
-            return new WaitForEndOfFrame();
+            yield return new WaitForEndOfFrame();
         }
 
         private void StopTrack(MediaStreamTrack track)
@@ -242,7 +241,6 @@ namespace Unity.WebRTC
             rts[1].Create();
             camCopyRts.Add(rts);
             cam.targetTexture = rts[0];
-            /*
             cam.gameObject.AddCleanerCallback(() =>
             {
                 CameraExtension.RemoveRt(rts);
@@ -251,7 +249,6 @@ namespace Unity.WebRTC
                 UnityEngine.Object.Destroy(rts[0]);
                 UnityEngine.Object.Destroy(rts[1]);
             });
-            */
             started = true;
 
             var stream = WebRTC.Context.CaptureVideoStream(rts[1].GetNativeTexturePtr(), width, height);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -168,6 +168,8 @@ namespace Unity.WebRTC
         {
             WebRTC.SyncContext.Post(_ =>
             {
+                if (null == WebRTC.Table)
+                    return;
                 var connection = WebRTC.Table[ptr] as RTCPeerConnection;
                 connection.OnDataChannel(new RTCDataChannel(ptrChannel, connection));
             }, null);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -281,6 +281,8 @@ namespace Unity.WebRTC
         {
             WebRTC.SyncContext.Post(_ =>
             {
+                if (null == WebRTC.Table)
+                    return;
                 var connection = WebRTC.Table[ptr] as RTCPeerConnection;
                 connection.m_opSessionDesc.desc.sdp = sdp;
                 connection.m_opSessionDesc.desc.type = type;

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -283,7 +283,9 @@ namespace Unity.WebRTC
             {
                 if (null == WebRTC.Table)
                     return;
-                var connection = WebRTC.Table[ptr] as RTCPeerConnection;
+                if (!(WebRTC.Table[ptr] is RTCPeerConnection connection))
+                    return;
+
                 connection.m_opSessionDesc.desc.sdp = sdp;
                 connection.m_opSessionDesc.desc.type = type;
                 connection.m_opSessionDesc.Done();

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -7,6 +7,12 @@ using System.Collections;
 
 namespace Unity.WebRTC
 {
+    public enum EncoderType
+    {
+        Software = 0,
+        Hardware = 1
+    }
+
     public struct RTCIceCandidate​
     {
         [MarshalAs(UnmanagedType.LPStr)]
@@ -135,8 +141,6 @@ namespace Unity.WebRTC
         public RTCSdpType type;
         [MarshalAs(UnmanagedType.LPStr)]
         public string sdp;
-
-
     }
 
     public struct RTCOfferOptions
@@ -219,10 +223,10 @@ namespace Unity.WebRTC
         private static SynchronizationContext s_syncContext;
         private static Material flipMat;
 
-        public static void Initialize()
+        public static void Initialize(EncoderType type = EncoderType.Hardware)
         {
             NativeMethods.RegisterDebugLog(DebugLog);
-            s_context = Context.Create();
+            s_context = Context.Create(encoderType:type);
             s_renderCallback = s_context.GetRenderEventFunc();
             NativeMethods.SetCurrentContext(s_context.self);
             s_syncContext = SynchronizationContext.Current;
@@ -256,6 +260,11 @@ namespace Unity.WebRTC
             s_context.Dispose();
             s_context = null;
             NativeMethods.RegisterDebugLog(null);
+        }
+
+        public static EncoderType GetEncoderType()
+        {
+            return s_context.GetEncoderType();
         }
 
         internal static string GetModuleName()
@@ -351,7 +360,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void RegisterDebugLog(DelegateDebugLog func);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreate(int uid);
+        public static extern IntPtr ContextCreate(int uid, EncoderType encoderType);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDestroy(int uid);
         [DllImport(WebRTC.Lib)]
@@ -434,6 +443,8 @@ namespace Unity.WebRTC
         public static extern IntPtr ContextDeleteVideoStream(IntPtr context, IntPtr stream);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextDeleteAudioStream(IntPtr context, IntPtr stream);
+        [DllImport(WebRTC.Lib)]
+        public static extern EncoderType ContextGetEncoderType(IntPtr context);
         [DllImport(WebRTC.Lib)]
         public static extern void MediaStreamAddTrack(IntPtr stream, IntPtr track);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -301,7 +301,7 @@ namespace Unity.WebRTC
 
         internal static Hashtable Table { get
             {
-                return (null == s_context) ? null : s_context.table;
+                return s_context?.table;
             }
         }
 

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -45,6 +45,7 @@ class ContextTest
     {
         var context = Context.Create();
         Assert.AreEqual(EncoderType.Hardware, context.GetEncoderType());
+        context.Dispose();
     }
 
     [Test]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -1,73 +1,75 @@
-﻿using NUnit.Framework;
-using Unity.WebRTC;
+using NUnit.Framework;
 
-class ContextTest
+namespace Unity.WebRTC.RuntimeTest
 {
-    [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
-    static void DebugLog(string str)
+    class ContextTest
     {
-        UnityEngine.Debug.Log(str);
-    }
+        [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
+        static void DebugLog(string str)
+        {
+            UnityEngine.Debug.Log(str);
+        }
 
-    [SetUp]
-    public void SetUp()
-    {
-        NativeMethods.RegisterDebugLog(DebugLog);
-    }
+        [SetUp]
+        public void SetUp()
+        {
+            NativeMethods.RegisterDebugLog(DebugLog);
+        }
 
-    [TearDown]
-    public void TearDown()
-    {
-        NativeMethods.RegisterDebugLog(null);
-    }
+        [TearDown]
+        public void TearDown()
+        {
+            NativeMethods.RegisterDebugLog(null);
+        }
 
-    [Test]
-    [Category("Context")]
-    public void Context_CreateAndDelete()
-    {
-    	var context = Context.Create();
-        context.Dispose();
-    }
+        [Test]
+        [Category("Context")]
+        public void Context_CreateAndDelete()
+        {
+            var context = Context.Create();
+            context.Dispose();
+        }
 
-    [Test]
-    [Category("Context")]
-    public void Context_GetCodecInitializationResult()
-    {
-        var context = Context.Create();
-        var result = context.GetCodecInitializationResult();
-        Assert.AreEqual(CodecInitializationResult.NotInitialized, result);
-        context.Dispose();
-    }
+        [Test]
+        [Category("Context")]
+        public void Context_GetCodecInitializationResult()
+        {
+            var context = Context.Create();
+            var result = context.GetCodecInitializationResult();
+            Assert.AreEqual(CodecInitializationResult.NotInitialized, result);
+            context.Dispose();
+        }
 
-    [Test]
-    [Category("Context")]
-    public void Context_GetSetEncoderType()
-    {
-        var context = Context.Create();
-        Assert.AreEqual(EncoderType.Hardware, context.GetEncoderType());
-        context.Dispose();
-    }
+        [Test]
+        [Category("Context")]
+        public void Context_GetSetEncoderType()
+        {
+            var context = Context.Create();
+            Assert.AreEqual(EncoderType.Hardware, context.GetEncoderType());
+            context.Dispose();
+        }
 
-    [Test]
-    [Category("Context")]
-    public void Context_CreateAndDeletePeerConnection()
-    {
-        var context = Context.Create();
-        var peerPtr = context.CreatePeerConnection();
-        context.DeletePeerConnection(peerPtr);
-        context.Dispose();
-    }
+        [Test]
+        [Category("Context")]
+        public void Context_CreateAndDeletePeerConnection()
+        {
+            var context = Context.Create();
+            var peerPtr = context.CreatePeerConnection();
+            context.DeletePeerConnection(peerPtr);
+            context.Dispose();
+        }
 
-    [Test]
-    [Category("Context")]
-    public void Context_CreateAndDeleteDataChannel()
-    {
-        var context = Context.Create();
-        var peerPtr = context.CreatePeerConnection();
-        var init = new RTCDataChannelInit(true);
-        var channelPtr = context.CreateDataChannel(peerPtr, "test", ref init);
-        context.DeleteDataChannel(channelPtr);
-        context.DeletePeerConnection(peerPtr);
-        context.Dispose();
+        [Test]
+        [Category("Context")]
+        public void Context_CreateAndDeleteDataChannel()
+        {
+            var context = Context.Create();
+            var peerPtr = context.CreatePeerConnection();
+            var init = new RTCDataChannelInit(true);
+            var channelPtr = context.CreateDataChannel(peerPtr, "test", ref init);
+            context.DeleteDataChannel(channelPtr);
+            context.DeletePeerConnection(peerPtr);
+            context.Dispose();
+        }
     }
 }

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -41,6 +41,14 @@ class ContextTest
 
     [Test]
     [Category("Context")]
+    public void Context_GetSetEncoderType()
+    {
+        var context = Context.Create();
+        Assert.AreEqual(EncoderType.Hardware, context.GetEncoderType());
+    }
+
+    [Test]
+    [Category("Context")]
     public void Context_CreateAndDeletePeerConnection()
     {
         var context = Context.Create();

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -1,112 +1,114 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
-using Unity.WebRTC;
 
-class DataChannelTest
+namespace Unity.WebRTC.RuntimeTest
 {
-    [SetUp]
-    public void SetUp()
+    class DataChannelTest
     {
-        WebRTC.Initialize();
-    }
-
-    [TearDown]
-    public void TearDown()
-    {
-        WebRTC.Finalize();
-    }
-
-
-    [Test]
-    public void DataChannel_CreateDataChannel()
-    {
-        RTCConfiguration config = default;
-        config.iceServers = new RTCIceServer[]
+        [SetUp]
+        public void SetUp()
         {
-            new RTCIceServer
-            {
-                urls = new string[] { "stun:stun.l.google.com:19302" }
-            }
-        };
-        var peer = new RTCPeerConnection(ref config);
-        var option1 = new RTCDataChannelInit(true);
-        var channel1 = peer.CreateDataChannel("test1", ref option1);
-        Assert.AreEqual("test1", channel1.Label);
+            WebRTC.Initialize();
+        }
 
-        // It is return -1 when channel is not connected.
-        Assert.AreEqual(channel1.Id, -1);
-
-        channel1.Close();
-        peer.Close();
-    }
-
-    /*
-    [UnityTest]
-    [Timeout(5000)]
-    public IEnumerator DataChannel_EventsAreSentToOther()
-    {
-        RTCConfiguration config = default;
-        config.iceServers = new RTCIceServer[]
+        [TearDown]
+        public void TearDown()
         {
-            new RTCIceServer
-            {
-                urls = new string[] { "stun:stun.l.google.com:19302" }
-            }
-        };
-        var peer1 = new RTCPeerConnection(ref config);
-        var peer2 = new RTCPeerConnection(ref config);
-        RTCDataChannel channel1 = null, channel2 = null;
+            WebRTC.Finalize();
+        }
 
-        peer1.OnIceCandidate = new DelegateOnIceCandidate(candidate => { peer2.AddIceCandidate(ref candidate); });
-        peer2.OnIceCandidate = new DelegateOnIceCandidate(candidate => { peer1.AddIceCandidate(ref candidate); });
-        peer2.OnDataChannel = new DelegateOnDataChannel(channel => { channel2 = channel; });
 
-        var conf = new RTCDataChannelInit(true);
-        channel1 = peer1.CreateDataChannel("data", ref conf);
+        [Test]
+        public void DataChannel_CreateDataChannel()
+        {
+            RTCConfiguration config = default;
+            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            var peer = new RTCPeerConnection(ref config);
+            var option1 = new RTCDataChannelInit(true);
+            var channel1 = peer.CreateDataChannel("test1", ref option1);
+            Assert.AreEqual("test1", channel1.Label);
 
-        RTCOfferOptions options1 = default;
-        RTCAnswerOptions options2 = default;
-        var op1 = peer1.CreateOffer(ref options1);
-        yield return op1;
-        var op2 = peer1.SetLocalDescription(ref op1.desc);
-        yield return op2;
-        var op3 = peer2.SetRemoteDescription(ref op1.desc);
-        yield return op3;
-        var op4 = peer2.CreateAnswer(ref options2);
-        yield return op4;
-        var op5 = peer2.SetLocalDescription(ref op4.desc);
-        yield return op5;
-        var op6 = peer1.SetRemoteDescription(ref op4.desc);
-        yield return op6;
+            // It is return -1 when channel is not connected.
+            Assert.AreEqual(channel1.Id, -1);
 
-        yield return new WaitUntil(() => peer1.IceConnectionState == RTCIceConnectionState.Connected || peer1.IceConnectionState == RTCIceConnectionState.Completed);
-        yield return new WaitUntil(() => peer2.IceConnectionState == RTCIceConnectionState.Connected || peer2.IceConnectionState == RTCIceConnectionState.Completed);
-        yield return new WaitUntil(() => channel2 != null);
+            channel1.Close();
+            peer.Close();
+        }
 
-        Assert.AreEqual(channel1.Label, channel2.Label);
-        Assert.AreEqual(channel1.Id, channel2.Id);
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator DataChannel_EventsAreSentToOther()
+        {
+            RTCConfiguration config = default;
+            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+            RTCDataChannel channel1 = null, channel2 = null;
 
-        string message1 = "hello";
-        string message2 = null;
-        channel2.OnMessage = new DelegateOnMessage(bytes => { message2 = System.Text.Encoding.UTF8.GetString(bytes); });
-        channel1.Send(message1);
-        yield return new WaitUntil(() => !string.IsNullOrEmpty(message2));
-        Assert.AreEqual(message1, message2);
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
+            peer2.OnDataChannel = channel => { channel2 = channel; };
 
-        byte[] message3 = { 1, 2, 3 };
-        byte[] message4 = null;
-        channel2.OnMessage = new DelegateOnMessage(bytes => { message4 = bytes; });
-        channel1.Send(message3);
-        yield return new WaitUntil(() => message4 != null);
-        Assert.AreEqual(message3, message4);
+            var conf = new RTCDataChannelInit(true);
+            channel1 = peer1.CreateDataChannel("data", ref conf);
 
-        channel1.Close();
-        channel2.Close();
+            RTCOfferOptions options1 = default;
+            RTCAnswerOptions options2 = default;
+            var op1 = peer1.CreateOffer(ref options1);
+            yield return op1;
+            var op2 = peer1.SetLocalDescription(ref op1.desc);
+            yield return op2;
+            var op3 = peer2.SetRemoteDescription(ref op1.desc);
+            yield return op3;
+            var op4 = peer2.CreateAnswer(ref options2);
+            yield return op4;
+            var op5 = peer2.SetLocalDescription(ref op4.desc);
+            yield return op5;
+            var op6 = peer1.SetRemoteDescription(ref op4.desc);
+            yield return op6;
 
-        peer1.Close();
-        peer2.Close();
+            var op7 = new WaitUntilWithTimeout(
+                () => peer1.IceConnectionState == RTCIceConnectionState.Connected ||
+                      peer1.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op7;
+            Assert.True(op7.IsCompleted);
+            var op8 = new WaitUntilWithTimeout(
+                () => peer2.IceConnectionState == RTCIceConnectionState.Connected ||
+                      peer2.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op8;
+            Assert.True(op8.IsCompleted);
+            var op9 = new WaitUntilWithTimeout(() => channel2 != null, 5000);
+            yield return op9;
+            Assert.True(op9.IsCompleted);
+
+            Assert.AreEqual(channel1.Label, channel2.Label);
+            Assert.AreEqual(channel1.Id, channel2.Id);
+
+            string message1 = "hello";
+            string message2 = null;
+            channel2.OnMessage = bytes => { message2 = System.Text.Encoding.UTF8.GetString(bytes); };
+            channel1.Send(message1);
+            var op10 = new WaitUntilWithTimeout(() => !string.IsNullOrEmpty(message2), 5000);
+            yield return op10;
+            Assert.True(op10.IsCompleted);
+            Assert.AreEqual(message1, message2);
+
+            byte[] message3 = {1, 2, 3};
+            byte[] message4 = null;
+            channel2.OnMessage = bytes => { message4 = bytes; };
+            channel1.Send(message3);
+            var op11 = new WaitUntilWithTimeout(() => message4 != null, 5000);
+            yield return op11;
+            Assert.True(op11.IsCompleted);
+            Assert.AreEqual(message3, message4);
+
+            channel1.Close();
+            channel2.Close();
+
+            peer1.Close();
+            peer2.Close();
+        }
     }
-    */
 }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -1,97 +1,105 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
-using Unity.WebRTC;
 
-class MediaStreamTest
+namespace Unity.WebRTC.RuntimeTest
 {
-    [SetUp]
-    public void SetUp()
+    class MediaStreamTest
     {
-        WebRTC.Initialize();
-    }
-
-    [TearDown]
-    public void TearDown()
-    {
-        WebRTC.Finalize();
-    }
-
-    [UnityTest]
-    [Timeout(5000)]
-    public IEnumerator MediaStreamTest_AddAndRemoveMediaStream()
-    {
-        var camObj = new GameObject("Camera");
-        var cam = camObj.AddComponent<Camera>();
-        RTCConfiguration config = default;
-        config.iceServers = new RTCIceServer[]
+        [SetUp]
+        public void SetUp()
         {
-            new RTCIceServer
+            WebRTC.Initialize();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            WebRTC.Finalize();
+        }
+
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator MediaStreamTest_AddAndRemoveMediaStream()
+        {
+            var camObj = new GameObject("Camera");
+            var cam = camObj.AddComponent<Camera>();
+            RTCConfiguration config = default;
+            config.iceServers = new[]
             {
-                urls = new string[] { "stun:stun.l.google.com:19302" }
+                new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}
+            };
+
+            var pc1Senders = new List<RTCRtpSender>();
+            var pc2Senders = new List<RTCRtpSender>();
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
+            peer2.OnTrack = e => { pc2Senders.Add(peer2.AddTrack(e.Track)); };
+            var videoStream = cam.CaptureStream(1280, 720);
+            yield return new WaitForEndOfFrame();
+
+            foreach (var track in videoStream.GetTracks())
+            {
+                pc1Senders.Add(peer1.AddTrack(track));
             }
-        };
 
-        var pc1Senders = new List<RTCRtpSender>();
-        var pc2Senders = new List<RTCRtpSender>();
-        var peer1 = new RTCPeerConnection(ref config);
-        var peer2 = new RTCPeerConnection(ref config);
+            var audioStream = Audio.CaptureStream();
+            peer1.AddTrack(audioStream.GetTracks()[0]);
 
-        peer1.OnIceCandidate = new DelegateOnIceCandidate(candidate => { peer2.AddIceCandidate(ref candidate); });
-        peer2.OnIceCandidate = new DelegateOnIceCandidate(candidate => { peer1.AddIceCandidate(ref candidate); });
-        peer2.OnTrack = new DelegateOnTrack(e =>
-        {
-            pc2Senders.Add(peer2.AddTrack(e.Track));
-        });
-        var videoStream = cam.CaptureStream(1280, 720);
-        yield return new WaitForEndOfFrame();
+            RTCOfferOptions options1 = default;
+            RTCAnswerOptions options2 = default;
+            var op1 = peer1.CreateOffer(ref options1);
+            yield return op1;
+            var op2 = peer1.SetLocalDescription(ref op1.desc);
+            yield return op2;
+            var op3 = peer2.SetRemoteDescription(ref op1.desc);
+            yield return op3;
+            var op4 = peer2.CreateAnswer(ref options2);
+            yield return op4;
+            var op5 = peer2.SetLocalDescription(ref op4.desc);
+            yield return op5;
+            var op6 = peer1.SetRemoteDescription(ref op4.desc);
+            yield return op6;
 
-        foreach (var track in videoStream.GetTracks())
-        {
-            pc1Senders.Add(peer1.AddTrack(track));
+            var op7 = new WaitUntilWithTimeout(() =>
+                peer1.IceConnectionState == RTCIceConnectionState.Connected ||
+                peer1.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op7;
+            Assert.True(op7.IsCompleted);
+
+            var op8 = new WaitUntilWithTimeout(() =>
+                peer2.IceConnectionState == RTCIceConnectionState.Connected ||
+                peer2.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op8;
+            Assert.True(op7.IsCompleted);
+
+            var op9 = new WaitUntilWithTimeout(() => pc2Senders.Count > 0, 5000);
+            yield return op9;
+            Assert.True(op9.IsCompleted);
+
+            foreach (var sender in pc1Senders)
+            {
+                peer1.RemoveTrack(sender);
+            }
+
+            foreach (var sender in pc2Senders)
+            {
+                peer2.RemoveTrack(sender);
+            }
+
+            pc1Senders.Clear();
+            GameObject.DestroyImmediate(camObj);
+
+            peer1.Close();
+            peer2.Close();
+
+            yield return videoStream.FinalizeEncoder();
+            videoStream.Dispose();
         }
-
-        var audioStream = Audio.CaptureStream();
-        peer1.AddTrack(audioStream.GetTracks()[0]);
-
-        var conf = new RTCDataChannelInit(true);
-
-        RTCOfferOptions options1 = default;
-        RTCAnswerOptions options2 = default;
-        var op1 = peer1.CreateOffer(ref options1);
-        yield return op1;
-        var op2 = peer1.SetLocalDescription(ref op1.desc);
-        yield return op2;
-        var op3 = peer2.SetRemoteDescription(ref op1.desc);
-        yield return op3;
-        var op4 = peer2.CreateAnswer(ref options2);
-        yield return op4;
-        var op5 = peer2.SetLocalDescription(ref op4.desc);
-        yield return op5;
-        var op6 = peer1.SetRemoteDescription(ref op4.desc);
-        yield return op6;
-
-        yield return new WaitUntil(() => peer1.IceConnectionState == RTCIceConnectionState.Connected || peer1.IceConnectionState == RTCIceConnectionState.Completed);
-        yield return new WaitUntil(() => peer2.IceConnectionState == RTCIceConnectionState.Connected || peer2.IceConnectionState == RTCIceConnectionState.Completed);
-        yield return new WaitUntil(() => pc2Senders.Count > 0);
-
-        foreach (var sender in pc1Senders)
-        {
-            peer1.RemoveTrack(sender);
-        }
-        foreach (var sender in pc2Senders)
-        {
-            peer2.RemoveTrack(sender);
-        }
-        pc1Senders.Clear();
-        GameObject.DestroyImmediate(camObj);
-
-        peer1.Close();
-        peer2.Close();
-
-        yield return videoStream.FinalizeEncoder();
-        videoStream.Dispose();
     }
 }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -19,6 +19,7 @@ class MediaStreamTest
         WebRTC.Finalize();
     }
 
+    /*
     [UnityTest]
     [Timeout(5000)]
     public IEnumerator MediaStreamTest_AddAndRemoveMediaStream()
@@ -94,4 +95,5 @@ class MediaStreamTest
         yield return videoStream.FinalizeEncoder();
         videoStream.Dispose();
     }
+    */
 }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -21,8 +21,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        [Timeout(10000)]
-        //[UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
+        [Timeout(5000)]
+        [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
             var camObj = new GameObject("Camera");
@@ -50,7 +50,7 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [UnityTest]
-        [Timeout(10000)]
+        [Timeout(5000)]
         public IEnumerator MediaStreamTest_AddAndRemoveAudioTrack()
         {
             RTCConfiguration config = default;
@@ -67,7 +67,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        [Timeout(10000)]
+        [Timeout(5000)]
         [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoTrack()
         {
@@ -138,17 +138,17 @@ namespace Unity.WebRTC.RuntimeTest
 
                 var op7 = new WaitUntilWithTimeout(() =>
                     peer1.IceConnectionState == RTCIceConnectionState.Connected ||
-                    peer1.IceConnectionState == RTCIceConnectionState.Completed, 10000);
+                    peer1.IceConnectionState == RTCIceConnectionState.Completed, 5000);
                 yield return op7;
                 Assert.True(op7.IsCompleted);
 
                 var op8 = new WaitUntilWithTimeout(() =>
                     peer2.IceConnectionState == RTCIceConnectionState.Connected ||
-                    peer2.IceConnectionState == RTCIceConnectionState.Completed, 10000);
+                    peer2.IceConnectionState == RTCIceConnectionState.Completed, 5000);
                 yield return op8;
                 Assert.True(op7.IsCompleted);
 
-                var op9 = new WaitUntilWithTimeout(() => pc2Senders.Count > 0, 10000);
+                var op9 = new WaitUntilWithTimeout(() => pc2Senders.Count > 0, 5000);
                 yield return op9;
                 Assert.True(op9.IsCompleted);
 

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -39,6 +39,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return videoStream.FinalizeEncoder();
             Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
             yield return new WaitForSeconds(0.1f);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             videoStream.Dispose();
             Object.DestroyImmediate(camObj);
         }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -19,7 +19,6 @@ class MediaStreamTest
         WebRTC.Finalize();
     }
 
-    /*
     [UnityTest]
     [Timeout(5000)]
     public IEnumerator MediaStreamTest_AddAndRemoveMediaStream()
@@ -95,5 +94,4 @@ class MediaStreamTest
         yield return videoStream.FinalizeEncoder();
         videoStream.Dispose();
     }
-    */
 }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -31,18 +31,14 @@ namespace Unity.WebRTC.RuntimeTest
             var camObj = new GameObject("Camera");
             var cam = camObj.AddComponent<Camera>();
             var videoStream = cam.CaptureStream(1280, 720);
-            yield return new WaitForSeconds(1.0f);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 0");
+            yield return new WaitForSeconds(0.1f);
             Assert.AreEqual(1, videoStream.GetVideoTracks().Length);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
             Assert.AreEqual(0, videoStream.GetAudioTracks().Length);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             Assert.AreEqual(1, videoStream.GetTracks().Length);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 3");
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 0");
             yield return videoStream.FinalizeEncoder();
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 4");
-            yield return new WaitForSeconds(1.0f);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 5");
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
+            yield return new WaitForSeconds(0.1f);
             videoStream.Dispose();
             Object.DestroyImmediate(camObj);
         }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -24,7 +24,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        //[UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
 
@@ -63,15 +62,14 @@ namespace Unity.WebRTC.RuntimeTest
             };
             var audioStream = Audio.CaptureStream();
 
-            var test = new MonoBehaviourTest<SignalingPeersTest>().component;
-            test.SetStream(audioStream);
+            var test = new MonoBehaviourTest<SignalingPeersTest>();
+            test.component.SetStream(audioStream);
             yield return test;
             audioStream.Dispose();
         }
 
         [UnityTest]
         [Timeout(5000)]
-        //[UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoTrack()
         {
             var camObj = new GameObject("Camera");
@@ -79,8 +77,8 @@ namespace Unity.WebRTC.RuntimeTest
             var videoStream = cam.CaptureStream(1280, 720);
             yield return new WaitForSeconds(0.1f);
 
-            var test = new MonoBehaviourTest<SignalingPeersTest>().component;
-            test.SetStream(videoStream);
+            var test = new MonoBehaviourTest<SignalingPeersTest>();
+            test.component.SetStream(videoStream);
             yield return test;
             videoStream.FinalizeEncoder();
             yield return new WaitForSeconds(0.1f);

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -12,12 +12,14 @@ namespace Unity.WebRTC.RuntimeTest
         public void SetUp()
         {
             WebRTC.Initialize();
+            Debug.Log("MediaStreamTest SetUp");
         }
 
         [TearDown]
         public void TearDown()
         {
             WebRTC.Finalize();
+            Debug.Log("MediaStreamTest TearDown");
         }
 
         [UnityTest]
@@ -25,17 +27,21 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
             var camObj = new GameObject("Camera");
             var cam = camObj.AddComponent<Camera>();
             var videoStream = cam.CaptureStream(1280, 720);
             yield return new WaitForSeconds(1.0f);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             Assert.AreEqual(1, videoStream.GetVideoTracks().Length);
             Assert.AreEqual(0, videoStream.GetAudioTracks().Length);
             Assert.AreEqual(1, videoStream.GetTracks().Length);
             yield return videoStream.FinalizeEncoder();
             yield return new WaitForSeconds(1.0f);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 3");
             videoStream.Dispose();
             Object.DestroyImmediate(camObj);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 4");
         }
 
         [Test]

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -33,10 +33,6 @@ class MediaStreamTest
                 urls = new string[] { "stun:stun.l.google.com:19302" }
             }
         };
-        if(!WebRTC.HWEncoderSupport)
-        {
-            Assert.Pass("Test environment does not support HW encoding");
-        }
 
         var pc1Senders = new List<RTCRtpSender>();
         var pc2Senders = new List<RTCRtpSender>();

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -21,8 +21,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        [Timeout(5000)]
-        [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
+        [Timeout(10000)]
+        //[UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
             var camObj = new GameObject("Camera");
@@ -50,7 +50,7 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [UnityTest]
-        [Timeout(5000)]
+        [Timeout(10000)]
         public IEnumerator MediaStreamTest_AddAndRemoveAudioTrack()
         {
             RTCConfiguration config = default;
@@ -67,7 +67,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        [Timeout(5000)]
+        [Timeout(10000)]
         [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoTrack()
         {
@@ -138,17 +138,17 @@ namespace Unity.WebRTC.RuntimeTest
 
                 var op7 = new WaitUntilWithTimeout(() =>
                     peer1.IceConnectionState == RTCIceConnectionState.Connected ||
-                    peer1.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+                    peer1.IceConnectionState == RTCIceConnectionState.Completed, 10000);
                 yield return op7;
                 Assert.True(op7.IsCompleted);
 
                 var op8 = new WaitUntilWithTimeout(() =>
                     peer2.IceConnectionState == RTCIceConnectionState.Connected ||
-                    peer2.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+                    peer2.IceConnectionState == RTCIceConnectionState.Completed, 10000);
                 yield return op8;
                 Assert.True(op7.IsCompleted);
 
-                var op9 = new WaitUntilWithTimeout(() => pc2Senders.Count > 0, 5000);
+                var op9 = new WaitUntilWithTimeout(() => pc2Senders.Count > 0, 10000);
                 yield return op9;
                 Assert.True(op9.IsCompleted);
 

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -21,6 +21,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
+        [Timeout(5000)]
+        [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
             var camObj = new GameObject("Camera");
@@ -119,6 +121,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoTrack()
         {
             var camObj = new GameObject("Camera");

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -24,7 +24,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
+        //[UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
 
@@ -37,11 +37,13 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(1, videoStream.GetTracks().Length);
             Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 0");
             yield return videoStream.FinalizeEncoder();
+            //Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
+            //yield return new WaitForSeconds(0.1f);
             Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
-            yield return new WaitForSeconds(0.1f);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             videoStream.Dispose();
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             Object.DestroyImmediate(camObj);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 3");
         }
 
         [Test]
@@ -74,7 +76,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
+        //[UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoTrack()
         {
             var camObj = new GameObject("Camera");

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -21,29 +21,42 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        public IEnumerator MediaStreamTest_AddAndRemoveTrack()
+        public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
             var camObj = new GameObject("Camera");
             var cam = camObj.AddComponent<Camera>();
             var videoStream = cam.CaptureStream(1280, 720);
             yield return new WaitForSeconds(1.0f);
+            Assert.AreEqual(1, videoStream.GetVideoTracks().Length);
+            Assert.AreEqual(0, videoStream.GetAudioTracks().Length);
+            Assert.AreEqual(1, videoStream.GetTracks().Length);
             yield return videoStream.FinalizeEncoder();
             yield return new WaitForSeconds(1.0f);
             videoStream.Dispose();
+            Object.DestroyImmediate(camObj);
         }
+
+        [Test]
+        public void MediaStreamTest_AddAndRemoveAudioStream()
+        {
+            var audioStream = Audio.CaptureStream();
+            Assert.AreEqual(1, audioStream.GetAudioTracks().Length);
+            Assert.AreEqual(0, audioStream.GetVideoTracks().Length);
+            Assert.AreEqual(1, audioStream.GetTracks().Length);
+            audioStream.Dispose();
+        }
+
 
         [UnityTest]
         [Timeout(5000)]
-        public IEnumerator MediaStreamTest_AddAndRemoveMediaStream()
+        public IEnumerator MediaStreamTest_AddAndRemoveAudioTrack()
         {
-            var camObj = new GameObject("Camera");
-            var cam = camObj.AddComponent<Camera>();
             RTCConfiguration config = default;
             config.iceServers = new[]
             {
                 new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}
             };
-
+            var audioStream = Audio.CaptureStream();
             var pc1Senders = new List<RTCRtpSender>();
             var pc2Senders = new List<RTCRtpSender>();
             var peer1 = new RTCPeerConnection(ref config);
@@ -52,16 +65,11 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
             peer2.OnTrack = e => { pc2Senders.Add(peer2.AddTrack(e.Track)); };
-            var videoStream = cam.CaptureStream(1280, 720);
-            yield return new WaitForSeconds(1.0f);
 
-            foreach (var track in videoStream.GetTracks())
+            foreach (var track in audioStream.GetTracks())
             {
                 pc1Senders.Add(peer1.AddTrack(track));
             }
-
-            var audioStream = Audio.CaptureStream();
-            peer1.AddTrack(audioStream.GetTracks()[0]);
 
             RTCOfferOptions options1 = default;
             RTCAnswerOptions options2 = default;
@@ -103,16 +111,88 @@ namespace Unity.WebRTC.RuntimeTest
             {
                 peer2.RemoveTrack(sender);
             }
-
             pc1Senders.Clear();
-            GameObject.DestroyImmediate(camObj);
+            peer1.Close();
+            peer2.Close();
+            audioStream.Dispose();
+        }
 
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator MediaStreamTest_AddAndRemoveVideoTrack()
+        {
+            var camObj = new GameObject("Camera");
+            var cam = camObj.AddComponent<Camera>();
+            RTCConfiguration config = default;
+            config.iceServers = new[]
+            {
+                new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}
+            };
+
+            var pc1Senders = new List<RTCRtpSender>();
+            var pc2Senders = new List<RTCRtpSender>();
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
+            peer2.OnTrack = e => { pc2Senders.Add(peer2.AddTrack(e.Track)); };
+            var videoStream = cam.CaptureStream(1280, 720);
+            yield return new WaitForSeconds(1.0f);
+
+            foreach (var track in videoStream.GetTracks())
+            {
+                pc1Senders.Add(peer1.AddTrack(track));
+            }
+
+            RTCOfferOptions options1 = default;
+            RTCAnswerOptions options2 = default;
+            var op1 = peer1.CreateOffer(ref options1);
+            yield return op1;
+            var op2 = peer1.SetLocalDescription(ref op1.desc);
+            yield return op2;
+            var op3 = peer2.SetRemoteDescription(ref op1.desc);
+            yield return op3;
+            var op4 = peer2.CreateAnswer(ref options2);
+            yield return op4;
+            var op5 = peer2.SetLocalDescription(ref op4.desc);
+            yield return op5;
+            var op6 = peer1.SetRemoteDescription(ref op4.desc);
+            yield return op6;
+
+            var op7 = new WaitUntilWithTimeout(() =>
+                peer1.IceConnectionState == RTCIceConnectionState.Connected ||
+                peer1.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op7;
+            Assert.True(op7.IsCompleted);
+
+            var op8 = new WaitUntilWithTimeout(() =>
+                peer2.IceConnectionState == RTCIceConnectionState.Connected ||
+                peer2.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op8;
+            Assert.True(op7.IsCompleted);
+
+            var op9 = new WaitUntilWithTimeout(() => pc2Senders.Count > 0, 5000);
+            yield return op9;
+            Assert.True(op9.IsCompleted);
+
+            foreach (var sender in pc1Senders)
+            {
+                peer1.RemoveTrack(sender);
+            }
+
+            foreach (var sender in pc2Senders)
+            {
+                peer2.RemoveTrack(sender);
+            }
+            pc1Senders.Clear();
             peer1.Close();
             peer2.Close();
 
             yield return videoStream.FinalizeEncoder();
             yield return new WaitForSeconds(1.0f);
             videoStream.Dispose();
+            Object.DestroyImmediate(camObj);
         }
     }
 }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -35,15 +35,10 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(1, videoStream.GetVideoTracks().Length);
             Assert.AreEqual(0, videoStream.GetAudioTracks().Length);
             Assert.AreEqual(1, videoStream.GetTracks().Length);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 0");
-            yield return videoStream.FinalizeEncoder();
-            //Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
-            //yield return new WaitForSeconds(0.1f);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
+            videoStream.FinalizeEncoder();
+            yield return new WaitForSeconds(0.1f);
             videoStream.Dispose();
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             Object.DestroyImmediate(camObj);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 3");
         }
 
         [Test]
@@ -82,13 +77,13 @@ namespace Unity.WebRTC.RuntimeTest
             var camObj = new GameObject("Camera");
             var cam = camObj.AddComponent<Camera>();
             var videoStream = cam.CaptureStream(1280, 720);
-            yield return new WaitForSeconds(1.0f);
+            yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeersTest>().component;
             test.SetStream(videoStream);
             yield return test;
-            yield return videoStream.FinalizeEncoder();
-            yield return new WaitForSeconds(1.0f);
+            videoStream.FinalizeEncoder();
+            yield return new WaitForSeconds(0.1f);
             videoStream.Dispose();
             Object.DestroyImmediate(camObj);
         }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -21,6 +21,18 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
+        public IEnumerator MediaStreamTest_AddAndRemoveTrack()
+        {
+            var camObj = new GameObject("Camera");
+            var cam = camObj.AddComponent<Camera>();
+            var videoStream = cam.CaptureStream(1280, 720);
+            yield return new WaitForSeconds(1.0f);
+            yield return videoStream.FinalizeEncoder();
+            yield return new WaitForSeconds(1.0f);
+            videoStream.Dispose();
+        }
+
+        [UnityTest]
         [Timeout(5000)]
         public IEnumerator MediaStreamTest_AddAndRemoveMediaStream()
         {
@@ -41,7 +53,7 @@ namespace Unity.WebRTC.RuntimeTest
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
             peer2.OnTrack = e => { pc2Senders.Add(peer2.AddTrack(e.Track)); };
             var videoStream = cam.CaptureStream(1280, 720);
-            yield return new WaitForEndOfFrame();
+            yield return new WaitForSeconds(1.0f);
 
             foreach (var track in videoStream.GetTracks())
             {
@@ -99,6 +111,7 @@ namespace Unity.WebRTC.RuntimeTest
             peer2.Close();
 
             yield return videoStream.FinalizeEncoder();
+            yield return new WaitForSeconds(1.0f);
             videoStream.Dispose();
         }
     }

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -27,21 +27,24 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] {RuntimePlatform.OSXEditor})] // TODO:: fix Crush bug on Yamato
         public IEnumerator MediaStreamTest_AddAndRemoveVideoStream()
         {
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
+
             var camObj = new GameObject("Camera");
             var cam = camObj.AddComponent<Camera>();
             var videoStream = cam.CaptureStream(1280, 720);
             yield return new WaitForSeconds(1.0f);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 0");
             Assert.AreEqual(1, videoStream.GetVideoTracks().Length);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 1");
             Assert.AreEqual(0, videoStream.GetAudioTracks().Length);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 2");
             Assert.AreEqual(1, videoStream.GetTracks().Length);
-            yield return videoStream.FinalizeEncoder();
-            yield return new WaitForSeconds(1.0f);
             Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 3");
+            yield return videoStream.FinalizeEncoder();
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 4");
+            yield return new WaitForSeconds(1.0f);
+            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 5");
             videoStream.Dispose();
             Object.DestroyImmediate(camObj);
-            Debug.Log("MediaStreamTest_AddAndRemoveVideoStream 4");
         }
 
         [Test]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -39,7 +39,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void Init()
         {
             NativeMethods.RegisterDebugLog(DebugLog);
-            encoderType = EncoderType.Software;
+            encoderType = EncoderType.Hardware;
             Debug.Log("Init");
         }
 

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -21,6 +21,14 @@ namespace Unity.WebRTC.RuntimeTest
     {
         protected EncoderType encoderType;
 
+        private static RenderTexture CreateRenderTexture(int width, int height)
+        {
+            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var renderTexture = new RenderTexture(width, height, 0, format);
+            renderTexture.Create();
+            return renderTexture;
+        }
+
         [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
         protected static void DebugLog(string str)
         {
@@ -84,13 +92,13 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             const int width = 1280;
             const int height = 720;
-            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-            var renderTexture = new RenderTexture(width, height, 0, format);
-            renderTexture.Create();
+            var renderTexture = CreateRenderTexture(width, height);
             var stream =
                 NativeMethods.ContextCreateVideoStream(context, renderTexture.GetNativeTexturePtr(), width, height);
             NativeMethods.ContextDeleteVideoStream(context, stream);
             NativeMethods.ContextDestroy(0);
+
+            UnityEngine.Object.DestroyImmediate(renderTexture);
         }
 
         [Test]
@@ -119,9 +127,7 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             const int width = 1280;
             const int height = 720;
-            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-            var renderTexture = new RenderTexture(width, height, 0, format);
-            renderTexture.Create();
+            var renderTexture = CreateRenderTexture(width, height);
             var stream =
                 NativeMethods.ContextCreateVideoStream(context, renderTexture.GetNativeTexturePtr(), width, height);
             var callback = NativeMethods.GetRenderEventFunc(context);
@@ -137,6 +143,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             NativeMethods.ContextDeleteVideoStream(context, stream);
             NativeMethods.ContextDestroy(0);
+
+            UnityEngine.Object.DestroyImmediate(renderTexture);
         }
     }
 

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -2,123 +2,135 @@
 using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
-using Unity.WebRTC;
 using UnityEngine.TestTools;
 
-class NativeAPITest
+namespace Unity.WebRTC.RuntimeTest
 {
-    [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
-    static void DebugLog(string str)
+    [TestFixture(EncoderType.Software)]
+    [TestFixture(EncoderType.Hardware)]
+    class NativeAPITest
     {
-        Debug.Log(str);
-    }
+        private readonly EncoderType _encoderType;
 
-    [SetUp]
-    public void SetUp()
-    {
-        NativeMethods.RegisterDebugLog(DebugLog);
-    }
-
-    [TearDown]
-    public void TearDown()
-    {
-        NativeMethods.RegisterDebugLog(null);
-    }
-
-    [Test]
-    public void CreateAndDestroyContext()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        NativeMethods.ContextDestroy(0);
-    }
-
-    [Test]
-    public void GetEncoderType()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        Assert.AreEqual(EncoderType.Hardware, NativeMethods.ContextGetEncoderType(context));
-        NativeMethods.ContextDestroy(0);
-
-        var context2 = NativeMethods.ContextCreate(0, EncoderType.Software);
-        Assert.AreEqual(EncoderType.Software, NativeMethods.ContextGetEncoderType(context2));
-        NativeMethods.ContextDestroy(0);
-    }
-
-    [Test]
-    public void CreateAndDeletePeerConnection()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        var peer = NativeMethods.ContextCreatePeerConnection(context);
-        NativeMethods.ContextDeletePeerConnection(context, peer);
-        NativeMethods.ContextDestroy(0);
-    }
-
-    [Test]
-    public void CreateAndDeleteDataChannel()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        var peer = NativeMethods.ContextCreatePeerConnection(context);
-        var init = new RTCDataChannelInit(true);
-        var channel = NativeMethods.ContextCreateDataChannel(context, peer, "test", ref init);
-        NativeMethods.ContextDeleteDataChannel(context, channel);
-        NativeMethods.ContextDeletePeerConnection(context, peer);
-        NativeMethods.ContextDestroy(0);
-    }
-    [Test]
-    public void CreateAndDeleteVideoStream()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        const int width = 1280;
-        const int height = 720;
-        var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-        var renderTexture = new RenderTexture(width, height, 0, format);
-        renderTexture.Create();
-        var stream = NativeMethods.ContextCreateVideoStream(context, renderTexture.GetNativeTexturePtr(), width, height);
-        NativeMethods.ContextDeleteVideoStream(context, stream);
-        NativeMethods.ContextDestroy(0);
-    }
-
-    [Test]
-    public void CreateAndDeleteAudioStream()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        var stream = NativeMethods.ContextCreateAudioStream(context);
-        NativeMethods.ContextDeleteAudioStream(context, stream);
-        NativeMethods.ContextDestroy(0);
-    }
+        public NativeAPITest(EncoderType encoderType)
+        {
+            _encoderType = encoderType;
+        }
 
 
-    [Test]
-    public void CallGetRenderEventFunc()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        var callback = NativeMethods.GetRenderEventFunc(context);
-        Assert.AreNotEqual(callback, IntPtr.Zero);
-        NativeMethods.ContextDestroy(0);
-    }
+        [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
+        static void DebugLog(string str)
+        {
+            Debug.Log(str);
+        }
 
-    [UnityTest]
-    public IEnumerator CallVideoEncoderMethods()
-    {
-        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
-        const int width = 1280;
-        const int height = 720;
-        var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-        var renderTexture = new RenderTexture(width, height, 0, format);
-        renderTexture.Create();
-        var stream = NativeMethods.ContextCreateVideoStream(context, renderTexture.GetNativeTexturePtr(), width, height);
-        var callback = NativeMethods.GetRenderEventFunc(context);
+        [SetUp]
+        public void SetUp()
+        {
+            NativeMethods.RegisterDebugLog(DebugLog);
+        }
 
-        // TODO::
-        // note:: You must call `InitializeEncoder` method after `NativeMethods.ContextCaptureVideoStream`
-        VideoEncoderMethods.InitializeEncoder(callback);
-        yield return new WaitForSeconds(1.0f);
-        VideoEncoderMethods.Encode(callback);
-        yield return new WaitForSeconds(1.0f);
-        VideoEncoderMethods.FinalizeEncoder(callback);
-        yield return new WaitForSeconds(1.0f);
+        [TearDown]
+        public void TearDown()
+        {
+            NativeMethods.RegisterDebugLog(null);
+        }
 
-        NativeMethods.ContextDeleteVideoStream(context, stream);
-        NativeMethods.ContextDestroy(0);
+        [Test]
+        public void CreateAndDestroyContext()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            NativeMethods.ContextDestroy(0);
+        }
+
+        [Test]
+        public void GetEncoderType()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            Assert.AreEqual(_encoderType, NativeMethods.ContextGetEncoderType(context));
+            NativeMethods.ContextDestroy(0);
+        }
+
+        [Test]
+        public void CreateAndDeletePeerConnection()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var peer = NativeMethods.ContextCreatePeerConnection(context);
+            NativeMethods.ContextDeletePeerConnection(context, peer);
+            NativeMethods.ContextDestroy(0);
+        }
+
+        [Test]
+        public void CreateAndDeleteDataChannel()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var peer = NativeMethods.ContextCreatePeerConnection(context);
+            var init = new RTCDataChannelInit(true);
+            var channel = NativeMethods.ContextCreateDataChannel(context, peer, "test", ref init);
+            NativeMethods.ContextDeleteDataChannel(context, channel);
+            NativeMethods.ContextDeletePeerConnection(context, peer);
+            NativeMethods.ContextDestroy(0);
+        }
+
+        [Test]
+        public void CreateAndDeleteVideoStream()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            const int width = 1280;
+            const int height = 720;
+            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var renderTexture = new RenderTexture(width, height, 0, format);
+            renderTexture.Create();
+            var stream =
+                NativeMethods.ContextCreateVideoStream(context, renderTexture.GetNativeTexturePtr(), width, height);
+            NativeMethods.ContextDeleteVideoStream(context, stream);
+            NativeMethods.ContextDestroy(0);
+        }
+
+        [Test]
+        public void CreateAndDeleteAudioStream()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var stream = NativeMethods.ContextCreateAudioStream(context);
+            NativeMethods.ContextDeleteAudioStream(context, stream);
+            NativeMethods.ContextDestroy(0);
+        }
+
+
+        [Test]
+        public void CallGetRenderEventFunc()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var callback = NativeMethods.GetRenderEventFunc(context);
+            Assert.AreNotEqual(callback, IntPtr.Zero);
+            NativeMethods.ContextDestroy(0);
+            NativeMethods.GetRenderEventFunc(IntPtr.Zero);
+        }
+
+        [UnityTest]
+        public IEnumerator CallVideoEncoderMethods()
+        {
+            var context = NativeMethods.ContextCreate(0, _encoderType);
+            const int width = 1280;
+            const int height = 720;
+            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var renderTexture = new RenderTexture(width, height, 0, format);
+            renderTexture.Create();
+            var stream =
+                NativeMethods.ContextCreateVideoStream(context, renderTexture.GetNativeTexturePtr(), width, height);
+            var callback = NativeMethods.GetRenderEventFunc(context);
+
+            // TODO::
+            // note:: You must call `InitializeEncoder` method after `NativeMethods.ContextCaptureVideoStream`
+            VideoEncoderMethods.InitializeEncoder(callback);
+            yield return new WaitForSeconds(1.0f);
+            VideoEncoderMethods.Encode(callback);
+            yield return new WaitForSeconds(1.0f);
+            VideoEncoderMethods.FinalizeEncoder(callback);
+            yield return new WaitForSeconds(1.0f);
+
+            NativeMethods.ContextDeleteVideoStream(context, stream);
+            NativeMethods.ContextDestroy(0);
+        }
     }
 }

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -1,42 +1,56 @@
-﻿using System;
+using System;
 using System.Collections;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Unity.WebRTC.RuntimeTest
 {
-    // [TestFixture(EncoderType.Software)]
-    // [TestFixture(EncoderType.Hardware)]
-    class NativeAPITest
+    class NativeAPITestWithSoftwareEncoder : NativeAPITestWithHardwareEncoder
     {
+        [SetUp]
+        public new void Init()
+        {
+            NativeMethods.RegisterDebugLog(DebugLog);
+            encoderType = EncoderType.Software;
+        }
+    }
+
+    class NativeAPITestWithHardwareEncoder
+    {
+        protected EncoderType encoderType;
+
         [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
-        static void DebugLog(string str)
+        protected static void DebugLog(string str)
         {
             Debug.Log(str);
         }
 
         [SetUp]
-        public void SetUp()
+        public void Init()
         {
             NativeMethods.RegisterDebugLog(DebugLog);
+            encoderType = EncoderType.Software;
+            Debug.Log("Init");
         }
 
         [TearDown]
-        public void TearDown()
+        public void CleanUp()
         {
             NativeMethods.RegisterDebugLog(null);
+            Debug.Log("CleanUp");
         }
 
         [Test]
-        public void CreateAndDestroyContext([Values] EncoderType encoderType)
+        public void CreateAndDestroyContext()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             NativeMethods.ContextDestroy(0);
         }
 
         [Test]
-        public void GetEncoderType([Values] EncoderType encoderType)
+        public void GetEncoderType()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             Assert.AreEqual(encoderType, NativeMethods.ContextGetEncoderType(context));
@@ -44,7 +58,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeletePeerConnection([Values] EncoderType encoderType)
+        public void CreateAndDeletePeerConnection()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
@@ -53,7 +67,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeleteDataChannel([Values] EncoderType encoderType)
+        public void CreateAndDeleteDataChannel()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
@@ -65,7 +79,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeleteVideoStream([Values] EncoderType encoderType)
+        public void CreateAndDeleteVideoStream()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             const int width = 1280;
@@ -80,7 +94,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeleteAudioStream([Values] EncoderType encoderType)
+        public void CreateAndDeleteAudioStream()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             var stream = NativeMethods.ContextCreateAudioStream(context);
@@ -90,7 +104,7 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        public void CallGetRenderEventFunc([Values] EncoderType encoderType)
+        public void CallGetRenderEventFunc()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             var callback = NativeMethods.GetRenderEventFunc(context);
@@ -100,7 +114,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        public IEnumerator CallVideoEncoderMethods([Values] EncoderType encoderType)
+        public IEnumerator CallVideoEncoderMethods()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             const int width = 1280;
@@ -123,6 +137,32 @@ namespace Unity.WebRTC.RuntimeTest
 
             NativeMethods.ContextDeleteVideoStream(context, stream);
             NativeMethods.ContextDestroy(0);
+        }
+    }
+
+    [UnityPlatform(RuntimePlatform.WindowsEditor, RuntimePlatform.OSXEditor, RuntimePlatform.LinuxEditor)]
+    class NativeAPITestWithHardwareEncoderAndEnterPlayModeOptionsEnabled : NativeAPITestWithHardwareEncoder, IPrebuildSetup
+    {
+        public void Setup()
+        {
+#if UNITY_EDITOR
+            EditorSettings.enterPlayModeOptionsEnabled = true;
+            EditorSettings.enterPlayModeOptions =
+                EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload;
+#endif
+        }
+    }
+
+    [UnityPlatform(RuntimePlatform.WindowsEditor, RuntimePlatform.OSXEditor, RuntimePlatform.LinuxEditor)]
+    class NativeAPITestWithSoftwareEncoderAndEnterPlayModeOptionsEnabled : NativeAPITestWithHardwareEncoder, IPrebuildSetup
+    {
+        public void Setup()
+        {
+#if UNITY_EDITOR
+            EditorSettings.enterPlayModeOptionsEnabled = true;
+            EditorSettings.enterPlayModeOptions =
+                EnterPlayModeOptions.DisableDomainReload | EnterPlayModeOptions.DisableSceneReload;
+#endif
         }
     }
 }

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -28,14 +28,26 @@ class NativeAPITest
     [Test]
     public void CreateAndDestroyContext()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
+        NativeMethods.ContextDestroy(0);
+    }
+
+    [Test]
+    public void GetEncoderType()
+    {
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
+        Assert.AreEqual(EncoderType.Hardware, NativeMethods.ContextGetEncoderType(context));
+        NativeMethods.ContextDestroy(0);
+
+        var context2 = NativeMethods.ContextCreate(0, EncoderType.Software);
+        Assert.AreEqual(EncoderType.Software, NativeMethods.ContextGetEncoderType(context2));
         NativeMethods.ContextDestroy(0);
     }
 
     [Test]
     public void CreateAndDeletePeerConnection()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
         var peer = NativeMethods.ContextCreatePeerConnection(context);
         NativeMethods.ContextDeletePeerConnection(context, peer);
         NativeMethods.ContextDestroy(0);
@@ -44,7 +56,7 @@ class NativeAPITest
     [Test]
     public void CreateAndDeleteDataChannel()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
         var peer = NativeMethods.ContextCreatePeerConnection(context);
         var init = new RTCDataChannelInit(true);
         var channel = NativeMethods.ContextCreateDataChannel(context, peer, "test", ref init);
@@ -55,7 +67,7 @@ class NativeAPITest
     [Test]
     public void CreateAndDeleteVideoStream()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
         const int width = 1280;
         const int height = 720;
         var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
@@ -69,7 +81,7 @@ class NativeAPITest
     [Test]
     public void CreateAndDeleteAudioStream()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
         var stream = NativeMethods.ContextCreateAudioStream(context);
         NativeMethods.ContextDeleteAudioStream(context, stream);
         NativeMethods.ContextDestroy(0);
@@ -79,7 +91,7 @@ class NativeAPITest
     [Test]
     public void CallGetRenderEventFunc()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
         var callback = NativeMethods.GetRenderEventFunc(context);
         Assert.AreNotEqual(callback, IntPtr.Zero);
         NativeMethods.ContextDestroy(0);
@@ -88,7 +100,7 @@ class NativeAPITest
     [UnityTest]
     public IEnumerator CallVideoEncoderMethods()
     {
-        var context = NativeMethods.ContextCreate(0);
+        var context = NativeMethods.ContextCreate(0, EncoderType.Hardware);
         const int width = 1280;
         const int height = 720;
         var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -102,6 +102,29 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void MediaStreamGetAudioTracks()
+        {
+            var context = NativeMethods.ContextCreate(0, encoderType);
+            var stream = NativeMethods.ContextCreateAudioStream(context);
+            int trackSize = 0;
+            IntPtr trackNativePtr = NativeMethods.MediaStreamGetAudioTracks(stream, ref trackSize);
+            Assert.AreNotEqual(trackNativePtr, IntPtr.Zero);
+            Assert.Greater(trackSize, 0);
+
+            IntPtr[] tracksPtr = new IntPtr[trackSize];
+            System.Runtime.InteropServices.Marshal.Copy(trackNativePtr, tracksPtr, 0, trackSize);
+            System.Runtime.InteropServices.Marshal.FreeCoTaskMem(trackNativePtr);
+
+            for (int i = 0; i < trackSize; i++)
+            {
+                MediaStreamTrack track = new MediaStreamTrack(tracksPtr[i]);
+                Assert.True(track.Enabled);
+            }
+            NativeMethods.ContextDeleteAudioStream(context, stream);
+            NativeMethods.ContextDestroy(0);
+        }
+
+        [Test]
         public void CreateAndDeleteAudioStream()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -6,18 +6,10 @@ using UnityEngine.TestTools;
 
 namespace Unity.WebRTC.RuntimeTest
 {
-    [TestFixture(EncoderType.Software)]
-    [TestFixture(EncoderType.Hardware)]
+    // [TestFixture(EncoderType.Software)]
+    // [TestFixture(EncoderType.Hardware)]
     class NativeAPITest
     {
-        private readonly EncoderType _encoderType;
-
-        public NativeAPITest(EncoderType encoderType)
-        {
-            _encoderType = encoderType;
-        }
-
-
         [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
         static void DebugLog(string str)
         {
@@ -37,33 +29,33 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDestroyContext()
+        public void CreateAndDestroyContext([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             NativeMethods.ContextDestroy(0);
         }
 
         [Test]
-        public void GetEncoderType()
+        public void GetEncoderType([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
-            Assert.AreEqual(_encoderType, NativeMethods.ContextGetEncoderType(context));
+            var context = NativeMethods.ContextCreate(0, encoderType);
+            Assert.AreEqual(encoderType, NativeMethods.ContextGetEncoderType(context));
             NativeMethods.ContextDestroy(0);
         }
 
         [Test]
-        public void CreateAndDeletePeerConnection()
+        public void CreateAndDeletePeerConnection([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
         }
 
         [Test]
-        public void CreateAndDeleteDataChannel()
+        public void CreateAndDeleteDataChannel([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var init = new RTCDataChannelInit(true);
             var channel = NativeMethods.ContextCreateDataChannel(context, peer, "test", ref init);
@@ -73,9 +65,9 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeleteVideoStream()
+        public void CreateAndDeleteVideoStream([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             const int width = 1280;
             const int height = 720;
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
@@ -88,9 +80,9 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeleteAudioStream()
+        public void CreateAndDeleteAudioStream([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             var stream = NativeMethods.ContextCreateAudioStream(context);
             NativeMethods.ContextDeleteAudioStream(context, stream);
             NativeMethods.ContextDestroy(0);
@@ -98,9 +90,9 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        public void CallGetRenderEventFunc()
+        public void CallGetRenderEventFunc([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             var callback = NativeMethods.GetRenderEventFunc(context);
             Assert.AreNotEqual(callback, IntPtr.Zero);
             NativeMethods.ContextDestroy(0);
@@ -108,9 +100,9 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        public IEnumerator CallVideoEncoderMethods()
+        public IEnumerator CallVideoEncoderMethods([Values] EncoderType encoderType)
         {
-            var context = NativeMethods.ContextCreate(0, _encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType);
             const int width = 1280;
             const int height = 720;
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -1,107 +1,142 @@
-﻿using UnityEngine;
-using UnityEngine.TestTools;
+﻿using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 using Unity.WebRTC;
 
-class PeerConnectionTest
+namespace Unity.WebRTC.RuntimeTest
 {
-    static RTCConfiguration GetConfiguration()
+    class PeerConnectionTest
     {
-        RTCConfiguration config = default;
-        config.iceServers = new RTCIceServer[]
+        static RTCConfiguration GetConfiguration()
         {
-            new RTCIceServer
+            RTCConfiguration config = default;
+            config.iceServers = new RTCIceServer[]
             {
-                urls = new string[] { "stun:stun.l.google.com:19302" },
-                username = "",
-                credential = "",
-                credentialType = RTCIceCredentialType.Password
-            }
-        };
-        return config;
-    }
+                new RTCIceServer
+                {
+                    urls = new string[] {"stun:stun.l.google.com:19302"},
+                    username = "",
+                    credential = "",
+                    credentialType = RTCIceCredentialType.Password
+                }
+            };
+            return config;
+        }
 
-    [SetUp]
-    public void SetUp()
-    {
-        WebRTC.Initialize();
-    }
+        [SetUp]
+        public void SetUp()
+        {
+            WebRTC.Initialize();
+        }
 
-    [TearDown]
-    public void TearDown()
-    {
-        WebRTC.Finalize();
-    }
+        [TearDown]
+        public void TearDown()
+        {
+            WebRTC.Finalize();
+        }
 
-    [Test]
-    [Category("PeerConnection")]
-    public void PeerConnection_Construct()
-    {
-        var peer = new RTCPeerConnection();
-        peer.Close();
-    }
+        [Test]
+        [Category("PeerConnection")]
+        public void PeerConnection_Construct()
+        {
+            var peer = new RTCPeerConnection();
+            peer.Close();
+        }
 
-    [Test]
-    [Category("PeerConnection")]
-    public void PeerConnection_ConstructWithConfig()
-    {
-        var config = GetConfiguration();
-        var peer = new RTCPeerConnection(ref config);
+        [Test]
+        [Category("PeerConnection")]
+        public void PeerConnection_ConstructWithConfig()
+        {
+            var config = GetConfiguration();
+            var peer = new RTCPeerConnection(ref config);
 
-        var config2 = peer.GetConfiguration();
-        Assert.NotNull(config.iceServers);
-        Assert.NotNull(config2.iceServers);
-        Assert.AreEqual(config.iceServers.Length, config2.iceServers.Length);
-        Assert.AreEqual(config.iceServers[0].username, config2.iceServers[0].username);
-        Assert.AreEqual(config.iceServers[0].credential, config2.iceServers[0].credential);
-        Assert.AreEqual(config.iceServers[0].urls, config2.iceServers[0].urls);
+            var config2 = peer.GetConfiguration();
+            Assert.NotNull(config.iceServers);
+            Assert.NotNull(config2.iceServers);
+            Assert.AreEqual(config.iceServers.Length, config2.iceServers.Length);
+            Assert.AreEqual(config.iceServers[0].username, config2.iceServers[0].username);
+            Assert.AreEqual(config.iceServers[0].credential, config2.iceServers[0].credential);
+            Assert.AreEqual(config.iceServers[0].urls, config2.iceServers[0].urls);
 
-        peer.Close();
-    }
+            peer.Close();
+        }
 
-    [Test]
-    [Category("PeerConnection")]
-    public void PeerConnection_SetConfiguration()
-    {
-        var peer = new RTCPeerConnection();
-        var config = GetConfiguration();
-        var result = peer.SetConfiguration(ref config);
-        Assert.AreEqual(RTCErrorType.None, result);
-    }
+        [Test]
+        [Category("PeerConnection")]
+        public void PeerConnection_SetConfiguration()
+        {
+            var peer = new RTCPeerConnection();
+            var config = GetConfiguration();
+            var result = peer.SetConfiguration(ref config);
+            Assert.AreEqual(RTCErrorType.None, result);
+        }
 
-    [UnityTest]
-    [Category("PeerConnection")]
+        [UnityTest]
+        [Category("PeerConnection")]
 
-    public IEnumerator PeerConnection_CreateOffer()
-    {
-        var config = GetConfiguration();
-        var peer = new RTCPeerConnection(ref config);
-        RTCOfferOptions options = default;
-        var op = peer.CreateOffer(ref options);
+        public IEnumerator PeerConnection_CreateOffer()
+        {
+            var config = GetConfiguration();
+            var peer = new RTCPeerConnection(ref config);
+            RTCOfferOptions options = default;
+            var op = peer.CreateOffer(ref options);
 
-        yield return op;
-        Assert.True(op.isDone);
-        Assert.False(op.isError);
+            yield return op;
+            Assert.True(op.isDone);
+            Assert.False(op.isError);
 
-        peer.Close();
-    }
+            peer.Close();
+        }
 
-    [UnityTest]
-    [Category("PeerConnection")]
+        [UnityTest]
+        [Category("PeerConnection")]
 
-    public IEnumerator PeerConnection_SetLocalDescription()
-    {
-        var peer = new RTCPeerConnection();
-        RTCOfferOptions options = default;
-        var op = peer.CreateOffer(ref options);
-        yield return op;
-        Assert.True(op.isDone);
-        Assert.False(op.isError);
-        var op2 = peer.SetLocalDescription(ref op.desc);
-        yield return op2;
-        Assert.True(op2.isDone);
-        Assert.False(op2.isError);
-        peer.Close();
+        public IEnumerator PeerConnection_SetLocalDescription()
+        {
+            var peer = new RTCPeerConnection();
+            RTCOfferOptions options = default;
+            var op = peer.CreateOffer(ref options);
+            yield return op;
+            Assert.True(op.isDone);
+            Assert.False(op.isError);
+            var op2 = peer.SetLocalDescription(ref op.desc);
+            yield return op2;
+            Assert.True(op2.isDone);
+            Assert.False(op2.isError);
+            peer.Close();
+        }
+
+        [UnityTest]
+        [Category("PeerConnection")]
+        public IEnumerator PeerConnection_SetRemoteDescription()
+        {
+            RTCConfiguration config = default;
+            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+            RTCDataChannel channel1 = null, channel2 = null;
+
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
+            peer2.OnDataChannel = channel => { channel2 = channel; };
+
+            var conf = new RTCDataChannelInit(true);
+            channel1 = peer1.CreateDataChannel("data", ref conf);
+
+            RTCOfferOptions options1 = default;
+            RTCAnswerOptions options2 = default;
+            var op1 = peer1.CreateOffer(ref options1);
+            yield return op1;
+            var op2 = peer1.SetLocalDescription(ref op1.desc);
+            yield return op2;
+            var op3 = peer2.SetRemoteDescription(ref op1.desc);
+            yield return op3;
+            var op4 = peer2.CreateAnswer(ref options2);
+            yield return op4;
+            var op5 = peer2.SetLocalDescription(ref op4.desc);
+            yield return op5;
+            var op6 = peer1.SetRemoteDescription(ref op4.desc);
+            yield return op6;
+        }
     }
 }

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine.TestTools;
+using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 using Unity.WebRTC;
@@ -116,10 +116,6 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             RTCDataChannel channel1 = null, channel2 = null;
 
-            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
-            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
-            peer2.OnDataChannel = channel => { channel2 = channel; };
-
             var conf = new RTCDataChannelInit(true);
             channel1 = peer1.CreateDataChannel("data", ref conf);
 
@@ -137,6 +133,10 @@ namespace Unity.WebRTC.RuntimeTest
             yield return op5;
             var op6 = peer1.SetRemoteDescription(ref op4.desc);
             yield return op6;
+
+            channel1.Dispose();
+            peer1.Dispose();
+            peer2.Dispose();
         }
     }
 }

--- a/Tests/Runtime/WaitUntilWithTimeout.cs
+++ b/Tests/Runtime/WaitUntilWithTimeout.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+public class WaitUntilWithTimeout : CustomYieldInstruction
+{
+    public bool IsCompleted { get; private set; }
+
+    private readonly float timeoutTime;
+
+    private readonly System.Func<bool> predicate;
+
+    public override bool keepWaiting
+    {
+        get
+        {
+            IsCompleted = predicate();
+            if (IsCompleted)
+            {
+                return false;
+            }
+
+            return !(Time.realtimeSinceStartup >= timeoutTime);
+        }
+    }
+
+    public WaitUntilWithTimeout(System.Func<bool> predicate, int timeout)
+    {
+        this.timeoutTime = Time.realtimeSinceStartup + timeout * 0.001f;
+        this.predicate = predicate;
+    }
+}

--- a/Tests/Runtime/WaitUntilWithTimeout.cs.meta
+++ b/Tests/Runtime/WaitUntilWithTimeout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe51594b7ab1949e79e9c2cb3283cc81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Create new C# API 

### Changed
- Added `WebRTC.Initialize()` method argument `encoderType`
- Added tests for Software/Hardware encoder using parameterized tests methods

## ~~TODO~~
- ~~Mac OS unit tests on Yamato are failed~~
    - ~~Test com.unity.webrtc with mono 2019.3 on macos~~
    - ~~Test com.unity.webrtc with il2cpp 2019.3 on macos~~