### PR TITLE
fixed: Color bug using OpenGL Encoder

### DIFF
--- a/BuildScripts~/build_plugin.sh
+++ b/BuildScripts~/build_plugin.sh
@@ -9,6 +9,7 @@ unzip -d $SOLUTION_DIR/webrtc webrtc.zip
 
 # Install libc++, libc++abi googletest clang glut
 # TODO:: Remove this install process from here and recreate an image to build the plugin.
+sudo apt update
 sudo apt install -y libc++-dev libc++abi-dev googletest clang freeglut3-dev
 
 # Install googletest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to the webrtc package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2020-03-19
+
+- Fixed: OpenGL color order
+
 ## [1.1.1] - 2020-02-28
 
 - Fixed: DLL import error
-
 
 ## [1.1.0] - 2020-02-25
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -32,6 +32,7 @@ namespace WebRTC
         NvEncoder(
             NV_ENC_DEVICE_TYPE type,
             NV_ENC_INPUT_RESOURCE_TYPE inputType,
+            NV_ENC_BUFFER_FORMAT bufferFormat,
             int width, int height, IGraphicsDevice* device);
         virtual ~NvEncoder();
 
@@ -58,6 +59,7 @@ namespace WebRTC
 
         NV_ENC_DEVICE_TYPE m_deviceType;
         NV_ENC_INPUT_RESOURCE_TYPE m_inputType;
+        NV_ENC_BUFFER_FORMAT m_bufferFormat;
 
         bool isNvEncoderSupported = false;
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
@@ -7,7 +7,7 @@
 namespace WebRTC {
 
     NvEncoderCuda::NvEncoderCuda(const uint32_t nWidth, const uint32_t nHeight, IGraphicsDevice* device) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY, nWidth, nHeight, device)
+        NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.cpp
@@ -7,7 +7,7 @@
 namespace WebRTC
 {
     NvEncoderD3D11::NvEncoderD3D11(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_DIRECTX, NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX, nWidth, nHeight, device)
+        NvEncoder(NV_ENC_DEVICE_TYPE_DIRECTX, NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.cpp
@@ -7,7 +7,7 @@
 namespace WebRTC {
 
     NvEncoderGL::NvEncoderGL(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_OPENGL, NV_ENC_INPUT_RESOURCE_TYPE_OPENGL_TEX, nWidth, nHeight, device)
+        NvEncoder(NV_ENC_DEVICE_TYPE_OPENGL, NV_ENC_INPUT_RESOURCE_TYPE_OPENGL_TEX, NV_ENC_BUFFER_FORMAT_ABGR, nWidth, nHeight, device)
     {
     }
 

--- a/WebRTC~/Packages/com.unity.webrtc/package.json
+++ b/WebRTC~/Packages/com.unity.webrtc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "1.1.1-preview",
+  "version": "1.1.2-preview",
   "unity": "2019.3",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "1.1.1-preview",
+  "version": "1.1.2-preview",
   "unity": "2019.3",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [


### PR DESCRIPTION
This is for a **hotfix version 1.1.2** for `com.unity.webrtc` package

## Fixed issue

- OpenGL color order error (Issue of Unity Render Streaming [#239](https://github.com/Unity-Technologies/UnityRenderStreaming/issues/239))