### PR TITLE
chore: Upgrade package to fix dll error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to the webrtc package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2020-01-10
+## [1.1.1] - 2020-02-28
+
+- Fixed: DLL import error
+
+
+## [1.1.0] - 2020-02-25
 
 - Added: IL2CPP support
 - Added: Linux OpenGL hardware encoder support

--- a/WebRTC~/Packages/com.unity.webrtc/package.json
+++ b/WebRTC~/Packages/com.unity.webrtc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "1.1.0-preview",
+  "version": "1.1.1-preview",
   "unity": "2019.3",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "1.1.0-preview",
+  "version": "1.1.1-preview",
   "unity": "2019.3",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [


### PR DESCRIPTION
# What
This PR is for the hotfix of [this issue](https://github.com/Unity-Technologies/UnityRenderStreaming/issues/227).
This problem caused by the misunderstanding about the CI process.

According to the process of the CI tool called Yamato, `promote` command only works copying the artifact made from `publish command`.
But `publish` command does not overwrite the package when already uploaded the same version. And unfortunately, this job succeeds even if the package is not uploaded. 

# Future actions

- will depend `promote` job on `publish` job
- will fix the build process to return failure when the package is not uploaded