### PR TITLE
fix: workaround to avoid the crash on Unity editor

### DIFF
--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -12,25 +12,15 @@ namespace Unity.WebRTC
         private bool disposed;
         private IntPtr renderFunction;
 
-        public bool IsNull
-        {
-            get { return self == IntPtr.Zero; }
-        }
-
-        public static implicit operator bool(Context v)
-        {
-            return v.self != IntPtr.Zero;
-        }
-
-        public static bool ToBool(Context v)
-        {
-            return v;
-        }
-
         public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware)
         {
             var ptr = NativeMethods.ContextCreate(id, encoderType);
             return new Context(ptr, id);
+        }
+
+        public bool IsNull
+        {
+            get { return self == IntPtr.Zero; }
         }
 
         private Context(IntPtr ptr, int id)


### PR DESCRIPTION
This PR adds a workaround to avoid the crash when executing auto-refresh on Unity Editor.
This crash is caused by not executing dispose of resources when hot reload. So need to add the event when reloading assembly.