### PR TITLE
fix: fixed DataChannel crash bug

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -312,12 +312,14 @@ namespace webrtc
         config.ordered = options.ordered;
         config.maxRetransmitTime = options.maxRetransmitTime;
         config.maxRetransmits = options.maxRetransmits;
-        config.protocol = options.protocol;
+        config.protocol = options.protocol == nullptr ? "" : options.protocol;
         config.negotiated = options.negotiated;
 
         auto channel = obj->connection->CreateDataChannel(label, &config);
+        if (channel == nullptr)
+            return nullptr;
         auto dataChannelObj = std::make_unique<DataChannelObject>(channel, *obj);
-        auto ptr = dataChannelObj.get();
+        DataChannelObject* ptr = dataChannelObj.get();
         m_mapDataChannels[ptr] = std::move(dataChannelObj);
         return ptr;
     }

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -324,7 +324,10 @@ namespace Unity.WebRTC
 
         public RTCDataChannel CreateDataChannel(string label, ref RTCDataChannelInit options)
         {
-            return new RTCDataChannel(WebRTC.Context.CreateDataChannel(self, label, ref options), this);
+            IntPtr ptr = WebRTC.Context.CreateDataChannel(self, label, ref options);
+            if (ptr == IntPtr.Zero)
+                throw new ArgumentException("RTCDataChannelInit object is incorrect.");
+            return new RTCDataChannel(ptr, this);
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateCreateSDSuccess))]

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -21,7 +21,7 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        public void DataChannel_CreateDataChannel()
+        public void CreateDataChannel()
         {
             RTCConfiguration config = default;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
@@ -37,9 +37,21 @@ namespace Unity.WebRTC.RuntimeTest
             peer.Close();
         }
 
+        [Test]
+        public void CreateDataChannelFailed()
+        {
+            RTCConfiguration config = default;
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
+            var peer = new RTCPeerConnection(ref config);
+
+            RTCDataChannelInit option1 = default;
+            Assert.Throws<System.ArgumentException>(() => peer.CreateDataChannel("test1", ref option1));
+            peer.Close();
+        }
+
         [UnityTest]
         [Timeout(5000)]
-        public IEnumerator DataChannel_EventsAreSentToOther()
+        public IEnumerator EventsAreSentToOther()
         {
             RTCConfiguration config = default;
             config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};


### PR DESCRIPTION
This PR related the issue the user reported. https://github.com/Unity-Technologies/com.unity.webrtc/issues/97

The cause of the crash is the default parameters of the  `RTCDataChannelInit`.

Fixed the native code to return `nullptr` when the argument is incorrect.
And fixed the managed code to throw the exception when returned the null from the native-side. 