### PR TITLE
[WIP] feat: Add API RTCRtpSender.SetParameters

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -228,7 +228,7 @@ namespace webrtc
     {
         const uint32_t bitrate = parameters.bitrate.get_sum_bps();
         m_bitrateAdjuster->SetTargetBitrateBps(bitrate);
-        m_frameRate = parameters.framerate_fps;
+        m_frameRate = static_cast<uint32_t>(parameters.framerate_fps);
     }
 
     bool NvEncoder::CopyBuffer(void* frame)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -449,13 +449,18 @@ extern "C"
         return transceiver->sender().get();
     }
 
+    struct RTCRtpEncodingParameters
+    {
+        bool active;
+        uint64_t maxBitrate;
+        uint32_t maxFramerate;
+        char* rid;
+    };
 
     struct RTCRtpSendParameters
     {
-        int codecsLength;
-        void* codecs;
-        int encodingsLength;
-        void* encodings;
+        uint32_t encodingsLength;
+        RTCRtpEncodingParameters* encodings;
         char* transactionId;
     };
 
@@ -465,8 +470,16 @@ extern "C"
         *parameters = CoTaskMemAlloc(sizeof(RTCRtpSendParameters));
 
         const auto dst = static_cast<RTCRtpSendParameters*>(*parameters);
-        dst->codecsLength = src.codecs.size();
-        dst->encodingsLength = src.encodings.size();
+        dst->encodingsLength = static_cast<uint32_t>(src.encodings.size());
+        dst->encodings = static_cast<RTCRtpEncodingParameters*>(CoTaskMemAlloc(sizeof(RTCRtpEncodingParameters) * src.encodings.size()));
+
+        for(int i = 0; i < src.encodings.size(); i++)
+        {
+            dst->encodings[i].active = src.encodings[i].active;
+            dst->encodings[i].maxBitrate = src.encodings[i].max_bitrate_bps.value();
+            dst->encodings[i].maxFramerate = src.encodings[i].max_framerate.value();
+            dst->encodings[i].rid = ConvertString(src.encodings[i].rid);
+        }
         dst->transactionId = ConvertString(src.transaction_id);
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -456,6 +456,8 @@ extern "C"
         uint64_t maxBitrate;
         bool hasValueMaxFramerate;
         uint32_t maxFramerate;
+        bool hasValueScaleResolutionDownBy;
+        double scaleResolutionDownBy;
         char* rid;
     };
 
@@ -480,13 +482,15 @@ extern "C"
             dst->encodings[i].maxBitrate = src.encodings[i].max_bitrate_bps.value_or(0);
             dst->encodings[i].hasValueMaxFramerate = src.encodings[i].max_framerate.has_value();
             dst->encodings[i].maxFramerate = src.encodings[i].max_framerate.value_or(0);
+            dst->encodings[i].hasValueScaleResolutionDownBy = src.encodings[i].scale_resolution_down_by.has_value();
+            dst->encodings[i].scaleResolutionDownBy = src.encodings[i].scale_resolution_down_by.value_or(0);
             dst->encodings[i].rid = ConvertString(src.encodings[i].rid);
         }
         dst->transactionId = ConvertString(src.transaction_id);
         *parameters = dst;
     }
 
-    UNITY_INTERFACE_EXPORT void SenderSetParameters(RtpSenderInterface* sender, const RTCRtpSendParameters* src)
+    UNITY_INTERFACE_EXPORT RTCErrorType SenderSetParameters(RtpSenderInterface* sender, const RTCRtpSendParameters* src)
     {
         RtpParameters dst = sender->GetParameters();
 
@@ -497,8 +501,12 @@ extern "C"
                 dst.encodings[i].max_bitrate_bps = static_cast<int>(src->encodings[i].maxBitrate);
             if (src->encodings[i].hasValueMaxFramerate)
                 dst.encodings[i].max_framerate = static_cast<int>(src->encodings[i].maxFramerate);
+            if (src->encodings[i].hasValueScaleResolutionDownBy)
+                dst.encodings[i].scale_resolution_down_by = static_cast<int>(src->encodings[i].scaleResolutionDownBy);
             dst.encodings[i].rid = std::string(src->encodings[i].rid);
         }
+        const ::webrtc::RTCError error = sender->SetParameters(dst);
+        return error.type();
     }
 
     UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* SenderGetTrack(RtpSenderInterface* sender)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -449,6 +449,35 @@ extern "C"
         return transceiver->sender().get();
     }
 
+
+    struct RTCRtpSendParameters
+    {
+        int codecsLength;
+        void* codecs;
+        int encodingsLength;
+        void* encodings;
+        char* transactionId;
+    };
+
+    UNITY_INTERFACE_EXPORT void SenderGetParameters(webrtc::RtpSenderInterface* sender, LPVOID* parameters)
+    {
+        const webrtc::RtpParameters src = sender->GetParameters();
+        *parameters = CoTaskMemAlloc(sizeof(RTCRtpSendParameters));
+
+        const auto dst = static_cast<RTCRtpSendParameters*>(*parameters);
+        dst->codecsLength = src.codecs.size();
+        dst->encodingsLength = src.encodings.size();
+        dst->transactionId = ConvertString(src.transaction_id);
+    }
+
+    UNITY_INTERFACE_EXPORT void SenderSetParameters(webrtc::RtpSenderInterface* sender, const LPVOID* parameters)
+    {
+        auto src = sender->GetParameters();
+        src.encodings[0].max_framerate = 30;
+
+        sender->SetParameters(src);
+    }
+
     UNITY_INTERFACE_EXPORT int DataChannelGetID(DataChannelObject* dataChannelObj)
     {
         return dataChannelObj->GetID();

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -52,7 +52,7 @@ T** ConvertArray(std::vector<rtc::scoped_refptr<T>> vec, int* length)
 
 char* ConvertString(const std::string str)
 {
-    const int size = str.size();
+    const size_t size = str.size();
     char* ret = static_cast<char*>(CoTaskMemAlloc(size + sizeof(char)));
     str.copy(ret, size);
     ret[size] = '\0';
@@ -459,9 +459,9 @@ extern "C"
         char* transactionId;
     };
 
-    UNITY_INTERFACE_EXPORT void SenderGetParameters(webrtc::RtpSenderInterface* sender, LPVOID* parameters)
+    UNITY_INTERFACE_EXPORT void SenderGetParameters(RtpSenderInterface* sender, LPVOID* parameters)
     {
-        const webrtc::RtpParameters src = sender->GetParameters();
+        const RtpParameters src = sender->GetParameters();
         *parameters = CoTaskMemAlloc(sizeof(RTCRtpSendParameters));
 
         const auto dst = static_cast<RTCRtpSendParameters*>(*parameters);
@@ -470,12 +470,26 @@ extern "C"
         dst->transactionId = ConvertString(src.transaction_id);
     }
 
-    UNITY_INTERFACE_EXPORT void SenderSetParameters(webrtc::RtpSenderInterface* sender, const LPVOID* parameters)
+    UNITY_INTERFACE_EXPORT void SenderSetParameters(RtpSenderInterface* sender, const LPVOID* parameters)
     {
-        auto src = sender->GetParameters();
-        src.encodings[0].max_framerate = 30;
+        // not implemented yet
+        throw;
+    }
 
+    UNITY_INTERFACE_EXPORT void SenderSetParameters2(RtpSenderInterface* sender, int framerate, int bitrate_bps)
+    {
+        RtpParameters src = sender->GetParameters();
+        for (int i = 0; i < src.encodings.size(); i++)
+        {
+            src.encodings[i].max_framerate = framerate;
+            src.encodings[i].max_bitrate_bps = bitrate_bps;
+        }
         sender->SetParameters(src);
+    }
+
+    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* SenderGetTrack(RtpSenderInterface* sender)
+    {
+        return sender->track();
     }
 
     UNITY_INTERFACE_EXPORT int DataChannelGetID(DataChannelObject* dataChannelObj)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -466,12 +466,10 @@ extern "C"
         char* transactionId;
     };
 
-    UNITY_INTERFACE_EXPORT void SenderGetParameters(RtpSenderInterface* sender, LPVOID* parameters)
+    UNITY_INTERFACE_EXPORT void SenderGetParameters(RtpSenderInterface* sender, RTCRtpSendParameters** parameters)
     {
         const RtpParameters src = sender->GetParameters();
-        *parameters = CoTaskMemAlloc(sizeof(RTCRtpSendParameters));
-
-        const auto dst = static_cast<RTCRtpSendParameters*>(*parameters);
+        RTCRtpSendParameters* dst = static_cast<RTCRtpSendParameters*>(CoTaskMemAlloc(sizeof(RTCRtpSendParameters)));
         dst->encodingsLength = static_cast<uint32_t>(src.encodings.size());
         dst->encodings = static_cast<RTCRtpEncodingParameters*>(CoTaskMemAlloc(sizeof(RTCRtpEncodingParameters) * src.encodings.size()));
 
@@ -485,6 +483,7 @@ extern "C"
             dst->encodings[i].rid = ConvertString(src.encodings[i].rid);
         }
         dst->transactionId = ConvertString(src.transaction_id);
+        *parameters = dst;
     }
 
     UNITY_INTERFACE_EXPORT void SenderSetParameters(RtpSenderInterface* sender, const RTCRtpSendParameters* src)

--- a/Runtime/Scripts/IntPtrExtension.cs
+++ b/Runtime/Scripts/IntPtrExtension.cs
@@ -24,5 +24,31 @@ namespace Unity.WebRTC
             }
             return Marshal.PtrToStringAnsi(ptr);
         }
+
+        public static void ToArray<T>(this IntPtr ptr, T[] array)
+        {
+            IntPtr iter = ptr;
+            int size = Marshal.SizeOf(typeof(T));
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = (T)Marshal.PtrToStructure(iter, typeof(T));
+                iter = IntPtr.Add(iter, size);
+            }
+        }
+
+        public static IntPtr ToPtr<T>(T[] array)
+        {
+            int size = Marshal.SizeOf(typeof(T));
+            int length = size * array.Length;
+            IntPtr ptr = Marshal.AllocCoTaskMem(length);
+            IntPtr iter = ptr;
+            for (var i = 0; i < array.Length; i++)
+            {
+                Marshal.StructureToPtr(array[i], iter, false);
+                iter = IntPtr.Add(iter, size);
+            }
+            return ptr;
+
+        }
     }
 }

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using UnityEngine;
 
 namespace Unity.WebRTC
@@ -11,7 +10,6 @@ namespace Unity.WebRTC
         protected bool disposed;
         private bool enabled;
         private TrackState readyState;
-        internal Action<MediaStreamTrack> stopTrack;
 
         /// <summary>
         /// 
@@ -76,12 +74,6 @@ namespace Unity.WebRTC
             }
             this.disposed = true;
             GC.SuppressFinalize(this);
-        }
-
-        //Disassociate track from its source(video or audio), not for destroying the track
-        public void Stop()
-        {
-            stopTrack(this);
         }
     }
 

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -23,9 +23,8 @@ namespace Unity.WebRTC
             rid = parameter.rid.AsAnsiStringWithFreeMem();
         }
 
-        internal RTCRtpEncodingParametersInternal Create()
+        internal void CopyInternal(ref RTCRtpEncodingParametersInternal instance)
         {
-            RTCRtpEncodingParametersInternal instance = default;
             instance.active = active;
             instance.hasValueMaxBitrate = maxBitrate.HasValue;
             if(maxBitrate.HasValue)
@@ -37,7 +36,6 @@ namespace Unity.WebRTC
             if (scaleResolutionDownBy.HasValue)
                 instance.scaleResolutionDownBy = scaleResolutionDownBy.Value;
             instance.rid = Marshal.StringToCoTaskMemAnsi(rid);
-            return instance;
         }
     }
 
@@ -59,7 +57,11 @@ namespace Unity.WebRTC
 
         internal IntPtr CreatePtr()
         {
-            RTCRtpEncodingParametersInternal[] encodings = Array.ConvertAll(_encodings, _ => _.Create());
+            RTCRtpEncodingParametersInternal[] encodings = new RTCRtpEncodingParametersInternal[_encodings.Length];
+            for(int i = 0; i < _encodings.Length; i++)
+            {
+                _encodings[i].CopyInternal(ref encodings[i]);
+            }
             RTCRtpSendParametersInternal instance = default;
             instance.encodingsLength = _encodings.Length;
             instance.encodings = IntPtrExtension.ToPtr(encodings);
@@ -69,7 +71,7 @@ namespace Unity.WebRTC
             return ptr;
         }
 
-        static internal void FreePtr(IntPtr ptr)
+        static internal void DeletePtr(IntPtr ptr)
         {
             var instance = Marshal.PtrToStructure<RTCRtpSendParametersInternal>(ptr);
             Marshal.FreeCoTaskMem(instance.encodings);

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -1,49 +1,94 @@
 using System;
 using System.Runtime.InteropServices;
-using UnityEngine;
 
 namespace Unity.WebRTC
 {
+    public class RTCRtpEncodingParameters
+    {
+        public bool active;
+        public ulong? maxBitrate;
+        public uint? maxFramerate;
+        public string rid;
+
+        internal RTCRtpEncodingParameters(RTCRtpEncodingParametersInternal parameter)
+        {
+            active = parameter.active;
+            if (parameter.hasValueMaxBitrate)
+                maxBitrate = parameter.maxBitrate;
+            if (parameter.hasValueMaxFramerate)
+                maxFramerate = parameter.maxFramerate;
+            rid = parameter.rid.AsAnsiStringWithFreeMem();
+        }
+
+        internal RTCRtpEncodingParametersInternal Create()
+        {
+            RTCRtpEncodingParametersInternal instance = default;
+            instance.active = active;
+            instance.hasValueMaxBitrate = maxBitrate.HasValue;
+            if(maxBitrate.HasValue)
+                instance.maxBitrate = maxBitrate.Value;
+            if (maxFramerate.HasValue)
+                instance.hasValueMaxFramerate = maxFramerate.HasValue;
+            instance.rid = Marshal.StringToCoTaskMemAnsi(rid);
+            return instance;
+        }
+    }
+
+    public class RTCRtpSendParameters
+    {
+        readonly RTCRtpEncodingParameters[] _encodings;
+        readonly string _transactionId;
+
+        internal RTCRtpSendParameters(IntPtr ptr)
+        {
+            var parameters = Marshal.PtrToStructure<RTCRtpSendParametersInternal>(ptr);
+            Marshal.FreeHGlobal(ptr);
+
+            RTCRtpEncodingParametersInternal[] encodings = new RTCRtpEncodingParametersInternal[parameters.encodingsLength];
+            parameters.encodings.ToArray(encodings);
+            _encodings = Array.ConvertAll(encodings, _ => new RTCRtpEncodingParameters(_));
+            _transactionId = parameters.transactionId.AsAnsiStringWithFreeMem();
+        }
+
+        internal IntPtr CreatePtr()
+        {
+            RTCRtpEncodingParametersInternal[] encodings = Array.ConvertAll(_encodings, _ => _.Create());
+            RTCRtpSendParametersInternal instance = default;
+            instance.encodingsLength = _encodings.Length;
+            instance.encodings = IntPtrExtension.ToPtr(encodings);
+            instance.transactionId = Marshal.StringToCoTaskMemAnsi(_transactionId);
+            IntPtr ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf(instance));
+            Marshal.StructureToPtr(instance, ptr, false);
+            return ptr;
+        }
+
+        static internal void FreePtr(IntPtr ptr)
+        {
+            var instance = Marshal.PtrToStructure<RTCRtpSendParametersInternal>(ptr);
+            Marshal.FreeCoTaskMem(instance.encodings);
+            Marshal.FreeCoTaskMem(ptr);
+        }
+
+        public string TransactionId => _transactionId;
+
+        public RTCRtpEncodingParameters[] Encodings => _encodings;
+    }
+
     [StructLayout(LayoutKind.Sequential)]
-    public struct RTCRtpSendParameters
+    internal struct RTCRtpSendParametersInternal
     {
         internal int encodingsLength;
         internal IntPtr encodings;
         internal IntPtr transactionId;
-
-        RTCRtpEncodingParameters[] _encodings;
-
-        public RTCRtpEncodingParameters[] Encodings
-        {
-            get
-            {
-                if (_encodings == null)
-                {
-                    Debug.Log(encodingsLength);
-                    //_encodings = Marshal.PtrToStructure<RTCRtpEncodingParameters[]>(encodings);
-                }
-                return _encodings;
-            }
-            set
-            {
-
-            }
-        }
-
-        public string TransactionId
-        {
-            get
-            {
-                return transactionId.AsAnsiStringWithFreeMem();
-            }
-        }
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct RTCRtpEncodingParameters
+    internal struct RTCRtpEncodingParametersInternal
     {
         internal bool active;
+        internal bool hasValueMaxBitrate;
         internal ulong maxBitrate;
+        internal bool hasValueMaxFramerate;
         internal uint maxFramerate;
         internal IntPtr rid;
     }

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -1,22 +1,57 @@
-
+using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
 
 namespace Unity.WebRTC
 {
-    internal struct RTCRtpSendParameters
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RTCRtpSendParameters
     {
-        public RTCRtpCodecParameters[] codecs;
-        public RTCRtpEncodingParameters[] encodings;
-        public string transactionId;
+        internal int codecsLength;
+        internal IntPtr codecs;
+        internal int encodingsLength;
+        internal IntPtr encodings;
+        internal IntPtr transactionId;
+
+        public RTCRtpEncodingParameters[] Codecs
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public RTCRtpCodecParameters[] Encodings
+        {
+            get
+            {
+                return null;
+            }
+            set
+            {
+
+            }
+        }
+
+        public string TransactionId
+        {
+            get
+            {
+                //Debug.Log(transactionId == IntPtr.Zero);
+                //return string.Empty;
+                return Marshal.PtrToStringAnsi(transactionId);
+            }
+        }
     }
 
-    internal struct RTCRtpEncodingParameters
+    public struct RTCRtpEncodingParameters
     {
         public bool active;
         public ulong maxBitrate;
-        public string rid;
+        public IntPtr rid;
     }
 
-    internal struct RTCRtpCodecParameters
+    public struct RTCRtpCodecParameters
     {
     }
 }

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -7,25 +7,22 @@ namespace Unity.WebRTC
     [StructLayout(LayoutKind.Sequential)]
     public struct RTCRtpSendParameters
     {
-        internal int codecsLength;
-        internal IntPtr codecs;
         internal int encodingsLength;
         internal IntPtr encodings;
         internal IntPtr transactionId;
 
-        public RTCRtpEncodingParameters[] Codecs
-        {
-            get
-            {
-                return null;
-            }
-        }
+        RTCRtpEncodingParameters[] _encodings;
 
-        public RTCRtpCodecParameters[] Encodings
+        public RTCRtpEncodingParameters[] Encodings
         {
             get
             {
-                return null;
+                if (_encodings == null)
+                {
+                    Debug.Log(encodingsLength);
+                    //_encodings = Marshal.PtrToStructure<RTCRtpEncodingParameters[]>(encodings);
+                }
+                return _encodings;
             }
             set
             {
@@ -37,21 +34,17 @@ namespace Unity.WebRTC
         {
             get
             {
-                //Debug.Log(transactionId == IntPtr.Zero);
-                //return string.Empty;
-                return Marshal.PtrToStringAnsi(transactionId);
+                return transactionId.AsAnsiStringWithFreeMem();
             }
         }
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     public struct RTCRtpEncodingParameters
     {
-        public bool active;
-        public ulong maxBitrate;
-        public IntPtr rid;
-    }
-
-    public struct RTCRtpCodecParameters
-    {
+        internal bool active;
+        internal ulong maxBitrate;
+        internal uint maxFramerate;
+        internal IntPtr rid;
     }
 }

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -8,6 +8,7 @@ namespace Unity.WebRTC
         public bool active;
         public ulong? maxBitrate;
         public uint? maxFramerate;
+        public double? scaleResolutionDownBy;
         public string rid;
 
         internal RTCRtpEncodingParameters(RTCRtpEncodingParametersInternal parameter)
@@ -17,6 +18,8 @@ namespace Unity.WebRTC
                 maxBitrate = parameter.maxBitrate;
             if (parameter.hasValueMaxFramerate)
                 maxFramerate = parameter.maxFramerate;
+            if (parameter.hasValueScaleResolutionDownBy)
+                scaleResolutionDownBy = parameter.scaleResolutionDownBy;
             rid = parameter.rid.AsAnsiStringWithFreeMem();
         }
 
@@ -27,8 +30,12 @@ namespace Unity.WebRTC
             instance.hasValueMaxBitrate = maxBitrate.HasValue;
             if(maxBitrate.HasValue)
                 instance.maxBitrate = maxBitrate.Value;
+            instance.hasValueMaxFramerate = maxFramerate.HasValue;
             if (maxFramerate.HasValue)
-                instance.hasValueMaxFramerate = maxFramerate.HasValue;
+                instance.maxFramerate = maxFramerate.Value;
+            instance.hasValueScaleResolutionDownBy = scaleResolutionDownBy.HasValue;
+            if (scaleResolutionDownBy.HasValue)
+                instance.scaleResolutionDownBy = scaleResolutionDownBy.Value;
             instance.rid = Marshal.StringToCoTaskMemAnsi(rid);
             return instance;
         }
@@ -85,11 +92,17 @@ namespace Unity.WebRTC
     [StructLayout(LayoutKind.Sequential)]
     internal struct RTCRtpEncodingParametersInternal
     {
+        [MarshalAs(UnmanagedType.U1)]
         internal bool active;
+        [MarshalAs(UnmanagedType.U1)]
         internal bool hasValueMaxBitrate;
         internal ulong maxBitrate;
+        [MarshalAs(UnmanagedType.U1)]
         internal bool hasValueMaxFramerate;
         internal uint maxFramerate;
+        [MarshalAs(UnmanagedType.U1)]
+        internal bool hasValueScaleResolutionDownBy;
+        internal double scaleResolutionDownBy;
         internal IntPtr rid;
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -74,7 +74,7 @@ namespace Unity.WebRTC
         public RTCRtpSendParameters GetParameters()
         {
             NativeMethods.SenderGetParameters(self, out var ptr);
-            var parameters = (RTCRtpSendParameters)Marshal.PtrToStructure(ptr, typeof(RTCRtpSendParameters));
+            var parameters = (RTCRtpSendParameters)Marshal.PtrToStructure<RTCRtpSendParameters>(ptr);
             Marshal.FreeHGlobal(ptr);
             return parameters;
         }
@@ -598,8 +598,6 @@ namespace Unity.WebRTC
         public static extern IntPtr SenderGetTrack(IntPtr sender);
         [DllImport(WebRTC.Lib)]
         public static extern void SenderGetParameters(IntPtr sender, out IntPtr parameters);
-        [DllImport(WebRTC.Lib)]
-        public static extern void SenderSetParameters(IntPtr sender, ref IntPtr parameters);
         /// todo(kazuki): this is a temporary implementation.
         [DllImport(WebRTC.Lib)]
         public static extern void SenderSetParameters2(IntPtr sender, int framerate, int bitrateBPS);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -61,6 +61,16 @@ namespace Unity.WebRTC
         {
             self = ptr;
         }
+
+        public MediaStreamTrack Track
+        {
+            get
+            {
+                IntPtr ptr = NativeMethods.SenderGetTrack(self);
+                return WebRTC.FindOrCreate<MediaStreamTrack>(ptr, _ptr => new MediaStreamTrack(_ptr));
+            }
+        }
+
         public RTCRtpSendParameters GetParameters()
         {
             NativeMethods.SenderGetParameters(self, out var ptr);
@@ -69,12 +79,17 @@ namespace Unity.WebRTC
             return parameters;
         }
 
-        public void SetParameters(RTCRtpSendParameters parameters)
+        //public void SetParameters(RTCRtpSendParameters parameters)
+        //{
+        //    int size = Marshal.SizeOf(parameters);
+        //    IntPtr ptr = Marshal.AllocHGlobal(size);
+        //    Marshal.StructureToPtr(parameters, ptr, false);
+        //    NativeMethods.SenderSetParameters(self, ref ptr);
+        //}
+
+        public void SetParameters(int framerate, int bitrateBPS)
         {
-            int size = Marshal.SizeOf(parameters);
-            IntPtr ptr = Marshal.AllocHGlobal(size);
-            Marshal.StructureToPtr(parameters, ptr, false);
-            NativeMethods.SenderSetParameters(self, ref ptr);
+            NativeMethods.SenderSetParameters2(self, framerate, bitrateBPS);
         }
     }
 
@@ -580,10 +595,14 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr TransceiverGetSender(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
+        public static extern IntPtr SenderGetTrack(IntPtr sender);
+        [DllImport(WebRTC.Lib)]
         public static extern void SenderGetParameters(IntPtr sender, out IntPtr parameters);
         [DllImport(WebRTC.Lib)]
         public static extern void SenderSetParameters(IntPtr sender, ref IntPtr parameters);
-
+        /// todo(kazuki): this is a temporary implementation.
+        [DllImport(WebRTC.Lib)]
+        public static extern void SenderSetParameters2(IntPtr sender, int framerate, int bitrateBPS);
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -61,6 +61,21 @@ namespace Unity.WebRTC
         {
             self = ptr;
         }
+        public RTCRtpSendParameters GetParameters()
+        {
+            NativeMethods.SenderGetParameters(self, out var ptr);
+            var parameters = (RTCRtpSendParameters)Marshal.PtrToStructure(ptr, typeof(RTCRtpSendParameters));
+            Marshal.FreeHGlobal(ptr);
+            return parameters;
+        }
+
+        public void SetParameters(RTCRtpSendParameters parameters)
+        {
+            int size = Marshal.SizeOf(parameters);
+            IntPtr ptr = Marshal.AllocHGlobal(size);
+            Marshal.StructureToPtr(parameters, ptr, false);
+            NativeMethods.SenderSetParameters(self, ref ptr);
+        }
     }
 
     public enum RTCErrorDetailType
@@ -564,6 +579,11 @@ namespace Unity.WebRTC
         public static extern IntPtr TransceiverGetReceiver(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr TransceiverGetSender(IntPtr transceiver);
+        [DllImport(WebRTC.Lib)]
+        public static extern void SenderGetParameters(IntPtr sender, out IntPtr parameters);
+        [DllImport(WebRTC.Lib)]
+        public static extern void SenderSetParameters(IntPtr sender, ref IntPtr parameters);
+
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -74,22 +74,14 @@ namespace Unity.WebRTC
         public RTCRtpSendParameters GetParameters()
         {
             NativeMethods.SenderGetParameters(self, out var ptr);
-            var parameters = (RTCRtpSendParameters)Marshal.PtrToStructure<RTCRtpSendParameters>(ptr);
-            Marshal.FreeHGlobal(ptr);
-            return parameters;
+            return new RTCRtpSendParameters(ptr);
         }
 
-        //public void SetParameters(RTCRtpSendParameters parameters)
-        //{
-        //    int size = Marshal.SizeOf(parameters);
-        //    IntPtr ptr = Marshal.AllocHGlobal(size);
-        //    Marshal.StructureToPtr(parameters, ptr, false);
-        //    NativeMethods.SenderSetParameters(self, ref ptr);
-        //}
-
-        public void SetParameters(int framerate, int bitrateBPS)
+        public void SetParameters(RTCRtpSendParameters parameters)
         {
-            NativeMethods.SenderSetParameters2(self, framerate, bitrateBPS);
+            IntPtr ptr = parameters.CreatePtr();
+            NativeMethods.SenderSetParameters(self, ptr);
+            RTCRtpSendParameters.FreePtr(ptr);
         }
     }
 
@@ -598,9 +590,8 @@ namespace Unity.WebRTC
         public static extern IntPtr SenderGetTrack(IntPtr sender);
         [DllImport(WebRTC.Lib)]
         public static extern void SenderGetParameters(IntPtr sender, out IntPtr parameters);
-        /// todo(kazuki): this is a temporary implementation.
         [DllImport(WebRTC.Lib)]
-        public static extern void SenderSetParameters2(IntPtr sender, int framerate, int bitrateBPS);
+        public static extern void SenderSetParameters(IntPtr sender, IntPtr parameters);
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -25,12 +25,15 @@ namespace Unity.WebRTC
 
     public struct RTCDataChannelInit
     {
+        [MarshalAs(UnmanagedType.U1)]
         public bool reliable;
+        [MarshalAs(UnmanagedType.U1)]
         public bool ordered;
         public int maxRetransmitTime;
         public int maxRetransmits;
         [MarshalAs(UnmanagedType.LPStr)]
         public string protocol;
+        [MarshalAs(UnmanagedType.U1)]
         public bool negotiated;
         public int id;
 
@@ -77,11 +80,13 @@ namespace Unity.WebRTC
             return new RTCRtpSendParameters(ptr);
         }
 
-        public void SetParameters(RTCRtpSendParameters parameters)
+        public RTCErrorType SetParameters(RTCRtpSendParameters parameters)
         {
             IntPtr ptr = parameters.CreatePtr();
-            NativeMethods.SenderSetParameters(self, ptr);
+            RTCErrorType error = NativeMethods.SenderSetParameters(self, ptr);
             RTCRtpSendParameters.FreePtr(ptr);
+
+            return error;
         }
     }
 
@@ -183,13 +188,17 @@ namespace Unity.WebRTC
 
     public struct RTCOfferOptions
     {
+        [MarshalAs(UnmanagedType.U1)]
         public bool iceRestart;
+        [MarshalAs(UnmanagedType.U1)]
         public bool offerToReceiveAudio;
+        [MarshalAs(UnmanagedType.U1)]
         public bool offerToReceiveVideo;
     }
 
     public struct RTCAnswerOptions
     {
+        [MarshalAs(UnmanagedType.U1)]
         public bool iceRestart;
     }
 
@@ -591,7 +600,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void SenderGetParameters(IntPtr sender, out IntPtr parameters);
         [DllImport(WebRTC.Lib)]
-        public static extern void SenderSetParameters(IntPtr sender, IntPtr parameters);
+        public static extern RTCErrorType SenderSetParameters(IntPtr sender, IntPtr parameters);
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
@@ -640,7 +649,7 @@ namespace Unity.WebRTC
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool MediaStreamTrackGetEnabled(IntPtr track);
         [DllImport(WebRTC.Lib)]
-        public static extern void MediaStreamTrackSetEnabled(IntPtr track, bool enabled);
+        public static extern void MediaStreamTrackSetEnabled(IntPtr track, [MarshalAs(UnmanagedType.U1)] bool enabled);
         [DllImport(WebRTC.Lib)]
         public static extern void SetCurrentContext(IntPtr context);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -223,10 +223,17 @@ namespace Unity.WebRTC.RuntimeTest
                 var parameters = sender.GetParameters();
                 Assert.IsNotEmpty(parameters.Encodings);
                 const uint framerate = 30;
+                const uint bitrate = 2000000;
+                const double scaleResolutionDownBy = 2.0;
                 parameters.Encodings[0].maxFramerate = framerate;
-                sender.SetParameters(parameters);
+                parameters.Encodings[0].maxBitrate = bitrate;
+                parameters.Encodings[0].scaleResolutionDownBy = scaleResolutionDownBy;
+                RTCErrorType error = sender.SetParameters(parameters);
+                Assert.AreEqual(RTCErrorType.None, error);
                 var parameters2 = sender.GetParameters();
-                Assert.AreEqual(framerate, parameters.Encodings[0].maxFramerate);
+                Assert.AreEqual(framerate, parameters2.Encodings[0].maxFramerate);
+                Assert.AreEqual(bitrate, parameters2.Encodings[0].maxBitrate);
+                Assert.AreEqual(scaleResolutionDownBy, parameters2.Encodings[0].scaleResolutionDownBy);
             }
 
             test.component.Dispose();

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -216,11 +216,13 @@ namespace Unity.WebRTC.RuntimeTest
             yield return 0;
 
             var senders = test.component.GetPeer1Senders();
-            uint framerate = 30;
+            Assert.IsNotEmpty(senders);
+
             foreach(var sender in senders)
             {
                 var parameters = sender.GetParameters();
                 Assert.IsNotEmpty(parameters.Encodings);
+                const uint framerate = 30;
                 parameters.Encodings[0].maxFramerate = framerate;
                 sender.SetParameters(parameters);
                 var parameters2 = sender.GetParameters();

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -196,6 +196,42 @@ namespace Unity.WebRTC.RuntimeTest
             Object.DestroyImmediate(camObj);
         }
 
+        /// <todo>
+        /// This unittest failed standalone mono 2019.3 on linux
+        /// </todo>
+        [UnityTest]
+        [Timeout(5000)]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
+        public IEnumerator SenderParameters()
+        {
+            var camObj = new GameObject("Camera");
+            var cam = camObj.AddComponent<Camera>();
+            var videoStream = cam.CaptureStream(1280, 720, 1000000);
+            yield return new WaitForSeconds(0.1f);
+
+            var test = new MonoBehaviourTest<SignalingPeersTest>();
+            test.component.SetStream(videoStream);
+            yield return test;
+            test.component.CoroutineWebRTCUpdate();
+            yield return 0;
+
+            var senders = test.component.GetPeer1Senders();
+            uint framerate = 30;
+            foreach(var sender in senders)
+            {
+                var parameters = sender.GetParameters();
+                Assert.IsNotEmpty(parameters.Encodings);
+                parameters.Encodings[0].maxFramerate = framerate;
+                sender.SetParameters(parameters);
+                var parameters2 = sender.GetParameters();
+                Assert.AreEqual(framerate, parameters.Encodings[0].maxFramerate);
+            }
+
+            test.component.Dispose();
+            videoStream.Dispose();
+            Object.DestroyImmediate(camObj);
+        }
+
         public class SignalingPeersTest : MonoBehaviour, IMonoBehaviourTest
         {
             private bool m_isFinished;
@@ -292,6 +328,11 @@ namespace Unity.WebRTC.RuntimeTest
             public Coroutine CoroutineWebRTCUpdate()
             {
                 return StartCoroutine(WebRTC.Update());
+            }
+
+            public IEnumerable<RTCRtpSender> GetPeer1Senders()
+            {
+                return pc1Senders;
             }
 
             public void Dispose()

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -177,6 +177,14 @@ namespace Unity.WebRTC.RuntimeTest
             var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
+            NativeMethods.SenderGetParameters(sender, out var ptr);
+            var parameters = Marshal.PtrToStructure<RTCRtpSendParameters>(ptr);
+            Marshal.FreeHGlobal(ptr);
+
+            var encoders = parameters.Encodings;
+            Debug.Log(encoders.Length);
+            Assert.NotNull(parameters.TransactionId);
+
             NativeMethods.SenderSetParameters2(sender, 30, 100);
 
             NativeMethods.PeerConnectionRemoveTrack(peer, sender);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -153,12 +153,37 @@ namespace Unity.WebRTC.RuntimeTest
             var renderTexture = CreateRenderTexture(width, height);
             var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
+            var track2 = NativeMethods.SenderGetTrack(sender);
+            Assert.AreEqual(track, track2);
             NativeMethods.PeerConnectionRemoveTrack(peer, sender);
             NativeMethods.ContextDeleteMediaStreamTrack(context, track);
             NativeMethods.ContextDeleteMediaStream(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
+        }
+
+        [Test]
+        public void SenderSetParameter()
+        {
+            var context = NativeMethods.ContextCreate(0, encoderType);
+            var peer = NativeMethods.ContextCreatePeerConnection(context);
+            var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
+            string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
+            Assert.IsNotEmpty(streamId);
+            const int width = 1280;
+            const int height = 720;
+            var renderTexture = CreateRenderTexture(width, height);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
+
+            NativeMethods.SenderSetParameters2(sender, 30, 100);
+
+            NativeMethods.PeerConnectionRemoveTrack(peer, sender);
+            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
+            NativeMethods.ContextDeleteMediaStream(context, stream);
+            NativeMethods.ContextDeletePeerConnection(context, peer);
+            NativeMethods.ContextDestroy(0);
         }
 
         [Test]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -164,7 +164,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void SenderSetParameter()
+        public void SenderGetParameter()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
@@ -178,14 +178,11 @@ namespace Unity.WebRTC.RuntimeTest
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             NativeMethods.SenderGetParameters(sender, out var ptr);
-            var parameters = Marshal.PtrToStructure<RTCRtpSendParameters>(ptr);
+            var parameters = Marshal.PtrToStructure<RTCRtpSendParametersInternal>(ptr);
             Marshal.FreeHGlobal(ptr);
 
-            var encoders = parameters.Encodings;
-            Debug.Log(encoders.Length);
-            Assert.NotNull(parameters.TransactionId);
-
-            NativeMethods.SenderSetParameters2(sender, 30, 100);
+            Assert.AreNotEqual(IntPtr.Zero, parameters.encodings);
+            Assert.AreNotEqual(IntPtr.Zero, parameters.transactionId);
 
             NativeMethods.PeerConnectionRemoveTrack(peer, sender);
             NativeMethods.ContextDeleteMediaStreamTrack(context, track);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -97,7 +97,13 @@ namespace Unity.WebRTC.RuntimeTest
             var transceiver = peer.AddTransceiver(track);
             Assert.NotNull(transceiver);
             Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
-            Assert.NotNull(transceiver.Sender);
+            RTCRtpSender sender = transceiver.Sender;
+            Assert.NotNull(sender);
+            RTCRtpSendParameters parameters = sender.GetParameters();
+            Assert.NotNull(parameters);
+            Assert.IsNotEmpty(parameters.TransactionId);
+            Assert.IsNotEmpty(parameters.Codecs);
+            Assert.IsNotEmpty(parameters.Encodings);
             Assert.AreEqual(1, peer.GetTransceivers().Count());
             Assert.NotNull(peer.GetTransceivers().First());
         }

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -101,11 +101,9 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.NotNull(sender);
             Assert.AreEqual(track, sender.Track);
 
-//            RTCRtpSendParameters parameters = sender.GetParameters();
-//            Assert.NotNull(parameters);
-//            Assert.IsNotEmpty(parameters.TransactionId);
-//            Assert.IsNotEmpty(parameters.Codecs);
-//            Assert.IsNotEmpty(parameters.Encodings);
+            RTCRtpSendParameters parameters = sender.GetParameters();
+            Assert.NotNull(parameters);
+            Assert.IsNotEmpty(parameters.TransactionId);
             Assert.AreEqual(1, peer.GetTransceivers().Count());
             Assert.NotNull(peer.GetTransceivers().First());
         }

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -99,11 +99,13 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
             RTCRtpSender sender = transceiver.Sender;
             Assert.NotNull(sender);
-            RTCRtpSendParameters parameters = sender.GetParameters();
-            Assert.NotNull(parameters);
-            Assert.IsNotEmpty(parameters.TransactionId);
-            Assert.IsNotEmpty(parameters.Codecs);
-            Assert.IsNotEmpty(parameters.Encodings);
+            Assert.AreEqual(track, sender.Track);
+
+//            RTCRtpSendParameters parameters = sender.GetParameters();
+//            Assert.NotNull(parameters);
+//            Assert.IsNotEmpty(parameters.TransactionId);
+//            Assert.IsNotEmpty(parameters.Codecs);
+//            Assert.IsNotEmpty(parameters.Encodings);
             Assert.AreEqual(1, peer.GetTransceivers().Count());
             Assert.NotNull(peer.GetTransceivers().First());
         }


### PR DESCRIPTION
This API provides a way to control the streaming quality.

```csharp
RTCRtpSendParametersRTCRtpSender.GetParameters()
RTCErrorType RTCRtpSender.SetParameters(RTCRtpSendParameters parameter)
```

`RTCRtpSendParameters` contains an array of `RTCRtpEncodingParameters`.
`RTCRtpEncodingParameters` contains parameters to control video quality below.

- `active`
- `maxBitrate`
- `scaleResolutionDownBy`
- `maxFramerate` (This parameter is not implemented)