### PR TITLE
refactor: Added Parameterized Test with ValuesIn

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
@@ -36,7 +36,7 @@ namespace WebRTC
 
         webrtc::VideoFrame frame = webrtc::VideoFrame::Builder().set_video_frame_buffer(i420Buffer).set_rotation(webrtc::kVideoRotation_0).set_timestamp_us(0).build();
         CaptureFrame(frame);
-        frameCount++;
+        m_frameCount++;
         return true;
     }
 }

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "SoftwareEncoder.h"
 #include "Context.h"
 #include <cstring>
@@ -36,6 +36,7 @@ namespace WebRTC
 
         webrtc::VideoFrame frame = webrtc::VideoFrame::Builder().set_video_frame_buffer(i420Buffer).set_rotation(webrtc::kVideoRotation_0).set_timestamp_us(0).build();
         CaptureFrame(frame);
+        frameCount++;
         return true;
     }
 }

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <vector>
 #include <thread>
 #include <atomic>
@@ -19,13 +19,14 @@ namespace WebRTC
         virtual bool EncodeFrame() override;
         virtual bool IsSupported() const override { return true; }
         virtual void SetIdrFrame() override {}
-        virtual uint64 GetCurrentFrameCount() const override { return 0; }        
+        virtual uint64 GetCurrentFrameCount() const override { return frameCount; }        
 
     private:
         IGraphicsDevice* m_device;
         ITexture2D* m_encodeTex;
         int m_width = 1920;
         int m_height = 1080;
+        uint64 frameCount = 0;
     };
 //---------------------------------------------------------------------------------------------------------------------
    

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -19,14 +19,14 @@ namespace WebRTC
         virtual bool EncodeFrame() override;
         virtual bool IsSupported() const override { return true; }
         virtual void SetIdrFrame() override {}
-        virtual uint64 GetCurrentFrameCount() const override { return frameCount; }        
+        virtual uint64 GetCurrentFrameCount() const override { return m_frameCount; }        
 
     private:
         IGraphicsDevice* m_device;
         ITexture2D* m_encodeTex;
         int m_width = 1920;
         int m_height = 1080;
-        uint64 frameCount = 0;
+        uint64 m_frameCount = 0;
     };
 //---------------------------------------------------------------------------------------------------------------------
    

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -20,7 +20,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width, height, m_device, UnityEncoderType::UnityEncoderHardware);
+        EncoderFactory::GetInstance().Init(width, height, m_device, encoderType);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -6,6 +6,7 @@
 #include "../WebRTCPlugin/Context.h"
 
 using namespace WebRTC;
+using namespace testing;
 
 class ContextTest : public GraphicsDeviceTestBase
 {
@@ -65,8 +66,4 @@ TEST_P(ContextTest, CreateAndDeleteDataChannel) {
     context->DeletePeerConnection(connection);
 }
 
-INSTANTIATE_TEST_CASE_P(
-    GraphicsDeviceParameters,
-    ContextTest,
-    testing::Values(GraphicsDeviceTestBase::CreateParameter())
-);
+INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, ContextTest, ValuesIn(VALUES_TEST_ENV));

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -3,11 +3,9 @@
 #include "../WebRTCPlugin/GraphicsDevice/ITexture2D.h"
 
 using namespace WebRTC;
+using namespace testing;
 
 class GraphicsDeviceTest : public GraphicsDeviceTestBase {};
-
-
-
 TEST_P(GraphicsDeviceTest, GraphicsDeviceIsNotNull) {
     EXPECT_NE(nullptr, m_device);
 }
@@ -55,8 +53,5 @@ TEST_P(GraphicsDeviceTest, CopyResourceNativeV) {
 }
 #endif
 
-INSTANTIATE_TEST_CASE_P(
-    GraphicsDeviceParameters,
-    GraphicsDeviceTest,
-    testing::Values(GraphicsDeviceTestBase::CreateParameter())
-);
+INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, GraphicsDeviceTest, ValuesIn(VALUES_TEST_ENV));
+

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -78,25 +78,13 @@ IUnityInterface* CreateUnityInterface() {
 
 //---------------------------------------------------------------------------------------------------------------------
 
-std::tuple<UnityGfxRenderer, void*, IUnityInterface*> GraphicsDeviceTestBase::CreateParameter()
-{
-#if defined(SUPPORT_D3D11)
-    auto unityGfxRenderer = kUnityGfxRendererD3D11;
-#elif defined(SUPPORT_OPENGL_CORE)
-    auto unityGfxRenderer = kUnityGfxRendererOpenGLCore;
-#elif defined(SUPPORT_METAL)
-    auto unityGfxRenderer = kUnityGfxRendererMetal;
-#endif
-    return std::make_tuple(unityGfxRenderer, CreateDevice(), CreateUnityInterface());
-}
-
-
 void GraphicsDeviceTestBase::SetUp()
 {
     UnityGfxRenderer unityGfxRenderer;
-    void* pGraphicsDevice;
-    IUnityInterface* unityInterface;
-    std::tie(unityGfxRenderer, pGraphicsDevice, unityInterface) = GetParam();
+    UnityEncoderType encoderType;
+    std::tie(unityGfxRenderer, encoderType) = GetParam();
+    const auto pGraphicsDevice = CreateDevice();
+    const auto unityInterface = CreateUnityInterface();
 
     ASSERT_TRUE(GraphicsDevice::GetInstance().Init(unityGfxRenderer, pGraphicsDevice, unityInterface));
     m_device = GraphicsDevice::GetInstance().GetDevice();

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -113,7 +113,6 @@ IUnityInterface* CreateUnityInterface() {
 void GraphicsDeviceTestBase::SetUp()
 {
     UnityGfxRenderer unityGfxRenderer;
-    UnityEncoderType encoderType;
     std::tie(unityGfxRenderer, encoderType) = GetParam();
     const auto pGraphicsDevice = CreateDevice(unityGfxRenderer);
     const auto unityInterface = CreateUnityInterface();

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -77,26 +77,9 @@ void* CreateDevice(UnityGfxRenderer renderer)
     }
 }
 
-struct DummyUnityGraphicsD3D12v5 : IUnityGraphicsD3D12v5
-{
-public:
-    DummyUnityGraphicsD3D12v5(ID3D12Device5* device)
-    {
-    }
-    ID3D12CommandQueue* GetCommandQueue()
-    {
-        return pCommandQueue.Get();
-    }
-
-private:
-    ID3D12Device5* m_device;
-};
-
-IUnityInterface* CreateUnityInterface(void* device)
-{
-    return reinterpret_cast<IUnityInterface*>(new DummyUnityGraphicsD3D12v5(reinterpret_cast<ID3D12Device5*>(device)));
+IUnityInterface* CreateUnityInterface() {
+    return nullptr;
 }
-
 
 #elif defined(SUPPORT_METAL)
 
@@ -142,7 +125,7 @@ void GraphicsDeviceTestBase::SetUp()
     UnityGfxRenderer unityGfxRenderer;
     std::tie(unityGfxRenderer, encoderType) = GetParam();
     const auto pGraphicsDevice = CreateDevice(unityGfxRenderer);
-    const auto unityInterface = CreateUnityInterface(pGraphicsDevice);
+    const auto unityInterface = CreateUnityInterface();
 
     ASSERT_TRUE(GraphicsDevice::GetInstance().Init(unityGfxRenderer, pGraphicsDevice, unityInterface));
     m_device = GraphicsDevice::GetInstance().GetDevice();

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -49,7 +49,7 @@ void* CreateDeviceD3D12()
     EXPECT_NE(nullptr, pAdapter.Get());
 
     hr = D3D12CreateDevice(
-        pAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&pD3D12Device));
+        pAdapter.Get(), D3D_FEATURE_LEVEL_11_1, IID_PPV_ARGS(&pD3D12Device));
 
     EXPECT_TRUE(SUCCEEDED(hr));
     EXPECT_NE(nullptr, pD3D12Device.Get());

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -1,16 +1,28 @@
-﻿#pragma once
+#pragma once
 #include "gtest/gtest.h"
 #include "../WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h"
-#include "unity/include/IUnityInterface.h"
 
-class GraphicsDeviceTestBase : public testing::TestWithParam< ::std::tuple<UnityGfxRenderer, void*, IUnityInterface*> > {
+using WebRTC::UnityEncoderType;
+using std::tuple;
+using testing::Values;
 
-public:
-    static std::tuple<UnityGfxRenderer, void*, IUnityInterface*> CreateParameter();
+class GraphicsDeviceTestBase : public testing::TestWithParam<tuple<UnityGfxRenderer, UnityEncoderType> > {
 
 protected:
-    virtual void SetUp() override;
-    virtual void TearDown() override;
+    void SetUp() override;
+    void TearDown() override;
     WebRTC::IGraphicsDevice* m_device;
 };
 
+static tuple<UnityGfxRenderer, UnityEncoderType> VALUES_TEST_ENV[] = {
+#if defined(UNITY_WIN)
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware },
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware }
+#elif defined(UNITY_MAC)
+    { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware }
+#elif defined(UNITY_LINUX)
+    { kUnityGfxRendererOpenGLCore, UnityEncoderType::UnityEncoderHardware }
+#endif
+};

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -20,7 +20,7 @@ static tuple<UnityGfxRenderer, UnityEncoderType> VALUES_TEST_ENV[] = {
     { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware },
     { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware },
     { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware }
-#elif defined(UNITY_MAC)
+#elif defined(UNITY_OSX)
     { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware }
 #elif defined(UNITY_LINUX)
     { kUnityGfxRendererOpenGLCore, UnityEncoderType::UnityEncoderHardware }

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -12,6 +12,7 @@ protected:
     void SetUp() override;
     void TearDown() override;
     WebRTC::IGraphicsDevice* m_device;
+    UnityEncoderType encoderType;
 };
 
 static tuple<UnityGfxRenderer, UnityEncoderType> VALUES_TEST_ENV[] = {

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -9,8 +9,8 @@ using testing::Values;
 class GraphicsDeviceTestBase : public testing::TestWithParam<tuple<UnityGfxRenderer, UnityEncoderType> > {
 
 protected:
-    void SetUp() override;
-    void TearDown() override;
+    virtual void SetUp() override;
+    virtual void TearDown() override;
     WebRTC::IGraphicsDevice* m_device;
     UnityEncoderType encoderType;
 };
@@ -18,9 +18,9 @@ protected:
 static tuple<UnityGfxRenderer, UnityEncoderType> VALUES_TEST_ENV[] = {
 #if defined(UNITY_WIN)
     { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware },
-    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware },
-    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware },
-    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware }
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware }
+//    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware }
+//    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware }
 #elif defined(UNITY_OSX)
     { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware }
 #elif defined(UNITY_LINUX)

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -18,7 +18,7 @@ protected:
 
         const auto width = 256;
         const auto height = 256;
-        EncoderFactory::GetInstance().Init(width, height, m_device, UnityEncoderType::UnityEncoderHardware);
+        EncoderFactory::GetInstance().Init(width, height, m_device, encoderType);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
     }

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -1,10 +1,11 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "../GraphicsDeviceTestBase.h"
 #include "../WebRTCPlugin/GraphicsDevice/ITexture2D.h"
 #include "../WebRTCPlugin/Codec/EncoderFactory.h"
 #include "../WebRTCPlugin/Codec/IEncoder.h"
 
 using namespace WebRTC;
+using namespace testing;
 
 class NvEncoderTest : public GraphicsDeviceTestBase
 {
@@ -45,8 +46,4 @@ TEST_P(NvEncoderTest, EncodeFrame) {
     EXPECT_EQ(before + 1, after);
 }
 
-INSTANTIATE_TEST_CASE_P(
-    GraphicsDeviceParameters,
-    NvEncoderTest,
-    testing::Values(GraphicsDeviceTestBase::CreateParameter())
-);
+INSTANTIATE_TEST_CASE_P( GraphicsDeviceParameters, NvEncoderTest, ValuesIn(VALUES_TEST_ENV));

--- a/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "GraphicsDeviceTestBase.h"
 #include "../WebRTCPlugin/GraphicsDevice/ITexture2D.h"
 #include "../WebRTCPlugin/Codec/EncoderFactory.h"
@@ -6,46 +6,43 @@
 #include "../WebRTCPlugin/NvVideoCapturer.h"
 
 using namespace WebRTC;
+using namespace testing;
 
 class VideoCapturerTest : public GraphicsDeviceTestBase
 {
 protected:
     IEncoder* encoder_ = nullptr;
-    //IGraphicsDevice* device_ = nullptr;
-    const int width = 256;
-    const int height = 256;
-    std::unique_ptr<NvVideoCapturer> capturer;
+    const int width_ = 256;
+    const int height_ = 256;
+    std::unique_ptr<NvVideoCapturer> capturer_;
 
     void SetUp() override {
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width, height, m_device, UnityEncoderType::UnityEncoderHardware);
+        EncoderFactory::GetInstance().Init(width_, height_, m_device, UnityEncoderHardware);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 
-        capturer = std::make_unique<NvVideoCapturer>();
+        capturer_ = std::make_unique<NvVideoCapturer>();
     }
+
     void TearDown() override {
         EncoderFactory::GetInstance().Shutdown();
         GraphicsDeviceTestBase::TearDown();
     }
 };
 TEST_P(VideoCapturerTest, InitializeAndFinalize) {
-    capturer->InitializeEncoder(m_device, WebRTC::UnityEncoderType::UnityEncoderHardware);
-    capturer->FinalizeEncoder();
+    capturer_->InitializeEncoder(m_device, UnityEncoderHardware);
+    capturer_->FinalizeEncoder();
 }
 
 TEST_P(VideoCapturerTest, EncodeVideoData) {
-    capturer->InitializeEncoder(m_device, WebRTC::UnityEncoderType::UnityEncoderHardware);
-    auto tex = m_device->CreateDefaultTextureV(width, height);
-    capturer->SetFrameBuffer(tex->GetEncodeTexturePtrV());
-    capturer->EncodeVideoData();
-    capturer->FinalizeEncoder();
+    capturer_->InitializeEncoder(m_device, UnityEncoderHardware);
+    auto tex = m_device->CreateDefaultTextureV(width_, height_);
+    capturer_->SetFrameBuffer(tex->GetEncodeTexturePtrV());
+    capturer_->EncodeVideoData();
+    capturer_->FinalizeEncoder();
 }
 
-INSTANTIATE_TEST_CASE_P(
-    GraphicsDeviceParameters,
-    VideoCapturerTest,
-    testing::Values(GraphicsDeviceTestBase::CreateParameter())
-);
+INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, VideoCapturerTest, ValuesIn(VALUES_TEST_ENV));

--- a/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
@@ -20,7 +20,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width_, height_, m_device, UnityEncoderHardware);
+        EncoderFactory::GetInstance().Init(width_, height_, m_device, encoderType);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 

--- a/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
+++ b/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
@@ -212,7 +212,7 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <AdditionalDependencies>cuda.lib;vulkan-1.lib;webrtc.lib;webrtc_opus.lib;audio_decoder_opus.lib;Winmm.lib;Msdmo.lib;Dmoguids.lib;wmcodecdspuuid.lib;Secur32.lib;iphlpapi.lib;d3d11.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cuda.lib;vulkan-1.lib;webrtc.lib;webrtc_opus.lib;audio_decoder_opus.lib;Winmm.lib;Msdmo.lib;Dmoguids.lib;wmcodecdspuuid.lib;Secur32.lib;iphlpapi.lib;d3d11.lib;d3d12.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
This PR contains the parameterized test using `ValuesIn` in googletest ([link](https://github.com/google/googletest/blob/572e261b607585d7044ad3321f9530d5c14a2564/googletest/docs/advanced.md#how-to-write-value-parameterized-tests)).

This achieves combination test for Rendering API(`D3D11`, `D3D12`, `OpenGL`, `Metal`, `Vulkan`) and encoder type (`hardware`, `software`).

## TODO
Have not completed yet to implement `D3D12` native test because it is difficult to make a mock of `IUserInterface`.