### PR TITLE
fix: Fixing CS0219 warning 

### DIFF
--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -114,7 +114,7 @@ namespace Unity.WebRTC.RuntimeTest
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
-            RTCDataChannel channel1 = null, channel2 = null;
+            RTCDataChannel channel1 = null;
 
             var conf = new RTCDataChannelInit(true);
             channel1 = peer1.CreateDataChannel("data", ref conf);


### PR DESCRIPTION
warning CS0219: The variable 'channel2' is assigned but its value is never used