### PR TITLE
refactor: Changed the way of pass native string 

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -195,13 +195,13 @@ namespace webrtc
         return error.type();
     }
 
-    void PeerConnectionObject::GetConfiguration(std::string& config) const
+    std::string PeerConnectionObject::GetConfiguration() const
     {
         auto _config = connection->GetConfiguration();
 
         Json::Value root;
         root["iceServers"] = Json::Value(Json::arrayValue);
-        for (auto iceServer : _config.servers)
+        for (webrtc::PeerConnectionInterface::IceServer iceServer : _config.servers)
         {
             Json::Value jsonIceServer = Json::Value(Json::objectValue);
             jsonIceServer["username"] = iceServer.username;
@@ -215,7 +215,7 @@ namespace webrtc
             root["iceServers"].append(jsonIceServer);
         }
         Json::StreamWriterBuilder builder;
-        config = Json::writeString(builder, root);
+        return Json::writeString(builder, root);
     }
 
     void PeerConnectionObject::CreateOffer(const RTCOfferOptions & options)

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -57,7 +57,7 @@ namespace webrtc
         void CollectStats();
         void SetRemoteDescription(const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer);
         webrtc::RTCErrorType SetConfiguration(const std::string& config);
-        void GetConfiguration(std::string& config) const;
+        std::string GetConfiguration() const;
         void CreateOffer(const RTCOfferOptions& options);
         void CreateAnswer(const RTCAnswerOptions& options);
         void AddIceCandidate(const RTCIceCandidate& candidate);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -276,8 +276,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT char* PeerConnectionGetConfiguration(PeerConnectionObject* obj)
     {
-        std::string str;
-        obj->GetConfiguration(str);
+        const std::string str = obj->GetConfiguration();
         return ConvertString(str);
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -50,6 +50,15 @@ T** ConvertArray(std::vector<rtc::scoped_refptr<T>> vec, int* length)
     return ret;
 }
 
+char* ConvertString(const std::string str)
+{
+    const int size = str.size();
+    char* ret = static_cast<char*>(CoTaskMemAlloc(size + sizeof(char)));
+    str.copy(ret, size);
+    ret[size] = '\0';
+    return ret;
+}
+
 extern "C"
 {
     UNITY_INTERFACE_EXPORT bool GetHardwareEncoderSupport()
@@ -123,11 +132,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT char* MediaStreamGetID(MediaStreamInterface* stream)
     {
-        const auto idStr = stream->id();
-        const auto id = static_cast<char*>(CoTaskMemAlloc(idStr.size() + sizeof(char)));
-        idStr.copy(id, idStr.size());
-        id[idStr.size()] = '\0';
-        return id;
+        return ConvertString(stream->id());
     }
 
     UNITY_INTERFACE_EXPORT void MediaStreamRegisterOnAddTrack(Context* context, MediaStreamInterface* stream, DelegateMediaStreamOnAddTrack callback)
@@ -170,11 +175,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT char* MediaStreamTrackGetID(MediaStreamTrackInterface* track)
     {
-        const auto idStr = track->id();
-        const auto id = static_cast<char*>(CoTaskMemAlloc(idStr.size() + sizeof(char)));
-        idStr.copy(id, idStr.size());
-        id[idStr.size()] = '\0';
-        return id;
+        return ConvertString(track->id());
     }
 
     UNITY_INTERFACE_EXPORT bool MediaStreamTrackGetEnabled(MediaStreamTrackInterface* track)
@@ -273,15 +274,11 @@ extern "C"
         return obj->SetConfiguration(std::string(conf));
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionGetConfiguration(PeerConnectionObject* obj, char** conf, int* len)
+    UNITY_INTERFACE_EXPORT char* PeerConnectionGetConfiguration(PeerConnectionObject* obj)
     {
-        std::string _conf;
-        obj->GetConfiguration(_conf);
-#pragma warning(suppress: 4267)
-        *len = _conf.size();
-        *conf = static_cast<char*>(::CoTaskMemAlloc(_conf.size() + sizeof(char)));
-        _conf.copy(*conf, _conf.size());
-        (*conf)[_conf.size()] = '\0';
+        std::string str;
+        obj->GetConfiguration(str);
+        return ConvertString(str);
     }
 
     UNITY_INTERFACE_EXPORT void PeerConnectionSetRemoteDescription(Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc)
@@ -460,11 +457,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT char* DataChannelGetLabel(DataChannelObject* dataChannelObj)
     {
-        std::string tmp = dataChannelObj->GetLabel();
-        auto label = static_cast<char*>(CoTaskMemAlloc(tmp.size() + sizeof(char)));
-        tmp.copy(label, tmp.size());
-        label[tmp.size()] = '\0';
-        return label;
+        return ConvertString(dataChannelObj->GetLabel());
     }
 
     UNITY_INTERFACE_EXPORT void DataChannelSend(DataChannelObject* dataChannelObj, const char* msg)

--- a/Runtime/Scripts/IntPtrExtension.cs
+++ b/Runtime/Scripts/IntPtrExtension.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Unity.WebRTC
+{
+
+    public static class IntPtrExtension
+    {
+        public static string AsAnsiString(this IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero)
+            {
+                throw new ArgumentException("ptr is nullptr");
+            }
+            string str = Marshal.PtrToStringAnsi(ptr);
+            Marshal.FreeHGlobal(ptr);
+            return str;
+        }
+    }
+}

--- a/Runtime/Scripts/IntPtrExtension.cs
+++ b/Runtime/Scripts/IntPtrExtension.cs
@@ -6,15 +6,23 @@ namespace Unity.WebRTC
 
     public static class IntPtrExtension
     {
-        public static string AsAnsiString(this IntPtr ptr)
+        public static string AsAnsiStringWithFreeMem(this IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
             {
                 throw new ArgumentException("ptr is nullptr");
             }
             string str = Marshal.PtrToStringAnsi(ptr);
-            Marshal.FreeHGlobal(ptr);
+            Marshal.FreeCoTaskMem(ptr);
             return str;
+        }
+        public static string AsAnsiStringWithoutFreeMem(this IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero)
+            {
+                throw new ArgumentException("ptr is nullptr");
+            }
+            return Marshal.PtrToStringAnsi(ptr);
         }
     }
 }

--- a/Runtime/Scripts/IntPtrExtension.cs.meta
+++ b/Runtime/Scripts/IntPtrExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 382cca6191a10bc48960d982a92aea7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -116,7 +116,7 @@ namespace Unity.WebRTC
         {
             self = ptr;
             WebRTC.Table.Add(self, this);
-            id = Marshal.PtrToStringAnsi(NativeMethods.MediaStreamGetID(self));
+            id = NativeMethods.MediaStreamGetID(self).AsAnsiString();
 
             WebRTC.Context.MediaStreamRegisterOnAddTrack(self, MediaStreamOnAddTrack);
             WebRTC.Context.MediaStreamRegisterOnRemoveTrack(self, MediaStreamOnRemoveTrack);

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -116,7 +116,7 @@ namespace Unity.WebRTC
         {
             self = ptr;
             WebRTC.Table.Add(self, this);
-            id = NativeMethods.MediaStreamGetID(self).AsAnsiString();
+            id = NativeMethods.MediaStreamGetID(self).AsAnsiStringWithFreeMem();
 
             WebRTC.Context.MediaStreamRegisterOnAddTrack(self, MediaStreamOnAddTrack);
             WebRTC.Context.MediaStreamRegisterOnRemoveTrack(self, MediaStreamOnRemoveTrack);

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -53,7 +53,7 @@ namespace Unity.WebRTC
             self = ptr;
             WebRTC.Table.Add(self, this);
             Kind = NativeMethods.MediaStreamTrackGetKind(self);
-            Id = Marshal.PtrToStringAnsi(NativeMethods.MediaStreamTrackGetID(self));
+            Id = NativeMethods.MediaStreamTrackGetID(self).AsAnsiString();
         }
 
         ~MediaStreamTrack()

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -53,7 +53,7 @@ namespace Unity.WebRTC
             self = ptr;
             WebRTC.Table.Add(self, this);
             Kind = NativeMethods.MediaStreamTrackGetKind(self);
-            Id = NativeMethods.MediaStreamTrackGetID(self).AsAnsiString();
+            Id = NativeMethods.MediaStreamTrackGetID(self).AsAnsiStringWithFreeMem();
         }
 
         ~MediaStreamTrack()

--- a/Runtime/Scripts/RTCDataChannel.cs
+++ b/Runtime/Scripts/RTCDataChannel.cs
@@ -91,7 +91,7 @@ namespace Unity.WebRTC
         {
             self = ptr;
             WebRTC.Table.Add(self, this);
-            Label = NativeMethods.DataChannelGetLabel(self).AsAnsiString();
+            Label = NativeMethods.DataChannelGetLabel(self).AsAnsiStringWithFreeMem();
 
             NativeMethods.DataChannelRegisterOnMessage(self, DataChannelNativeOnMessage);
             NativeMethods.DataChannelRegisterOnOpen(self, DataChannelNativeOnOpen);

--- a/Runtime/Scripts/RTCDataChannel.cs
+++ b/Runtime/Scripts/RTCDataChannel.cs
@@ -91,8 +91,7 @@ namespace Unity.WebRTC
         {
             self = ptr;
             WebRTC.Table.Add(self, this);
-            var labelPtr = NativeMethods.DataChannelGetLabel(self);
-            Label = Marshal.PtrToStringAnsi(labelPtr);
+            Label = NativeMethods.DataChannelGetLabel(self).AsAnsiString();
 
             NativeMethods.DataChannelRegisterOnMessage(self, DataChannelNativeOnMessage);
             NativeMethods.DataChannelRegisterOnOpen(self, DataChannelNativeOnOpen);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -232,8 +232,7 @@ namespace Unity.WebRTC
         public RTCConfiguration GetConfiguration()
         {
             int len = 0;
-            IntPtr ptr = NativeMethods.PeerConnectionGetConfiguration(self);
-            var str = Marshal.PtrToStringAnsi(ptr);
+            var str = NativeMethods.PeerConnectionGetConfiguration(self).AsAnsiString();
             return JsonUtility.FromJson<RTCConfiguration>(str);
         }
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -232,7 +232,7 @@ namespace Unity.WebRTC
         public RTCConfiguration GetConfiguration()
         {
             int len = 0;
-            var str = NativeMethods.PeerConnectionGetConfiguration(self).AsAnsiString();
+            var str = NativeMethods.PeerConnectionGetConfiguration(self).AsAnsiStringWithFreeMem();
             return JsonUtility.FromJson<RTCConfiguration>(str);
         }
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -232,9 +232,8 @@ namespace Unity.WebRTC
         public RTCConfiguration GetConfiguration()
         {
             int len = 0;
-            var ptr = IntPtr.Zero;
-            NativeMethods.PeerConnectionGetConfiguration(self, ref ptr, ref len);
-            var str = Marshal.PtrToStringAnsi(ptr, len);
+            IntPtr ptr = NativeMethods.PeerConnectionGetConfiguration(self);
+            var str = Marshal.PtrToStringAnsi(ptr);
             return JsonUtility.FromJson<RTCConfiguration>(str);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -448,7 +448,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionGetConfiguration(IntPtr ptr, ref IntPtr conf, ref int len);
+        public static extern IntPtr PeerConnectionGetConfiguration(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionCreateOffer(IntPtr ptr, ref RTCOfferOptions options);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -146,7 +146,8 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            var streamId = Marshal.PtrToStringAnsi(NativeMethods.MediaStreamGetID(stream));
+            string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiString();
+            Assert.IsNotEmpty(streamId);
             const int width = 1280;
             const int height = 720;
             const int bitrate = 1000000;
@@ -217,7 +218,8 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            var streamId = Marshal.PtrToStringAnsi(NativeMethods.MediaStreamGetID(stream));
+            var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiString();
+            Assert.IsNotEmpty(streamId);
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
             NativeMethods.ContextDeleteMediaStreamTrack(context, track);
@@ -244,8 +246,8 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            var streamId = Marshal.PtrToStringAnsi(NativeMethods.MediaStreamGetID(stream));
-
+            var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiString();
+            Assert.IsNotEmpty(streamId);
             const int width = 1280;
             const int height = 720;
             const int bitrate = 1000000;

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -146,7 +146,7 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiString();
+            string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
             Assert.IsNotEmpty(streamId);
             const int width = 1280;
             const int height = 720;
@@ -218,7 +218,7 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiString();
+            var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
             Assert.IsNotEmpty(streamId);
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
@@ -246,7 +246,7 @@ namespace Unity.WebRTC.RuntimeTest
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiString();
+            var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
             Assert.IsNotEmpty(streamId);
             const int width = 1280;
             const int height = 720;


### PR DESCRIPTION
## Changed
- Add utility method `ConvertString`
- Changed `PeerConnectionObject::GetConfiguration()` method return value
- Add IntPtr extension method to free native memory