### PR TITLE
Fix: Fixed a crash bug caused by disposing a video track

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -106,7 +106,10 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         {
             s_context->FinalizeEncoder(s_mapEncoder[track].get());
             s_mapEncoder.erase(track);
-            GraphicsDevice::GetInstance().Shutdown();
+            if(s_mapEncoder.empty())
+            {
+                GraphicsDevice::GetInstance().Shutdown();
+            }
             return;
         }
         default: {

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -11,7 +11,6 @@ namespace Unity.WebRTC
         protected bool disposed;
         private bool enabled;
         private TrackState readyState;
-        internal Action<MediaStreamTrack> stopTrack;
 
         /// <summary>
         ///
@@ -81,7 +80,7 @@ namespace Unity.WebRTC
         //Disassociate track from its source(video or audio), not for destroying the track
         public void Stop()
         {
-            stopTrack(this);
+            WebRTC.Context.StopMediaStreamTrack(self);
         }
     }
 


### PR DESCRIPTION
## Issue
Occurring a crash when disposing a video track.

## Cause
The `GraphicsDevice` instance must be single one in a runtime. The instance is shared by video tracks, but it was
removed with removing the video track.