### PR TITLE
fix: bitrate control

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/IEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/IEncoder.h
@@ -20,7 +20,7 @@ namespace webrtc
     public:
         virtual ~IEncoder() {};        
         virtual void InitV() = 0;   //Can throw exception. 
-        virtual void SetRate(uint32_t rate) = 0;
+        virtual void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) = 0;
         virtual void UpdateSettings() = 0;
         virtual bool CopyBuffer(void* frame) = 0;
         virtual bool EncodeFrame() = 0;

--- a/Plugin~/WebRTCPlugin/Codec/IEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/IEncoder.h
@@ -30,11 +30,13 @@ namespace webrtc
         sigslot::signal1<webrtc::VideoFrame&> CaptureFrame;
 
         // todo(kazuki): remove this virtual method after refactoring DummyVideoEncoder
-        virtual void SetEncoderId(const uint32_t id) = 0;
+        virtual void SetEncoderId(const uint32_t id) { m_encoderId = id;  }
+        virtual uint32_t Id() const { return m_encoderId; }
 
         CodecInitializationResult GetCodecInitializationResult() const { return m_initializationResult; }
     protected:
         CodecInitializationResult m_initializationResult = CodecInitializationResult::NotInitialized;
+        uint32_t m_encoderId;
     };
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/IEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/IEncoder.h
@@ -29,6 +29,9 @@ namespace webrtc
         virtual uint64 GetCurrentFrameCount() const = 0;
         sigslot::signal1<webrtc::VideoFrame&> CaptureFrame;
 
+        // todo(kazuki): remove this virtual method after refactoring DummyVideoEncoder
+        virtual void SetEncoderId(const uint32_t id) = 0;
+
         CodecInitializationResult GetCodecInitializationResult() const { return m_initializationResult; }
     protected:
         CodecInitializationResult m_initializationResult = CodecInitializationResult::NotInitialized;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -226,6 +226,8 @@ namespace webrtc
     }
     void NvEncoder::SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters)
     {
+        LogPrint("SetRates\n");
+
         const uint32_t bitrate = parameters.bitrate.get_sum_bps();
         m_bitrateAdjuster->SetTargetBitrateBps(bitrate);
         m_frameRate = parameters.framerate_fps;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -202,14 +202,15 @@ namespace webrtc
     void NvEncoder::UpdateSettings()
     {
         bool settingChanged = false;
+        const uint32_t bitRate = m_bitrateAdjuster->GetAdjustedBitrateBps();
         if (nvEncConfig.rcParams.averageBitRate != bitRate)
         {
             nvEncConfig.rcParams.averageBitRate = bitRate;
             settingChanged = true;
         }
-        if (nvEncInitializeParams.frameRateNum != frameRate)
+        if (nvEncInitializeParams.frameRateNum != m_frameRate)
         {
-            nvEncInitializeParams.frameRateNum = frameRate;
+            nvEncInitializeParams.frameRateNum = m_frameRate;
             settingChanged = true;
         }
 
@@ -226,8 +227,7 @@ namespace webrtc
     {
         const uint32_t bitrate = parameters.bitrate.get_sum_bps();
         m_bitrateAdjuster->SetTargetBitrateBps(bitrate);
-        uint32_t newBitrate = m_bitrateAdjuster->GetAdjustedBitrateBps();
-        double newFrameRate = parameters.framerate_fps;
+        m_frameRate = parameters.framerate_fps;
     }
 
     bool NvEncoder::CopyBuffer(void* frame)

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -226,8 +226,6 @@ namespace webrtc
     }
     void NvEncoder::SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters)
     {
-        LogPrint("SetRates\n");
-
         const uint32_t bitrate = parameters.bitrate.get_sum_bps();
         m_bitrateAdjuster->SetTargetBitrateBps(bitrate);
         m_frameRate = parameters.framerate_fps;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -22,7 +22,7 @@ namespace webrtc
         const NV_ENC_INPUT_RESOURCE_TYPE inputType,
         const NV_ENC_BUFFER_FORMAT bufferFormat,
         const int width, const int height, IGraphicsDevice* device)
-    : width(width), height(height), m_device(device), m_deviceType(type), m_inputType(inputType), m_bufferFormat(bufferFormat)
+    : m_width(width), m_height(height), m_device(device), m_deviceType(type), m_inputType(inputType), m_bufferFormat(bufferFormat)
     {
         LogPrint(StringFormat("width is %d, height is %d", width, height).c_str());
         checkf(width > 0 && height > 0, "Invalid width or height!");
@@ -30,7 +30,8 @@ namespace webrtc
         m_bitrateAdjuster = std::make_unique<webrtc::BitrateAdjuster>(0.5f, 0.95f);
     }
 
-    void NvEncoder::InitV()  {
+    void NvEncoder::InitV()
+    {
         bool result = true;
         if (m_initializationResult == CodecInitializationResult::NotInitialized)
         {
@@ -53,13 +54,13 @@ namespace webrtc
 #pragma endregion
 #pragma region set initialization parameters
         nvEncInitializeParams.version = NV_ENC_INITIALIZE_PARAMS_VER;
-        nvEncInitializeParams.encodeWidth = width;
-        nvEncInitializeParams.encodeHeight = height;
-        nvEncInitializeParams.darWidth = width;
-        nvEncInitializeParams.darHeight = height;
+        nvEncInitializeParams.encodeWidth = m_width;
+        nvEncInitializeParams.encodeHeight = m_height;
+        nvEncInitializeParams.darWidth = m_width;
+        nvEncInitializeParams.darHeight = m_height;
         nvEncInitializeParams.encodeGUID = NV_ENC_CODEC_H264_GUID;
         nvEncInitializeParams.presetGUID = NV_ENC_PRESET_LOW_LATENCY_HQ_GUID;
-        nvEncInitializeParams.frameRateNum = frameRate;
+        nvEncInitializeParams.frameRateNum = m_frameRate;
         nvEncInitializeParams.frameRateDen = 1;
         nvEncInitializeParams.enablePTD = 1;
         nvEncInitializeParams.reportSliceOffsets = 0;
@@ -77,7 +78,7 @@ namespace webrtc
         std::memcpy(&nvEncConfig, &presetConfig.presetCfg, sizeof(NV_ENC_CONFIG));
         nvEncConfig.profileGUID = NV_ENC_H264_PROFILE_BASELINE_GUID;
         nvEncConfig.gopLength = nvEncInitializeParams.frameRateNum;
-        nvEncConfig.rcParams.averageBitRate = bitRate;
+        nvEncConfig.rcParams.averageBitRate = m_bitrateAdjuster->GetAdjustedBitrateBps();
         nvEncConfig.encodeCodecConfig.h264Config.idrPeriod = nvEncConfig.gopLength;
 
         nvEncConfig.encodeCodecConfig.h264Config.sliceMode = 0;
@@ -102,7 +103,7 @@ namespace webrtc
 #pragma endregion
 
         InitEncoderResources();
-        isNvEncoderSupported = true;
+        m_isNvEncoderSupported = true;
 
     }
     NvEncoder::~NvEncoder()
@@ -305,7 +306,7 @@ namespace webrtc
         checkf(NV_RESULT(errorCode), StringFormat("Failed to unlock bit stream, error is %d", errorCode).c_str());
         frame.isIdrFrame = lockBitStream.pictureType == NV_ENC_PIC_TYPE_IDR;
 #pragma endregion
-        rtc::scoped_refptr<FrameBuffer> buffer = new rtc::RefCountedObject<FrameBuffer>(width, height, frame.encodedFrame, 0);
+        rtc::scoped_refptr<FrameBuffer> buffer = new rtc::RefCountedObject<FrameBuffer>(m_width, m_height, frame.encodedFrame, m_encoderId);
         int64 timestamp = rtc::TimeMillis();
         webrtc::VideoFrame videoFrame{buffer, webrtc::VideoRotation::kVideoRotation_0, timestamp};
         videoFrame.set_ntp_time_ms(timestamp);
@@ -320,13 +321,13 @@ namespace webrtc
 
         if (!registerResource.resourceToRegister)
             LogPrint("resource is not initialized");
-        registerResource.width = width;
-        registerResource.height = height;
+        registerResource.width = m_width;
+        registerResource.height = m_height;
         if (inputType !=NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY)
         {
-            registerResource.pitch = GetWidthInBytes(m_bufferFormat, width);          
+            registerResource.pitch = GetWidthInBytes(m_bufferFormat, m_width);          
         } else{
-            registerResource.pitch = width;            
+            registerResource.pitch = m_width;            
         }
         registerResource.bufferFormat = m_bufferFormat;
         registerResource.bufferUsage = NV_ENC_INPUT_IMAGE;
@@ -355,7 +356,7 @@ namespace webrtc
     {
         for (uint32 i = 0; i < bufferedFrameNum; i++)
         {
-            renderTextures[i] = m_device->CreateDefaultTextureV(width, height);
+            renderTextures[i] = m_device->CreateDefaultTextureV(m_width, m_height);
             void* buffer = AllocateInputResourceV(renderTextures[i]);
 
             Frame& frame = bufferedFrames[i];

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -54,7 +54,6 @@ namespace webrtc
         bool IsSupported() const override { return m_isNvEncoderSupported; }
         void SetIdrFrame()  override { isIdrFrame = true; }
         uint64 GetCurrentFrameCount() const override { return frameCount; }
-        void SetEncoderId(const uint32_t id) override { m_encoderId = id; }
     protected:
         int m_width;
         int m_height;
@@ -88,7 +87,6 @@ namespace webrtc
 
         uint32_t m_frameRate = 30;
         std::unique_ptr<webrtc::BitrateAdjuster> m_bitrateAdjuster;
-        int m_encoderId = 0;
     };
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -54,8 +54,7 @@ namespace webrtc
         bool IsSupported() const override { return m_isNvEncoderSupported; }
         void SetIdrFrame()  override { isIdrFrame = true; }
         uint64 GetCurrentFrameCount() const override { return frameCount; }
-
-        void SetEncoderId(const uint32_t id) { m_encoderId = id; }
+        void SetEncoderId(const uint32_t id) override { m_encoderId = id; }
     protected:
         int m_width;
         int m_height;
@@ -89,7 +88,6 @@ namespace webrtc
 
         uint32_t m_frameRate = 30;
         std::unique_ptr<webrtc::BitrateAdjuster> m_bitrateAdjuster;
-        bool m_settingChanged = false;
         int m_encoderId = 0;
     };
     

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -39,7 +39,6 @@ namespace webrtc
             int width, int height, IGraphicsDevice* device);
         virtual ~NvEncoder();
 
-        virtual void InitV() override;
         static CodecInitializationResult LoadCodec();
         static bool LoadModule();
         static void UnloadModule();
@@ -47,24 +46,26 @@ namespace webrtc
         static uint32_t GetChromaHeight(const NV_ENC_BUFFER_FORMAT bufferFormat, const uint32_t lumaHeight);
         static uint32_t GetWidthInBytes(const NV_ENC_BUFFER_FORMAT bufferFormat, const uint32_t width);
 
+        void InitV() override;
         void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) override;
         void UpdateSettings() override;
         bool CopyBuffer(void* frame) override;
         bool EncodeFrame() override;
-        bool IsSupported() const override { return isNvEncoderSupported; }
+        bool IsSupported() const override { return m_isNvEncoderSupported; }
         void SetIdrFrame()  override { isIdrFrame = true; }
-        virtual uint64 GetCurrentFrameCount() const override { return frameCount; }
+        uint64 GetCurrentFrameCount() const override { return frameCount; }
+
+        void SetEncoderId(const uint32_t id) { m_encoderId = id; }
     protected:
-        int width = 1920;
-        int height = 1080;
-        int pitch = 0;
+        int m_width;
+        int m_height;
         IGraphicsDevice* m_device;
 
         NV_ENC_DEVICE_TYPE m_deviceType;
         NV_ENC_INPUT_RESOURCE_TYPE m_inputType;
         NV_ENC_BUFFER_FORMAT m_bufferFormat;
 
-        bool isNvEncoderSupported = false;
+        bool m_isNvEncoderSupported = false;
 
         virtual void* AllocateInputResourceV(ITexture2D* tex) = 0;
 
@@ -90,7 +91,6 @@ namespace webrtc
         std::unique_ptr<webrtc::BitrateAdjuster> m_bitrateAdjuster;
         bool m_settingChanged = false;
         int m_encoderId = 0;
-        webrtc::Clock* m_clock;
     };
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -47,7 +47,7 @@ namespace webrtc
         static uint32_t GetChromaHeight(const NV_ENC_BUFFER_FORMAT bufferFormat, const uint32_t lumaHeight);
         static uint32_t GetWidthInBytes(const NV_ENC_BUFFER_FORMAT bufferFormat, const uint32_t width);
 
-        void SetRate(uint32 rate) override;
+        void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) override;
         void UpdateSettings() override;
         bool CopyBuffer(void* frame) override;
         bool EncodeFrame() override;
@@ -85,13 +85,12 @@ namespace webrtc
         uint64 frameCount = 0;
         void* pEncoderInterface = nullptr;
         bool isIdrFrame = false;
-        //10Mbps
-        uint32_t bitRate = 10000000;
-        //100Mbps
-        uint32_t lastBitRate = 100000000;
-        //5Mbps
-        const uint32_t minBitRate = 5000000;
-        uint32_t frameRate = 45;
+
+        uint32_t m_frameRate = 30;
+        std::unique_ptr<webrtc::BitrateAdjuster> m_bitrateAdjuster;
+        bool m_settingChanged = false;
+        int m_encoderId = 0;
+        webrtc::Clock* m_clock;
     };
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -23,7 +23,6 @@ namespace webrtc
         bool IsSupported() const override { return true; }
         void SetIdrFrame() override {}
         uint64 GetCurrentFrameCount() const override { return m_frameCount; }
-        void SetEncoderId(const uint32_t id) override {};
 
     private:
         IGraphicsDevice* m_device;

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -16,7 +16,7 @@ namespace webrtc
     public:
         SoftwareEncoder(int _width, int _height, IGraphicsDevice* device);
         virtual void InitV() override;
-        virtual void SetRate(uint32_t rate) override {}
+        virtual void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) override {}
         virtual void UpdateSettings() override {}
         virtual bool CopyBuffer(void* frame) override;
         virtual bool EncodeFrame() override;

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -15,14 +15,15 @@ namespace webrtc
     {
     public:
         SoftwareEncoder(int _width, int _height, IGraphicsDevice* device);
-        virtual void InitV() override;
-        virtual void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) override {}
-        virtual void UpdateSettings() override {}
-        virtual bool CopyBuffer(void* frame) override;
-        virtual bool EncodeFrame() override;
-        virtual bool IsSupported() const override { return true; }
-        virtual void SetIdrFrame() override {}
-        virtual uint64 GetCurrentFrameCount() const override { return m_frameCount; }        
+        void InitV() override;
+        void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) override {}
+        void UpdateSettings() override {}
+        bool CopyBuffer(void* frame) override;
+        bool EncodeFrame() override;
+        bool IsSupported() const override { return true; }
+        void SetIdrFrame() override {}
+        uint64 GetCurrentFrameCount() const override { return m_frameCount; }
+        void SetEncoderId(const uint32_t id) override {};
 
     private:
         IGraphicsDevice* m_device;

--- a/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.h
+++ b/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.h
@@ -12,13 +12,15 @@ namespace webrtc
     public:
         VTEncoderMetal(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device);
         ~VTEncoderMetal();
-        void SetRate(uint32_t rate) override;
+        void SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters) override;
         void UpdateSettings() override;
         bool CopyBuffer(void* frame) override;
         bool EncodeFrame() override;
         bool IsSupported() const override;
         void SetIdrFrame() override;
         uint64 GetCurrentFrameCount() const override { return frameCount; }
+        void SetEncoderId(const uint32_t id) override {};
+
     private:
         uint64 frameCount = 0;
         uint64 m_width = 0;

--- a/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.h
+++ b/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.h
@@ -19,8 +19,7 @@ namespace webrtc
         bool IsSupported() const override;
         void SetIdrFrame() override;
         uint64 GetCurrentFrameCount() const override { return frameCount; }
-        void SetEncoderId(const uint32_t id) override {};
-
+        
     private:
         uint64 frameCount = 0;
         uint64 m_width = 0;

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -6,6 +6,7 @@
 #include "VideoCaptureTrackSource.h"
 #include "MediaStreamObserver.h"
 #include "SetSessionDescriptionObserver.h"
+#include "UnityVideoEncoderFactory.h"
 
 namespace unity
 {
@@ -145,7 +146,7 @@ namespace webrtc
 #else
         std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory =
             m_encoderType == UnityEncoderType::UnityEncoderHardware ?
-            std::make_unique<DummyVideoEncoderFactory>() : webrtc::CreateBuiltinVideoEncoderFactory();
+            std::make_unique<UnityVideoEncoderFactory>(static_cast<IVideoEncoderObserver*>(this)) : webrtc::CreateBuiltinVideoEncoderFactory();
 #endif
 
         m_peerConnectionFactory = webrtc::CreatePeerConnectionFactory(

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -181,6 +181,7 @@ namespace webrtc
         m_mapSetSessionDescriptionObserver.clear();
         m_mapVideoEncoderParameter.clear();
         m_mapDataChannels.clear();
+        m_mapIdAndEncoder.clear();
 
         m_workerThread->Quit();
         m_workerThread.reset();

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -197,6 +197,15 @@ namespace webrtc
         uint32_t id = GenerateUniqueId();
         encoder->SetEncoderId(id);
         m_mapIdAndEncoder[id] = encoder;
+        LogPrint("InitializeEncoder: %d size=%d\n", id, m_mapIdAndEncoder.size());
+
+        return true;
+    }
+
+    bool Context::FinalizeEncoder(IEncoder* encoder)
+    {
+        LogPrint("FinalizeEncoder: %d, size=%d\n", encoder->Id(), m_mapIdAndEncoder.size());
+        m_mapIdAndEncoder.erase(encoder->Id());
         return true;
     }
 
@@ -217,12 +226,18 @@ namespace webrtc
 
     void Context::SetKeyFrame(uint32_t id)
     {
-        m_mapIdAndEncoder[id]->SetIdrFrame();
+        if (m_mapIdAndEncoder.count(id))
+        {
+            m_mapIdAndEncoder[id]->SetIdrFrame();
+        }
     }
 
     void Context::SetRates(uint32_t id, const webrtc::VideoEncoder::RateControlParameters& parameters)
     {
-        m_mapIdAndEncoder[id]->SetRates(parameters);
+        if(m_mapIdAndEncoder.count(id))
+        {
+            m_mapIdAndEncoder[id]->SetRates(parameters);
+        }
     }
 
     UnityEncoderType Context::GetEncoderType() const

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -197,14 +197,11 @@ namespace webrtc
         uint32_t id = GenerateUniqueId();
         encoder->SetEncoderId(id);
         m_mapIdAndEncoder[id] = encoder;
-        LogPrint("InitializeEncoder: %d size=%d\n", id, m_mapIdAndEncoder.size());
-
         return true;
     }
 
     bool Context::FinalizeEncoder(IEncoder* encoder)
     {
-        LogPrint("FinalizeEncoder: %d, size=%d\n", encoder->Id(), m_mapIdAndEncoder.size());
         m_mapIdAndEncoder.erase(encoder->Id());
         return true;
     }

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -193,13 +193,9 @@ namespace webrtc
         m_mapVideoCapturer[track]->SetEncoder(encoder);
         m_mapVideoCapturer[track]->StartEncoder();
 
-        auto nvEncoder = dynamic_cast<NvEncoder*>(encoder);
-        if(nvEncoder != nullptr)
-        {
-            uint32_t id = GenerateUniqueId();
-            nvEncoder->SetEncoderId(id);
-            m_mapIdAndNvEncoder[id] = nvEncoder;
-        }
+        uint32_t id = GenerateUniqueId();
+        encoder->SetEncoderId(id);
+        m_mapIdAndEncoder[id] = encoder;
         return true;
     }
 
@@ -220,12 +216,12 @@ namespace webrtc
 
     void Context::SetKeyFrame(uint32_t id)
     {
-        m_mapIdAndNvEncoder[id]->SetIdrFrame();
+        m_mapIdAndEncoder[id]->SetIdrFrame();
     }
 
     void Context::SetRates(uint32_t id, const webrtc::VideoEncoder::RateControlParameters& parameters)
     {
-        m_mapIdAndNvEncoder[id]->SetRates(parameters);
+        m_mapIdAndEncoder[id]->SetRates(parameters);
     }
 
     UnityEncoderType Context::GetEncoderType() const

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "DummyAudioDevice.h"
+#include "DummyVideoEncoder.h"
 #include "PeerConnectionObject.h"
 #include "NvVideoCapturer.h"
 
@@ -36,7 +37,7 @@ namespace webrtc
         VideoEncoderParameter(int width, int height) :width(width), height(height) { }
     };
 
-    class Context
+    class Context : public IVideoEncoderObserver
     {
     public:
         
@@ -97,6 +98,9 @@ namespace webrtc
         std::map<const webrtc::PeerConnectionInterface*, rtc::scoped_refptr<SetSessionDescriptionObserver>> m_mapSetSessionDescriptionObserver;
         std::map<const webrtc::MediaStreamTrackInterface*, std::unique_ptr<VideoEncoderParameter>> m_mapVideoEncoderParameter;
         std::map<const DataChannelObject*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
+
+        void SetKeyFrame(uint32_t id) override {};
+        void SetRates(uint32_t id, const webrtc::VideoEncoder::RateControlParameters& parameters) override {};
     };
 
     extern bool Convert(const std::string& str, webrtc::PeerConnectionInterface::RTCConfiguration& config);

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Codec/NvCodec/NvEncoder.h"
 #include "DummyAudioDevice.h"
 #include "DummyVideoEncoder.h"
 #include "PeerConnectionObject.h"

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -77,6 +77,7 @@ namespace webrtc
         
         // You must call these methods on Rendering thread.
         bool InitializeEncoder(IEncoder* encoder, webrtc::MediaStreamTrackInterface* track);
+        bool FinalizeEncoder(IEncoder* encoder);
         // You must call these methods on Rendering thread.
         bool EncodeFrame(webrtc::MediaStreamTrackInterface* track);
         const VideoEncoderParameter* GetEncoderParameter(const webrtc::MediaStreamTrackInterface* track);

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Codec/NvCodec/NvEncoder.h"
 #include "DummyAudioDevice.h"
 #include "DummyVideoEncoder.h"
 #include "PeerConnectionObject.h"
@@ -55,7 +56,7 @@ namespace webrtc
 
 
         // MediaStreamTrack
-        webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label, void* frameBuffer, int32 width, int32 height, int32 bitRate);
+        webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label, void* frameBuffer);
         webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label);
         void DeleteMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
@@ -99,8 +100,17 @@ namespace webrtc
         std::map<const webrtc::MediaStreamTrackInterface*, std::unique_ptr<VideoEncoderParameter>> m_mapVideoEncoderParameter;
         std::map<const DataChannelObject*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
 
-        void SetKeyFrame(uint32_t id) override {};
-        void SetRates(uint32_t id, const webrtc::VideoEncoder::RateControlParameters& parameters) override {};
+        // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
+        std::map<const uint32_t, NvEncoder*> m_mapIdAndNvEncoder;
+
+        // todo(kazuki): remove these callback methods by moving hardware encoder instance to DummyVideoEncoder.
+        //               attention point is multi-threaded opengl implementation with nvcodec.
+        void SetKeyFrame(uint32_t id) override;
+        void SetRates(uint32_t id, const webrtc::VideoEncoder::RateControlParameters& parameters) override;
+
+        // todo(kazuki): static variable to set id each encoder.
+        static uint32_t s_encoderId;
+        static uint32_t GenerateUniqueId();
     };
 
     extern bool Convert(const std::string& str, webrtc::PeerConnectionInterface::RTCConfiguration& config);

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -101,7 +101,7 @@ namespace webrtc
         std::map<const DataChannelObject*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
 
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
-        std::map<const uint32_t, NvEncoder*> m_mapIdAndNvEncoder;
+        std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;
 
         // todo(kazuki): remove these callback methods by moving hardware encoder instance to DummyVideoEncoder.
         //               attention point is multi-threaded opengl implementation with nvcodec.

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
@@ -40,6 +40,8 @@ namespace webrtc
     int32_t DummyVideoEncoder::Release()
     {
         this->callback = nullptr;
+        this->m_setKeyFrame.disconnect_all();
+        this->m_setRates.disconnect_all();
         return WEBRTC_VIDEO_CODEC_OK;
     }
 

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
@@ -66,8 +66,8 @@ namespace webrtc
             webrtc::H264::FindNaluIndices(&frameDataBuffer[0], frameDataBuffer.size());
         for (uint32_t i = 0; i < naluIndices.size(); i++)
         {
-            webrtc::H264::NaluType NALUType = webrtc::H264::ParseNaluType(frameDataBuffer[naluIndices[i].payload_start_offset]);
-            if (NALUType == webrtc::H264::kIdr)
+            const webrtc::H264::NaluType naluType = webrtc::H264::ParseNaluType(frameDataBuffer[naluIndices[i].payload_start_offset]);
+            if (naluType == webrtc::H264::kIdr)
             {
                 m_encodedImage._frameType = webrtc::VideoFrameType::kVideoFrameKey;
                 break;

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
@@ -15,9 +15,19 @@ namespace webrtc
 
     int32_t DummyVideoEncoder::InitEncode(const webrtc::VideoCodec* codec_settings, int32_t number_of_cores, size_t max_payload_size)
     {
-        //m_bitrateAdjuster = std::make_unique<webrtc::BitrateAdjuster>(*codec_settings);
-        m_bitrateAdjuster.reset(new webrtc::BitrateAdjuster(.5, .95));
-        //m_bitrateAdjuster->OnEncoderInfo(this->GetEncoderInfo());
+        if (codec_settings == nullptr)
+        {
+            return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+        }
+        // TODO(kazuki):: this encoder should support codecs other than this.
+        if (codec_settings->codecType != webrtc::kVideoCodecH264)
+        {
+            return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+        }
+        if (codec_settings->maxFramerate == 0 || codec_settings->width == 0 || codec_settings->height == 0)
+        {
+            return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+        }
         return WEBRTC_VIDEO_CODEC_OK;
     }
 
@@ -38,17 +48,20 @@ namespace webrtc
         FrameBuffer* frameBuffer = static_cast<FrameBuffer*>(frame.video_frame_buffer().get());
         std::vector<uint8_t>& frameDataBuffer = frameBuffer->buffer();
 
-        encodedImage._completeFrame = true;
-        encodedImage.SetTimestamp(frame.timestamp());
-        encodedImage._encodedWidth = frame.video_frame_buffer()->width();
-        encodedImage._encodedHeight = frame.video_frame_buffer()->height();
-        encodedImage.ntp_time_ms_ = frame.ntp_time_ms();
-        encodedImage.capture_time_ms_ = frame.render_time_ms();
-        encodedImage.rotation_ = frame.rotation();
-        encodedImage.content_type_ = webrtc::VideoContentType::UNSPECIFIED;
-        encodedImage.timing_.flags = webrtc::VideoSendTiming::kInvalid;
-        encodedImage._frameType = webrtc::VideoFrameType::kVideoFrameDelta;
-        encodedImage.SetColorSpace(frame.color_space());
+        // todo(kazuki): remove it when refactor video encoding process.
+        m_encoderId = frameBuffer->encoderId();
+
+        m_encodedImage._completeFrame = true;
+        m_encodedImage.SetTimestamp(frame.timestamp());
+        m_encodedImage._encodedWidth = frame.video_frame_buffer()->width();
+        m_encodedImage._encodedHeight = frame.video_frame_buffer()->height();
+        m_encodedImage.ntp_time_ms_ = frame.ntp_time_ms();
+        m_encodedImage.capture_time_ms_ = frame.render_time_ms();
+        m_encodedImage.rotation_ = frame.rotation();
+        m_encodedImage.content_type_ = webrtc::VideoContentType::UNSPECIFIED;
+        m_encodedImage.timing_.flags = webrtc::VideoSendTiming::kInvalid;
+        m_encodedImage._frameType = webrtc::VideoFrameType::kVideoFrameDelta;
+        m_encodedImage.SetColorSpace(frame.color_space());
         std::vector<webrtc::H264::NaluIndex> naluIndices =
             webrtc::H264::FindNaluIndices(&frameDataBuffer[0], frameDataBuffer.size());
         for (uint32_t i = 0; i < naluIndices.size(); i++)
@@ -56,38 +69,38 @@ namespace webrtc
             webrtc::H264::NaluType NALUType = webrtc::H264::ParseNaluType(frameDataBuffer[naluIndices[i].payload_start_offset]);
             if (NALUType == webrtc::H264::kIdr)
             {
-                encodedImage._frameType = webrtc::VideoFrameType::kVideoFrameKey;
+                m_encodedImage._frameType = webrtc::VideoFrameType::kVideoFrameKey;
                 break;
             }
         }
 
-        if (encodedImage._frameType != webrtc::VideoFrameType::kVideoFrameKey && frameTypes && (*frameTypes)[0] == webrtc::VideoFrameType::kVideoFrameKey)
+        if (m_encodedImage._frameType != webrtc::VideoFrameType::kVideoFrameKey && frameTypes && (*frameTypes)[0] == webrtc::VideoFrameType::kVideoFrameKey)
         {
             m_setKeyFrame(m_encoderId);
         }
 
-        encodedImage.set_buffer(&frameDataBuffer[0], frameDataBuffer.capacity());
-        encodedImage.set_size(frameDataBuffer.size());
+        m_encodedImage.set_buffer(&frameDataBuffer[0], frameDataBuffer.capacity());
+        m_encodedImage.set_size(frameDataBuffer.size());
 
-        fragHeader.VerifyAndAllocateFragmentationHeader(naluIndices.size());
-        fragHeader.fragmentationVectorSize = static_cast<uint16_t>(naluIndices.size());
+        m_fragHeader.VerifyAndAllocateFragmentationHeader(naluIndices.size());
+        m_fragHeader.fragmentationVectorSize = static_cast<uint16_t>(naluIndices.size());
         for (uint32_t i = 0; i < naluIndices.size(); i++)
         {
             webrtc::H264::NaluIndex const& NALUIndex = naluIndices[i];
-            fragHeader.fragmentationOffset[i] = NALUIndex.payload_start_offset;
-            fragHeader.fragmentationLength[i] = NALUIndex.payload_size;
+            m_fragHeader.fragmentationOffset[i] = NALUIndex.payload_start_offset;
+            m_fragHeader.fragmentationLength[i] = NALUIndex.payload_size;
         }
 
         int qp;
         m_h264BitstreamParser.ParseBitstream(frameDataBuffer.data(), frameDataBuffer.size());
         m_h264BitstreamParser.GetLastSliceQp(&qp);
-        encodedImage.qp_ = qp;
+        m_encodedImage.qp_ = qp;
 
         webrtc::CodecSpecificInfo codecInfo;
         codecInfo.codecType = webrtc::kVideoCodecH264;
         codecInfo.codecSpecific.H264.packetization_mode = webrtc::H264PacketizationMode::NonInterleaved;
 
-        const auto result = callback->OnEncodedImage(encodedImage, &codecInfo, &fragHeader);
+        const auto result = callback->OnEncodedImage(m_encodedImage, &codecInfo, &m_fragHeader);
         if (result.error != webrtc::EncodedImageCallback::Result::OK)
         {
             LogPrint("Encode callback failed %d", result.error);

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
@@ -7,22 +7,48 @@ namespace unity
 namespace webrtc
 {
 
-    int32_t DummyVideoEncoder::Encode(
-        const webrtc::VideoFrame& frame,
-        const std::vector<webrtc::VideoFrameType>* frameTypes)
+    DummyVideoEncoder::DummyVideoEncoder(IVideoEncoderObserver* observer)
+    {
+        this->m_setKeyFrame.connect(observer, &IVideoEncoderObserver::SetKeyFrame);
+        this->m_setRates.connect(observer, &IVideoEncoderObserver::SetRates);
+    }
+
+    int32_t DummyVideoEncoder::InitEncode(const webrtc::VideoCodec* codec_settings, int32_t number_of_cores, size_t max_payload_size)
+    {
+        //m_bitrateAdjuster = std::make_unique<webrtc::BitrateAdjuster>(*codec_settings);
+        m_bitrateAdjuster.reset(new webrtc::BitrateAdjuster(.5, .95));
+        //m_bitrateAdjuster->OnEncoderInfo(this->GetEncoderInfo());
+        return WEBRTC_VIDEO_CODEC_OK;
+    }
+
+    int32_t DummyVideoEncoder::RegisterEncodeCompleteCallback(webrtc::EncodedImageCallback* callback)
+    {
+        this->callback = callback;
+        return WEBRTC_VIDEO_CODEC_OK;
+    }
+
+    int32_t DummyVideoEncoder::Release()
+    {
+        this->callback = nullptr;
+        return WEBRTC_VIDEO_CODEC_OK;
+    }
+
+    int32_t DummyVideoEncoder::Encode(const webrtc::VideoFrame& frame, const std::vector<webrtc::VideoFrameType>* frameTypes)
     {
         FrameBuffer* frameBuffer = static_cast<FrameBuffer*>(frame.video_frame_buffer().get());
-        std::vector<uint8_t>& frameDataBuffer = frameBuffer->buffer;
+        std::vector<uint8_t>& frameDataBuffer = frameBuffer->buffer();
 
         encodedImage._completeFrame = true;
         encodedImage.SetTimestamp(frame.timestamp());
         encodedImage._encodedWidth = frame.video_frame_buffer()->width();
         encodedImage._encodedHeight = frame.video_frame_buffer()->height();
         encodedImage.ntp_time_ms_ = frame.ntp_time_ms();
+        encodedImage.capture_time_ms_ = frame.render_time_ms();
         encodedImage.rotation_ = frame.rotation();
         encodedImage.content_type_ = webrtc::VideoContentType::UNSPECIFIED;
         encodedImage.timing_.flags = webrtc::VideoSendTiming::kInvalid;
         encodedImage._frameType = webrtc::VideoFrameType::kVideoFrameDelta;
+        encodedImage.SetColorSpace(frame.color_space());
         std::vector<webrtc::H264::NaluIndex> naluIndices =
             webrtc::H264::FindNaluIndices(&frameDataBuffer[0], frameDataBuffer.size());
         for (uint32_t i = 0; i < naluIndices.size(); i++)
@@ -37,13 +63,7 @@ namespace webrtc
 
         if (encodedImage._frameType != webrtc::VideoFrameType::kVideoFrameKey && frameTypes && (*frameTypes)[0] == webrtc::VideoFrameType::kVideoFrameKey)
         {
-            SetKeyFrame();
-        }
-
-        if (lastBitrate.get_sum_kbps() > 0)
-        {
-            RateControlParameters param(lastBitrate, 30);
-            SetRates(param);
+            m_setKeyFrame(m_encoderId);
         }
 
         encodedImage.set_buffer(&frameDataBuffer[0], frameDataBuffer.capacity());
@@ -57,10 +77,18 @@ namespace webrtc
             fragHeader.fragmentationOffset[i] = NALUIndex.payload_start_offset;
             fragHeader.fragmentationLength[i] = NALUIndex.payload_size;
         }
+
+        int qp;
+        m_h264BitstreamParser.ParseBitstream(frameDataBuffer.data(), frameDataBuffer.size());
+        m_h264BitstreamParser.GetLastSliceQp(&qp);
+        encodedImage.qp_ = qp;
+
         webrtc::CodecSpecificInfo codecInfo;
         codecInfo.codecType = webrtc::kVideoCodecH264;
-        auto result = callback->OnEncodedImage(encodedImage, &codecInfo, &fragHeader);
-        if(result.error != webrtc::EncodedImageCallback::Result::OK)
+        codecInfo.codecSpecific.H264.packetization_mode = webrtc::H264PacketizationMode::NonInterleaved;
+
+        const auto result = callback->OnEncodedImage(encodedImage, &codecInfo, &fragHeader);
+        if (result.error != webrtc::EncodedImageCallback::Result::OK)
         {
             LogPrint("Encode callback failed %d", result.error);
             return WEBRTC_VIDEO_CODEC_ERROR;
@@ -68,33 +96,9 @@ namespace webrtc
         return WEBRTC_VIDEO_CODEC_OK;
     }
 
-    void DummyVideoEncoder::SetRates(const webrtc::VideoEncoder::RateControlParameters& parameters)
+    void DummyVideoEncoder::SetRates(const RateControlParameters& parameters)
     {
-        lastBitrate = parameters.bitrate;
-        SetRate(parameters.bitrate.get_sum_kbps() * 1000);
-    }
-
-    DummyVideoEncoderFactory::DummyVideoEncoderFactory() {}
-
-    std::vector<webrtc::SdpVideoFormat> DummyVideoEncoderFactory::GetSupportedFormats() const
-    {
-        const absl::optional<std::string> profileLevelId =
-            webrtc::H264::ProfileLevelIdToString(webrtc::H264::ProfileLevelId(webrtc::H264::kProfileConstrainedBaseline, webrtc::H264::kLevel5_1));
-        return { webrtc::SdpVideoFormat(
-            cricket::kH264CodecName,
-            { {cricket::kH264FmtpProfileLevelId, *profileLevelId},
-              {cricket::kH264FmtpLevelAsymmetryAllowed, "1"},
-              {cricket::kH264FmtpPacketizationMode, "1"} }) };
-    }
-
-    webrtc::VideoEncoderFactory::CodecInfo DummyVideoEncoderFactory::QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const
-    {
-        return CodecInfo{ true, false };
-    }
-
-    std::unique_ptr<webrtc::VideoEncoder> DummyVideoEncoderFactory::CreateVideoEncoder(const webrtc::SdpVideoFormat& format)
-    {
-        return std::make_unique<DummyVideoEncoder>();
+        m_setRates(m_encoderId, parameters);
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
@@ -7,54 +7,40 @@ namespace webrtc
 
     namespace webrtc = ::webrtc;
 
-    class NvVideoCapturer;
+    class IVideoEncoderObserver : public sigslot::has_slots<>
+    {
+    public:
+        virtual void SetKeyFrame(uint32_t id) = 0;
+        virtual void SetRates(uint32_t id, const webrtc::VideoEncoder::RateControlParameters& parameters) = 0;
+    };
+
     class DummyVideoEncoder : public webrtc::VideoEncoder
     {
     public:
-        sigslot::signal0<> SetKeyFrame;
-        sigslot::signal1<uint32> SetRate;
-        //webrtc::VideoEncoder
+        DummyVideoEncoder(IVideoEncoderObserver* observer);
+
+        // webrtc::VideoEncoder
         // Initialize the encoder with the information from the codecSettings
-        virtual int32_t InitEncode(const webrtc::VideoCodec* codec_settings,
-            int32_t number_of_cores,
-            size_t max_payload_size) override {
-            return 0;
-        }
+        virtual int32_t InitEncode(const webrtc::VideoCodec* codec_settings, int32_t number_of_cores, size_t max_payload_size) override;
         // Register an encode complete callback object.
-        virtual int32_t RegisterEncodeCompleteCallback(webrtc::EncodedImageCallback* callback) override {
-            this->callback = callback;
-            return 0;
-        }
+        virtual int32_t RegisterEncodeCompleteCallback(webrtc::EncodedImageCallback* callback) override;
         // Free encoder memory.
-        virtual int32_t Release() override { callback = nullptr; return 0; }
+        virtual int32_t Release() override;
         // Encode an I420 image (as a part of a video stream). The encoded image
         // will be returned to the user through the encode complete callback.
-        virtual int32_t Encode(
-            const webrtc::VideoFrame& frame,
-            const std::vector<webrtc::VideoFrameType>* frame_types) override;
+        virtual int32_t Encode(const webrtc::VideoFrame& frame, const std::vector<webrtc::VideoFrameType>* frame_types) override;
         // Default fallback: Just use the sum of bitrates as the single target rate.
         virtual void SetRates(const RateControlParameters& parameters) override;
     private:
         webrtc::EncodedImageCallback* callback = nullptr;
         webrtc::EncodedImage encodedImage;
         webrtc::RTPFragmentationHeader fragHeader;
-        webrtc::VideoBitrateAllocation lastBitrate;
-    };
+        webrtc::H264BitstreamParser m_h264BitstreamParser;
 
-    class DummyVideoEncoderFactory : public webrtc::VideoEncoderFactory
-    {
-    public:
-        //VideoEncoderFactory
-        // Returns a list of supported video formats in order of preference, to use
-        // for signaling etc.
-        virtual std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
-        // Returns information about how this format will be encoded. The specified
-        // format must be one of the supported formats by this factory.
-        virtual webrtc::VideoEncoderFactory::CodecInfo QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const override;
-        // Creates a VideoEncoder for the specified format.
-        virtual std::unique_ptr<webrtc::VideoEncoder> CreateVideoEncoder(const webrtc::SdpVideoFormat& format) override;
-
-        DummyVideoEncoderFactory();
+        uint32_t m_encoderId = 0;
+        sigslot::signal1<uint32_t> m_setKeyFrame;
+        sigslot::signal2<uint32_t, const RateControlParameters&> m_setRates;
+        std::unique_ptr<webrtc::BitrateAdjuster>  m_bitrateAdjuster;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
@@ -33,14 +33,16 @@ namespace webrtc
         virtual void SetRates(const RateControlParameters& parameters) override;
     private:
         webrtc::EncodedImageCallback* callback = nullptr;
-        webrtc::EncodedImage encodedImage;
-        webrtc::RTPFragmentationHeader fragHeader;
+        webrtc::EncodedImage m_encodedImage;
+        webrtc::RTPFragmentationHeader m_fragHeader;
         webrtc::H264BitstreamParser m_h264BitstreamParser;
 
+        // todo(kazuki): this member is for identify video encoder instance (IEncoder implemented).
         uint32_t m_encoderId = 0;
+
+        // todo(kazuki): remove these signals when moving hardware encoder instance to this class
         sigslot::signal1<uint32_t> m_setKeyFrame;
         sigslot::signal2<uint32_t, const RateControlParameters&> m_setRates;
-        std::unique_ptr<webrtc::BitrateAdjuster>  m_bitrateAdjuster;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
@@ -7,6 +7,8 @@ namespace webrtc
 
     namespace webrtc = ::webrtc;
 
+    // todo(kazuki): this interface class is used to access hardware encoder from webrtc::VideoEncoder for controlling bitrate
+    //               remove this after webrtc::Video Encoder can access hw encoder directly.
     class IVideoEncoderObserver : public sigslot::has_slots<>
     {
     public:

--- a/Plugin~/WebRTCPlugin/Logger.cpp
+++ b/Plugin~/WebRTCPlugin/Logger.cpp
@@ -1,7 +1,5 @@
 #include "pch.h"
 
-#define _DEBUG
-
 #if defined(_DEBUG)
 #include <cstdarg>
 #include "WebRTCPlugin.h"

--- a/Plugin~/WebRTCPlugin/Logger.cpp
+++ b/Plugin~/WebRTCPlugin/Logger.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 
+#define _DEBUG
+
 #if defined(_DEBUG)
 #include <cstdarg>
 #include "WebRTCPlugin.h"

--- a/Plugin~/WebRTCPlugin/NvVideoCapturer.cpp
+++ b/Plugin~/WebRTCPlugin/NvVideoCapturer.cpp
@@ -7,22 +7,33 @@ namespace unity
 namespace webrtc
 {
 
-    NvVideoCapturer::NvVideoCapturer() {
+    NvVideoCapturer::NvVideoCapturer()
+    {
         set_enable_video_adapter(false);
-        SetSupportedFormats(std::vector<cricket::VideoFormat>(1, cricket::VideoFormat(width, height, cricket::VideoFormat::FpsToInterval(framerate), cricket::FOURCC_H264)));
+        SetSupportedFormats(
+            std::vector<cricket::VideoFormat>(1,
+                cricket::VideoFormat(width,
+                    height,
+                    cricket::VideoFormat::FpsToInterval(framerate),
+                    cricket::FOURCC_H264)));
     }
 
-    bool NvVideoCapturer::EncodeVideoData() {
-        if (captureStarted && !captureStopped) {
-            if(encoder_ == nullptr) {
+    bool NvVideoCapturer::EncodeVideoData()
+    {
+        if (captureStarted && !captureStopped)
+        {
+            if(encoder_ == nullptr)
+            {
                 LogPrint("encoder is null");
                 return false;
             }
-            if(!encoder_->CopyBuffer(unityRT)) {
+            if(!encoder_->CopyBuffer(unityRT))
+            {
                 LogPrint("Copy texture buffer is failed");
                 return false;
             }
-            if(!encoder_->EncodeFrame()) {
+            if(!encoder_->EncodeFrame())
+            {
                 LogPrint("Encode frame is failed");
                 return false;
             }
@@ -67,12 +78,9 @@ namespace webrtc
     {
         encoder_->SetIdrFrame();
     }
-    void NvVideoCapturer::SetRate(uint32 rate)
-    {
-        encoder_->SetRate(rate);
-    }
 
-    void NvVideoCapturer::SetEncoder(IEncoder* encoder) {
+    void NvVideoCapturer::SetEncoder(IEncoder* encoder)
+    {
         encoder_ = encoder;
         encoder_->CaptureFrame.connect(this, &NvVideoCapturer::CaptureFrame);
     }

--- a/Plugin~/WebRTCPlugin/NvVideoCapturer.h
+++ b/Plugin~/WebRTCPlugin/NvVideoCapturer.h
@@ -41,7 +41,6 @@ namespace webrtc
         void SetEncoder(IEncoder* encoder);
         void SetKeyFrame();
         void SetSize(int32 width, int32 height);
-        void SetRate(uint32 rate);
         void CaptureFrame(webrtc::VideoFrame& videoFrame);
         bool CaptureStarted() const { return captureStarted; }
         CodecInitializationResult GetCodecInitializationResult() const;
@@ -70,9 +69,15 @@ namespace webrtc
     class FrameBuffer : public webrtc::VideoFrameBuffer
     {
     public:
-        std::vector<uint8>& buffer;
-
-        FrameBuffer(int width, int height, std::vector<uint8>& data) : buffer(data), frameWidth(width), frameHeight(height)  {}
+        FrameBuffer(int width,
+            int height,
+            std::vector<uint8>& data,
+            const int encoderId)
+            : m_frameWidth(width),
+            m_frameHeight(height),
+            m_encoderId(encoderId),
+            m_buffer(data)
+        {}
 
         //webrtc::VideoFrameBuffer pure virtual functions
         // This function specifies in what pixel format the data is stored in.
@@ -85,12 +90,24 @@ namespace webrtc
         // subsampled, this is the highest-resolution plane.
         virtual int width() const override
         {
-            return frameWidth;
+            return m_frameWidth;
         }
         virtual int height() const override
         {
-            return frameHeight;
+            return m_frameHeight;
         }
+
+        std::vector<uint8>& buffer() const
+        {
+            return m_buffer;
+        }
+
+        // The id is for identifying encoder which encoded this frame.
+        int encoderId() const
+        {
+            return m_encoderId;
+        }
+
         // Returns a memory-backed frame buffer in I420 format. If the pixel data is
         // in another format, a conversion will take place. All implementations must
         // provide a fallback to I420 for compatibility with e.g. the internal WebRTC
@@ -101,8 +118,10 @@ namespace webrtc
         }
 
     private:
-        int frameWidth;
-        int frameHeight;
+        int m_frameWidth;
+        int m_frameHeight;
+        int m_encoderId;
+        std::vector<uint8>& m_buffer;
     };
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/NvVideoCapturer.h
+++ b/Plugin~/WebRTCPlugin/NvVideoCapturer.h
@@ -102,6 +102,7 @@ namespace webrtc
             return m_buffer;
         }
 
+        // todo(kazuki): remove the method by refactoring video encoding.
         // The id is for identifying encoder which encoded this frame.
         int encoderId() const
         {

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -8,7 +8,8 @@ namespace unity
 namespace webrtc
 {
 
-    bool IsFormatSupported(const std::vector<webrtc::SdpVideoFormat>& supported_formats,
+    bool IsFormatSupported(
+        const std::vector<webrtc::SdpVideoFormat>& supported_formats,
         const webrtc::SdpVideoFormat& format)
     {
         for (const webrtc::SdpVideoFormat& supported_format : supported_formats)
@@ -43,9 +44,13 @@ namespace webrtc
 
     std::vector<webrtc::SdpVideoFormat> UnityVideoEncoderFactory::GetSupportedFormats() const
     {
-        std::vector <webrtc::SdpVideoFormat> formats = internal_encoder_factory_->GetSupportedFormats();
-        std::vector <webrtc::SdpVideoFormat> formats2 = GetHardwareEncoderFormats();
-        formats.insert(formats.end(), formats2.begin(), formats2.end());
+        std::vector <webrtc::SdpVideoFormat> formats = GetHardwareEncoderFormats();
+
+        // todo(kazuki): should support codec other than h264 like vp8, vp9 and av1.
+        // 
+        // std::vector <webrtc::SdpVideoFormat> formats2 = internal_encoder_factory_->GetSupportedFormats();
+        // formats.insert(formats.end(), formats2.begin(), formats2.end());
+        
         return formats;
     }
 

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -1,0 +1,79 @@
+#include "pch.h"
+#include "UnityVideoEncoderFactory.h"
+
+#include "DummyVideoEncoder.h"
+
+namespace unity
+{    
+namespace webrtc
+{
+
+    bool IsFormatSupported(const std::vector<webrtc::SdpVideoFormat>& supported_formats,
+        const webrtc::SdpVideoFormat& format)
+    {
+        for (const webrtc::SdpVideoFormat& supported_format : supported_formats)
+        {
+            if (cricket::IsSameCodec(format.name, format.parameters,
+                supported_format.name,
+                supported_format.parameters))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    UnityVideoEncoderFactory::UnityVideoEncoderFactory(IVideoEncoderObserver* observer)
+    : internal_encoder_factory_(new webrtc::InternalEncoderFactory())
+    {
+        m_observer = observer;
+    }
+
+    std::vector<webrtc::SdpVideoFormat> UnityVideoEncoderFactory::GetHardwareEncoderFormats() const
+    {
+        const absl::optional<std::string> profileLevelId =
+            webrtc::H264::ProfileLevelIdToString(webrtc::H264::ProfileLevelId(webrtc::H264::kProfileConstrainedBaseline, webrtc::H264::kLevel5_1));
+        return { webrtc::SdpVideoFormat(
+            cricket::kH264CodecName,
+            { {cricket::kH264FmtpProfileLevelId, *profileLevelId},
+              {cricket::kH264FmtpLevelAsymmetryAllowed, "1"},
+              {cricket::kH264FmtpPacketizationMode, "1"} }) };
+    }
+
+
+    std::vector<webrtc::SdpVideoFormat> UnityVideoEncoderFactory::GetSupportedFormats() const
+    {
+        std::vector <webrtc::SdpVideoFormat> formats = internal_encoder_factory_->GetSupportedFormats();
+        std::vector <webrtc::SdpVideoFormat> formats2 = GetHardwareEncoderFormats();
+        formats.insert(formats.end(), formats2.begin(), formats2.end());
+        return formats;
+    }
+
+    webrtc::VideoEncoderFactory::CodecInfo UnityVideoEncoderFactory::QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const
+    {
+        if (IsFormatSupported(GetHardwareEncoderFormats(), format))
+        {
+            return CodecInfo{ true, false };
+        }
+        RTC_DCHECK(IsFormatSupported(GetSupportedFormats(), format));
+        return internal_encoder_factory_->QueryVideoEncoder(format);
+    }
+
+    std::unique_ptr<webrtc::VideoEncoder> UnityVideoEncoderFactory::CreateVideoEncoder(const webrtc::SdpVideoFormat& format)
+    {
+        if (IsFormatSupported(GetHardwareEncoderFormats(), format))
+        {
+            return std::make_unique<DummyVideoEncoder>(m_observer);
+        }
+
+        std::unique_ptr<webrtc::VideoEncoder> internalEncoder;
+        // Try creating internal encoder.
+        if (IsFormatSupported(GetSupportedFormats(), format))
+        {
+            internalEncoder = internal_encoder_factory_->CreateVideoEncoder(format);
+        }
+        return internalEncoder;
+    }
+
+}
+}

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace unity
+{
+namespace webrtc
+{
+    namespace webrtc = ::webrtc;
+
+    class IVideoEncoderObserver;
+    class UnityVideoEncoderFactory : public webrtc::VideoEncoderFactory
+    {
+    public:
+        //VideoEncoderFactory
+        // Returns a list of supported video formats in order of preference, to use
+        // for signaling etc.
+        virtual std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
+        // Returns information about how this format will be encoded. The specified
+        // format must be one of the supported formats by this factory.
+        virtual CodecInfo QueryVideoEncoder(const webrtc::SdpVideoFormat& format) const override;
+        // Creates a VideoEncoder for the specified format.
+        virtual std::unique_ptr<webrtc::VideoEncoder> CreateVideoEncoder(const webrtc::SdpVideoFormat& format) override;
+
+        virtual std::vector<webrtc::SdpVideoFormat> GetHardwareEncoderFormats() const;
+
+        UnityVideoEncoderFactory(IVideoEncoderObserver* observer);
+    private:
+        IVideoEncoderObserver* m_observer;
+        const std::unique_ptr<VideoEncoderFactory> internal_encoder_factory_;
+    };
+}
+}

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -16,8 +16,6 @@ namespace webrtc
 
     void debugLog(const char* buf)
     {
-        ::OutputDebugStringA(buf);
-
         if (delegateDebugLog != nullptr)
         {
             if(rtc::ThreadManager::Instance()->IsMainThread())

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -16,6 +16,8 @@ namespace webrtc
 
     void debugLog(const char* buf)
     {
+        ::OutputDebugStringA(buf);
+
         if (delegateDebugLog != nullptr)
         {
             if(rtc::ThreadManager::Instance()->IsMainThread())

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -78,9 +78,9 @@ extern "C"
         context->DeleteMediaStream(stream);
     }
 
-    UNITY_INTERFACE_EXPORT::webrtc::MediaStreamTrackInterface* ContextCreateVideoTrack(Context* context, const char* label, void* rt, int32 width, int32 height, int32 bitRate)
+    UNITY_INTERFACE_EXPORT::webrtc::MediaStreamTrackInterface* ContextCreateVideoTrack(Context* context, const char* label, void* rt, int32 width, int32 height)
     {
-        return context->CreateVideoTrack(label, rt, width, height, bitRate);
+        return context->CreateVideoTrack(label, rt);
     }
 
     UNITY_INTERFACE_EXPORT void ContextDeleteMediaStreamTrack(Context* context, ::webrtc::MediaStreamTrackInterface* track)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.vcxproj
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.vcxproj
@@ -214,9 +214,11 @@
     <ClInclude Include="GraphicsDevice\Vulkan\VulkanTexture2D.h" />
     <ClInclude Include="GraphicsDevice\Vulkan\VulkanUtility.h" />
     <ClInclude Include="MediaStreamObserver.h" />
+    <ClInclude Include="NvVideoCapturer.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="PeerConnectionObject.h" />
     <ClInclude Include="SetSessionDescriptionObserver.h" />
+    <ClInclude Include="UnityVideoEncoderFactory.h" />
     <ClInclude Include="VideoCapturer.h" />
     <ClInclude Include="VideoCaptureTrackSource.h" />
     <ClInclude Include="WebRTCConstants.h" />
@@ -258,6 +260,7 @@
     </ClCompile>
     <ClCompile Include="PeerConnectionObject.cpp" />
     <ClCompile Include="SetSessionDescriptionObserver.cpp" />
+    <ClCompile Include="UnityVideoEncoderFactory.cpp" />
     <ClCompile Include="VideoCapturer.cpp" />
     <ClCompile Include="VideoCaptureTrackSource.cpp" />
     <ClCompile Include="WebRTCPlugin.cpp" />

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.vcxproj.filters
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.vcxproj.filters
@@ -72,6 +72,7 @@
     <ClCompile Include="MediaStreamObserver.cpp" />
     <ClCompile Include="SetSessionDescriptionObserver.cpp" />
     <ClCompile Include="UnityRenderEvent.cpp" />
+    <ClCompile Include="UnityVideoEncoderFactory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Context.h" />
@@ -171,6 +172,8 @@
     </ClInclude>
     <ClInclude Include="MediaStreamObserver.h" />
     <ClInclude Include="SetSessionDescriptionObserver.h" />
+    <ClInclude Include="NvVideoCapturer.h" />
+    <ClInclude Include="UnityVideoEncoderFactory.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="GraphicsDevice">

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -39,11 +39,12 @@
 #include "rtc_base/win32_socket_server.h"
 #endif
 
-#include "media/engine/internal_decoder_factory.h"
+#include "media/engine/internal_encoder_factory.h"
 #include "media/base/h264_profile_level_id.h"
 #include "media/base/adapted_video_track_source.h"
 #include "media/base/media_channel.h"
 #include "media/base/video_common.h"
+#include "media/base/video_broadcaster.h"
 
 #include "modules/video_capture/video_capture_impl.h"
 #include "modules/video_capture/video_capture_factory.h"
@@ -55,11 +56,9 @@
 
 #include "common_video/h264/h264_bitstream_parser.h"
 #include "common_video/h264/h264_common.h"
-
-#include "media/base/video_broadcaster.h"
+#include "common_video/include/bitrate_adjuster.h"
 
 #include "pc/media_stream_observer.h"
-
 
 #pragma endregion
 

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -34,7 +34,7 @@ protected:
 TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height));
     EXPECT_NE(nullptr, tex);
-    const auto track = context->CreateVideoTrack("video", tex.get(), 256, 256, 10000000);
+    const auto track = context->CreateVideoTrack("video", tex.get());
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
 }
 
@@ -47,7 +47,7 @@ TEST_P(ContextTest, CreateAndDeleteMediaStream) {
 TEST_P(ContextTest, CreateAndDeleteVideoTrack) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height));
     EXPECT_NE(nullptr, tex.get());
-    const auto track = context->CreateVideoTrack("video", tex.get(), 256, 256, 10000000);
+    const auto track = context->CreateVideoTrack("video", tex.get());
     EXPECT_NE(nullptr, track);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
     context->DeleteMediaStreamTrack(track);
@@ -71,7 +71,7 @@ TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
 TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height));
     const auto stream = context->CreateMediaStream("videostream");
-    const auto track = context->CreateVideoTrack("video", tex.get(), 256, 256, 10000000);
+    const auto track = context->CreateVideoTrack("video", tex.get());
     const auto videoTrack = reinterpret_cast<webrtc::AudioTrackInterface*>(track);
     stream->AddTrack(videoTrack);
     stream->RemoveTrack(videoTrack);

--- a/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
+++ b/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
@@ -84,6 +84,7 @@
     <ClInclude Include="..\WebRTCPlugin\pch.h" />
     <ClInclude Include="..\WebRTCPlugin\PeerConnectionObject.h" />
     <ClInclude Include="..\WebRTCPlugin\SetSessionDescriptionObserver.h" />
+    <ClInclude Include="..\WebRTCPlugin\UnityVideoEncoderFactory.h" />
     <ClInclude Include="..\WebRTCPlugin\VideoCapturer.h" />
     <ClInclude Include="..\WebRTCPlugin\VideoCaptureTrackSource.h" />
     <ClInclude Include="..\WebRTCPlugin\PlatformBase.h" />
@@ -123,6 +124,7 @@
     <ClCompile Include="..\WebRTCPlugin\NvVideoCapturer.cpp" />
     <ClCompile Include="..\WebRTCPlugin\PeerConnectionObject.cpp" />
     <ClCompile Include="..\WebRTCPlugin\SetSessionDescriptionObserver.cpp" />
+    <ClCompile Include="..\WebRTCPlugin\UnityVideoEncoderFactory.cpp" />
     <ClCompile Include="..\WebRTCPlugin\VideoCapturer.cpp" />
     <ClCompile Include="..\WebRTCPlugin\VideoCaptureTrackSource.cpp" />
     <ClCompile Include="..\WebRTCPlugin\WebRTCPlugin.cpp" />
@@ -144,7 +146,7 @@
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" />
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -219,6 +221,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
   </Target>
 </Project>

--- a/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
+++ b/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
@@ -221,6 +221,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
   </Target>
 </Project>

--- a/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
+++ b/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
@@ -221,6 +221,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets'))" />
   </Target>
 </Project>

--- a/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
+++ b/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj
@@ -146,7 +146,7 @@
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.3\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" />
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.1.8.1.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj.filters
+++ b/Plugin~/WebRTCPluginTest/WebRTCPluginTest.vcxproj.filters
@@ -78,6 +78,7 @@
     </ClCompile>
     <ClCompile Include="..\WebRTCPlugin\MediaStreamObserver.cpp" />
     <ClCompile Include="..\WebRTCPlugin\SetSessionDescriptionObserver.cpp" />
+    <ClCompile Include="..\WebRTCPlugin\UnityVideoEncoderFactory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\WebRTCPlugin\Context.h" />
@@ -179,9 +180,7 @@
     </ClInclude>
     <ClInclude Include="..\WebRTCPlugin\MediaStreamObserver.h" />
     <ClInclude Include="..\WebRTCPlugin\SetSessionDescriptionObserver.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <ClInclude Include="..\WebRTCPlugin\UnityVideoEncoderFactory.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="NvCodec">
@@ -214,5 +213,8 @@
     <Filter Include="Codec\SoftwareCodec">
       <UniqueIdentifier>{c117917c-26a2-4240-8d04-4cf5c19448e3}</UniqueIdentifier>
     </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -151,9 +151,9 @@ namespace Unity.WebRTC
             return NativeMethods.ContextCreateAudioTrack(self, label);
         }
 
-        public IntPtr CreateVideoTrack(string label, IntPtr rt, int width, int height, int bitrate)
+        public IntPtr CreateVideoTrack(string label, IntPtr texturePtr)
         {
-            return NativeMethods.ContextCreateVideoTrack(self, label, rt, width, height, bitrate);
+            return NativeMethods.ContextCreateVideoTrack(self, label, texturePtr);
         }
 
         public void StopMediaStreamTrack(IntPtr track)

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -166,7 +166,7 @@ namespace Unity.WebRTC
             var rt = new RenderTexture(width, height, depthValue, format);
             rt.Create();
             cam.targetTexture = rt;
-            return new VideoStreamTrack(cam.name, rt, bitrate);
+            return new VideoStreamTrack(cam.name, rt);
         }
 
 

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using UnityEngine;
 
 namespace Unity.WebRTC
 {
@@ -99,8 +100,8 @@ namespace Unity.WebRTC
             return tex;
         }
 
-        internal VideoStreamTrack(string label, UnityEngine.RenderTexture source, UnityEngine.RenderTexture dest, int width, int height, int bitrate)
-            : this(label, dest.GetNativeTexturePtr(), width, height, bitrate)
+        internal VideoStreamTrack(string label, UnityEngine.Texture source, UnityEngine.RenderTexture dest, int width, int height)
+            : this(label, dest.GetNativeTexturePtr(), width, height)
         {
             m_needFlip = true;
             m_sourceTexture = source;
@@ -129,11 +130,20 @@ namespace Unity.WebRTC
         /// <param name="source"></param>
         /// <param name="width"></param>
         /// <param name="height"></param>
-        /// <param name="bitrate"></param>
-        public VideoStreamTrack(string label, UnityEngine.RenderTexture source, int bitrate)
-            : this(label, source, CreateRenderTexture(source.width, source.height, source.format), source.width, source.height, bitrate)
+        public VideoStreamTrack(string label, UnityEngine.RenderTexture source)
+            : this(label, source, CreateRenderTexture(source.width, source.height, source.format), source.width, source.height)
         {
         }
+
+        public VideoStreamTrack(string label, UnityEngine.Texture source)
+            : this(label,
+                source,
+                CreateRenderTexture(source.width, source.height, WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType)),
+                source.width,
+                source.height)
+        {
+        }
+        
 
         /// <summary>
         /// Creates a new VideoStream object.
@@ -146,9 +156,8 @@ namespace Unity.WebRTC
         /// <param name="ptr"></param>
         /// <param name="width"></param>
         /// <param name="height"></param>
-        /// <param name="bitrate"></param>
-        public VideoStreamTrack(string label, IntPtr ptr, int width, int height, int bitrate)
-            : base(WebRTC.Context.CreateVideoTrack(label, ptr, width, height, bitrate))
+        public VideoStreamTrack(string label, IntPtr ptr, int width, int height)
+            : base(WebRTC.Context.CreateVideoTrack(label, ptr))
         {
             WebRTC.Context.SetVideoEncoderParameter(self, width, height);
             WebRTC.Context.InitializeEncoder(self);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -438,7 +438,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteDataChannel(IntPtr ptr, IntPtr ptrChannel);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label, IntPtr rt, int width, int height, int bitRate);
+        public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label, IntPtr texturePtr);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreateAudioTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -69,11 +69,10 @@ namespace Unity.WebRTC.RuntimeTest
             var context = Context.Create();
             var width = 256;
             var height = 256;
-            var bitrate = 1000000;
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = context.CreateVideoTrack("video", rt.GetNativeTexturePtr(), width, height, bitrate);
+            var track = context.CreateVideoTrack("video", rt.GetNativeTexturePtr());
             context.DeleteMediaStreamTrack(track);
             context.Dispose();
         }

--- a/Tests/Runtime/InitializeOnLoad.cs
+++ b/Tests/Runtime/InitializeOnLoad.cs
@@ -5,7 +5,7 @@ using UnityEngine.TestTools;
 
 namespace Unity.WebRTC.RuntimeTest
 {
-    public class InitializeOnLoad
+    internal class InitializeOnLoad
     {
         [RuntimeInitializeOnLoadMethod]
         static void OnLoad()

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -46,11 +46,10 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var width = 256;
             var height = 256;
-            var bitrate = 1000000;
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = new VideoStreamTrack("video", rt, bitrate);
+            var track = new VideoStreamTrack("video", rt);
             Assert.NotNull(track);
             yield return new WaitForSeconds(0.1f);
 
@@ -75,12 +74,11 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var width = 256;
             var height = 256;
-            var bitrate = 1000000;
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
             var stream = new MediaStream();
-            var track = new VideoStreamTrack("video", rt, bitrate);
+            var track = new VideoStreamTrack("video", rt);
             yield return new WaitForSeconds(0.1f);
             Assert.AreEqual(TrackKind.Video, track.Kind);
             Assert.AreEqual(0, stream.GetVideoTracks().Count());

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -149,9 +149,8 @@ namespace Unity.WebRTC.RuntimeTest
             var streamId = Marshal.PtrToStringAnsi(NativeMethods.MediaStreamGetID(stream));
             const int width = 1280;
             const int height = 720;
-            const int bitrate = 1000000;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr(), width, height, bitrate);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
             NativeMethods.PeerConnectionRemoveTrack(peer, sender);
             NativeMethods.ContextDeleteMediaStreamTrack(context, track);
@@ -168,9 +167,8 @@ namespace Unity.WebRTC.RuntimeTest
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             const int width = 1280;
             const int height = 720;
-            const int bitrate = 1000000;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr(), width, height, bitrate);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
             NativeMethods.MediaStreamAddTrack(stream, track);
 
             int trackSize = 0;
@@ -248,9 +246,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             const int width = 1280;
             const int height = 720;
-            const int bitrate = 1000000;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr(), width, height, bitrate);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             var callback = NativeMethods.GetRenderEventFunc(context);


### PR DESCRIPTION
In this PR fixed bitrate issue

- `DummyVideoEncoder` receives events from webrtc API to control bitrate
- Define `IVideoEncoderObserver` class to detect events on `DummyVideoEncoder`
- `Context` class implements `IVideoEncoderObserver` and process the callback
- Remove `bitrate` parameter from MediaStreamTrack API because the feature not supported yet

## TODO
First, the original design has problems that the hardware encoder has been placed out of `DummyVideoEncoder`. It should be refactored but will take some time, so I don't fix it in this version.

`UnityVideoEncoderFactory` that factory class to make video encoders but in this current version only can support h264. It should be supported others like VP8, Vp9, and AV1.