### PR TITLE
fix: D3D12 native test

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -13,6 +13,7 @@ DefPtr(ID3D12GraphicsCommandList4);
 class D3D12GraphicsDevice : public IGraphicsDevice{
 public:
     explicit D3D12GraphicsDevice(ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface );
+    explicit D3D12GraphicsDevice(ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue);
     virtual ~D3D12GraphicsDevice();
     virtual bool InitV() override;
     virtual void ShutdownV() override;
@@ -35,6 +36,7 @@ private:
         const UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES);
 
     ID3D12Device* m_d3d12Device;
+    ID3D12CommandQueue* m_d3d12CommandQueue;
 
     //[Note-sin: 2019-10-30] sharing res from d3d12 to d3d11 require d3d11.1. Fence is supported in d3d11.4 or newer.
     ID3D11Device5* m_d3d11Device;
@@ -44,7 +46,6 @@ private:
     //[TODO-sin: 2019-12-2] //This should be allocated for each frame.
     ID3D12CommandAllocatorPtr m_commandAllocator;
     ID3D12GraphicsCommandList4Ptr m_commandList;
-    IUnityGraphicsD3D12v5* m_unityInterface;
 
     //Fence to copy resource on GPU (and CPU if the texture was created with CPU-access)
     ID3D12Fence* m_copyResourceFence;

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -20,7 +20,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width, height, m_device, encoderType);
+        EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -48,8 +48,8 @@ TEST_P(GraphicsDeviceTest, CopyResourceNativeV) {
     const auto height = 256;
     const auto src = m_device->CreateDefaultTextureV(width, height);
     const auto dst = m_device->CreateDefaultTextureV(width, height);
-    EXPECT_TRUE(m_device->CopyResourceFromNativeV(dst, src->GetEncodeTexturePtrV()));
-    EXPECT_FALSE(m_device->CopyResourceFromNativeV(dst, dst->GetEncodeTexturePtrV()));
+    EXPECT_TRUE(m_device->CopyResourceFromNativeV(dst, src->GetNativeTexturePtrV()));
+    EXPECT_FALSE(m_device->CopyResourceFromNativeV(dst, dst->GetNativeTexturePtrV()));
 }
 #endif
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -12,15 +12,18 @@ protected:
     virtual void SetUp() override;
     virtual void TearDown() override;
     WebRTC::IGraphicsDevice* m_device;
-    UnityEncoderType encoderType;
+    UnityEncoderType m_encoderType;
+    UnityGfxRenderer m_unityGfxRenderer;
 };
 
 static tuple<UnityGfxRenderer, UnityEncoderType> VALUES_TEST_ENV[] = {
 #if defined(UNITY_WIN)
     { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware },
-    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware }
-//    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware }
-//    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware }
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware }
+//    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderHardware },
+//    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderSoftware }
 #elif defined(UNITY_OSX)
     { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware }
 #elif defined(UNITY_LINUX)

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -18,7 +18,7 @@ protected:
 
         const auto width = 256;
         const auto height = 256;
-        EncoderFactory::GetInstance().Init(width, height, m_device, encoderType);
+        EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
     }
@@ -35,7 +35,7 @@ TEST_P(NvEncoderTest, CopyBuffer) {
     const auto width = 256;
     const auto height = 256;
     auto tex = m_device->CreateDefaultTextureV(width, height);
-    const auto result = encoder_->CopyBuffer(tex->GetEncodeTexturePtrV());
+    const auto result = encoder_->CopyBuffer(tex->GetNativeTexturePtrV());
     EXPECT_TRUE(result);
 }
 

--- a/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoCapturerTest.cpp
@@ -20,7 +20,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        EncoderFactory::GetInstance().Init(width_, height_, m_device, encoderType);
+        EncoderFactory::GetInstance().Init(width_, height_, m_device, m_encoderType);
         encoder_ = EncoderFactory::GetInstance().GetEncoder();
         EXPECT_NE(nullptr, encoder_);
 


### PR DESCRIPTION
- Correspond D3D12 native test
- Added the constructor of `D3D12GraphicsDevice` to initialize instance without `IUnityInterface` 

### TODO

- This PR does not correspond Vulkan API.
- The base class of test should be more simple.