### PR TITLE
feat: Show the item of encoding process into timeline in profiler window

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -1,8 +1,10 @@
 #include "pch.h"
 
+#include <IUnityGraphics.h>
+#include <IUnityProfiler.h>
+
 #include "Codec/EncoderFactory.h"
 #include "Context.h"
-#include "IUnityGraphics.h"
 #include "GraphicsDevice/GraphicsDevice.h"
 
 enum class VideoStreamRenderEventID
@@ -16,13 +18,15 @@ namespace unity
 {
 namespace webrtc
 {
-
     IUnityInterfaces* s_UnityInterfaces = nullptr;
     IUnityGraphics* s_Graphics = nullptr;
+    IUnityProfiler* s_UnityProfiler = nullptr;
     Context* s_context = nullptr;
     IGraphicsDevice* s_device;
     std::map<const ::webrtc::MediaStreamTrackInterface*, std::unique_ptr<IEncoder>> s_mapEncoder;
 
+    const UnityProfilerMarkerDesc* s_MarkerEncode = nullptr;
+    bool s_IsDevelopmentBuild = false;
 } // end namespace webrtc
 } // end namespace unity
 
@@ -60,6 +64,14 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnit
     s_UnityInterfaces = unityInterfaces;
     s_Graphics = unityInterfaces->Get<IUnityGraphics>();
     s_Graphics->RegisterDeviceEventCallback(OnGraphicsDeviceEvent);
+
+    s_UnityProfiler = unityInterfaces->Get<IUnityProfiler>();
+    if (s_UnityProfiler != nullptr)
+    {
+        s_IsDevelopmentBuild = s_UnityProfiler->IsAvailable() != 0;
+        s_UnityProfiler->CreateMarker(&s_MarkerEncode, "Encode", kUnityProfilerCategoryRender, kUnityProfilerMarkerFlagDefault, 0);
+    }
+
     OnGraphicsDeviceEvent(kUnityGfxDeviceEventInitialize);
 }
 extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
@@ -96,10 +108,15 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         }
         case VideoStreamRenderEventID::Encode:
         {
+            if (s_IsDevelopmentBuild)
+                s_UnityProfiler->BeginSample(s_MarkerEncode);
             if(!s_context->EncodeFrame(track))
             {
                 LogPrint("Encode frame failed");
             }
+            if (s_IsDevelopmentBuild)
+                s_UnityProfiler->EndSample(s_MarkerEncode);
+
             return;
         }
         case VideoStreamRenderEventID::Finalize:

--- a/Plugin~/unity/include/IUnityEventQueue.h
+++ b/Plugin~/unity/include/IUnityEventQueue.h
@@ -1,0 +1,438 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+
+#include "IUnityInterface.h"
+
+//  5.2 patch 1 + of Unity will support this.
+//  The lack or presence of this feature can cause the EventQueue
+//  to crash if used against the wrong version of Unity.
+//
+//  Before we had the IUnityInterfaces system this interface changed
+//  to support a cleanup handler on events. This broke our plugins
+//  in older versions of Unity. The registry should help us with
+//  this sort of thing in the future.
+#ifndef EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+    #define EVENTQUEUE_SUPPORTS_EVENT_CLEANUP 1
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// NOTE: Do not include any additional headers here. This is an external facing header
+//       so avoid any internal dependencies.
+////////////////////////////////////////////////////////////////////////////////////////
+// The Unity EventQueue is a standard way of passing information between plugins or parts
+// of the engine without any reliance on managed systems, game objects or
+// other pieces of Unity.
+//
+// Events are simply a structure and GUID pair. GUIDs were chosen rather
+// than hashes as it allows plugins to define their own event
+// payloads and use the EventQueue.
+//
+// While the EventQueue itself is self contained and can be used for
+// many different applications within Unity the global event
+// queue that is passed to plugins is always serviced on the main
+// simulation thread and thus serves as a convenient means of
+// pushing asynchronous operations back to the main game thread
+//
+// Payloads should strive to be small. The EventQueue is a 0 allocation
+// system which ensures that the use of events does not fragment
+// or add undue pressure on resource limited systems.
+//
+// This header defines ALL that is required to listen, define
+// and send events from both within Unity and from plugins.
+////////////////////////////////////////////////////////////////////////////////////////
+// USAGE:
+//
+// SENDING
+// ========
+//
+// To Define new Event:
+// --------------------
+// // Structure and GUID
+// struct MyEvent {};
+// REGISTER_EVENT_ID(0x19D736400584B24BULL,0x98B9EFBE26D3F3C9ULL,MyEvent)
+// // hash above is a GUID split into 2 64 bit integers for convenience.
+// // DO NOT DUPLICATE GUIDS!
+//
+// To Send an Event:
+// -----------------
+// // Create Payload and send
+// MyEvent evt;
+// GlobalEventQueue::GetInstance ().SendEvent (evt);
+//
+// LISTENING
+// ==========
+//
+// STATIC FUNCTION: To Listen For An Event:
+// ----------------------------------------
+//
+// void MyListenFunction (const MyEvent & payload)
+// { /* do something useful */ }
+//
+// // No register that function, create delegate, register delegate with EventQueue
+// // Lifetime of delegate is important.
+// StaticFunctionEventHandler<MyEvent> myEventDelegate (&MyListenFunction);
+// GlobalEventQueue::GetInstance ()->AddHandler (&myEventDelegate);
+//
+//
+// CLASS LISTENER: To Listen on an instance of a class:
+// ----------------------------------------------------
+// class MyClass
+// {
+//      // This method will get called, always called HandleEvent
+//      void HandleEvent(const MyEvent & payload);
+//
+//      MyClass()
+//      {
+//          // Hookup to listen can be anywhere but here it's in the ctor.
+//          GlobalEventQueue::GetInstance ()->AddHandler (m_myDelegate.SetObject (this));
+//      }
+//
+//      ~MyClass()
+//      {
+//          // Stop listening.
+//          GlobalEventQueue::GetInstance ()->RemoveHandler (m_myDelegate);
+//      }
+//
+//      // Delegate is a member of the class.
+//      ClassBasedEventHandler<MyEvent,MyClass> m_myDelegate;
+// };
+
+// GUID definition for a new event.
+//
+// There is a tool to compute these, run the tool on the name of your
+// message and insert the hash/type combination in your header file.
+// This defines the EventId for your event payload (struct)
+// Use this for events that do not require a destructor.
+#define REGISTER_EVENT_ID(HASHH, HASHL , TYPE)                  \
+namespace UnityEventQueue                                      \
+{                                                              \
+    template<>                                                 \
+    inline const EventId GetEventId< TYPE > ()                 \
+    {                                                          \
+        return EventId(HASHH,HASHL) ;                          \
+    }                                                          \
+}
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+// GUID definition for a new event with a destructor.
+//
+// If your event payload requires a destructor. Define:
+//
+// void Destroy()
+//
+// Which should be a method on your payload and then use this macro.
+// If your event
+// can guarantee that someone is listening before you fire
+// your first event this is all you have to do.
+//
+// However if you do not know if someone is listening when you
+// fire your first event you will need to call RegisterCleanup
+// somewhere to ensure your events get cleaned up properly.
+//
+// There is a tool to compute these, run the tool on the name of your
+// payload and insert the hash/type combination in your header file.
+#define REGISTER_EVENT_ID_WITH_CLEANUP(HASHH, HASHL, TYPE)                             \
+namespace UnityEventQueue                                                            \
+{                                                                                    \
+    typedef StaticFunctionEventHandler< TYPE > DestructorMethod_##HASHH##HASHL;      \
+                                                                                     \
+    template<>                                                                       \
+    inline void GenericDestructorMethodForType< TYPE > ( const TYPE & eventPayload ) \
+    { const_cast<TYPE&>(eventPayload).Destroy(); }                                   \
+                                                                                     \
+    template<>                                                                       \
+    inline EventHandler * GetEventDestructor< TYPE >()                               \
+    {                                                                                \
+        static DestructorMethod_##HASHH##HASHL g_Destructor(&GenericDestructorMethodForType< TYPE >); \
+        return &g_Destructor;                                                        \
+    }                                                                                \
+}                                                                                    \
+REGISTER_EVENT_ID(HASHH,HASHL,TYPE)
+
+#endif
+
+namespace UnityEventQueue
+{
+    // EventId - GUID
+    //
+    // To facilitate custom events the EventId object must be a full fledged GUID
+    // to ensure cross plugin uniqueness constraints.
+    //
+    // Template specialization is used to produce a means of looking up an
+    // EventId from it's payload type at compile time. The net result should compile
+    // down to passing around the GUID.
+    //
+    // REGISTER_EVENT_ID should be placed in
+    // the header file of any payload definition OUTSIDE of all namespaces (all EventIds live
+    // in the UnityEventQueue namespace by default) The payload structure and the registration ID are all that
+    // is required to expose the event to other systems.
+    //
+    // There is a tool to generate registration macros for EventIds.
+    struct EventId
+    {
+    public:
+        EventId(unsigned long long high, unsigned long long low)
+            : mGUIDHigh(high)
+            , mGUIDLow(low)
+        {}
+
+        EventId(const EventId & other)
+        {
+            mGUIDHigh = other.mGUIDHigh;
+            mGUIDLow  = other.mGUIDLow;
+        }
+
+        EventId & operator=(const EventId & other)
+        {
+            mGUIDHigh = other.mGUIDHigh;
+            mGUIDLow  = other.mGUIDLow;
+            return *this;
+        }
+
+        bool Equals(const EventId & other)   const      {   return mGUIDHigh == other.mGUIDHigh && mGUIDLow == other.mGUIDLow;  }
+        bool LessThan(const EventId & other) const      {   return mGUIDHigh < other.mGUIDHigh || (mGUIDHigh == other.mGUIDHigh && mGUIDLow < other.mGUIDLow);  }
+
+        unsigned long long mGUIDHigh;
+        unsigned long long mGUIDLow;
+    };
+    inline bool operator==(const EventId & left, const EventId & right) {  return left.Equals(right);      }
+    inline bool operator!=(const EventId & left, const EventId & right) {  return !left.Equals(right);     }
+    inline bool operator<(const EventId & left, const EventId & right) {  return left.LessThan(right);    }
+    inline bool operator>(const EventId & left, const EventId & right) {  return right.LessThan(left);    }
+    inline bool operator>=(const EventId & left, const EventId & right) {  return !operator<(left, right); }
+    inline bool operator<=(const EventId & left, const EventId & right) {  return !operator>(left, right); }
+    // Generic Version of GetEventId to allow for specialization
+    //
+    // If you get errors about return values related to this method
+    // then you have forgotten to include REGISTER_EVENT_ID() for your
+    // payload / event. This method should never be compiled, ever.
+    template<typename T> const EventId GetEventId();
+    class EventQueue;
+    class EventHandler;
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+    // Generic version retrieving a classes destructor.
+    // Any class that does not specialize this will not define a destructor.
+    template<typename T> EventHandler * GetEventDestructor() { return (EventHandler*)NULL; }
+
+    // This is a static method that helps us call a meaningful method on the event
+    // itself improving the cleanliness of the EQ design.
+    template<typename T> void GenericDestructorMethodForType(const T & /*eventPayload*/) {}
+#endif
+
+    // ====================================================================
+    // ADAPTER / DELEGATE - This is the base interface that the EventQueue
+    // uses to know about listeners for events.
+    //
+    // DO NOT USE DIRECTLY!
+    //
+    // Use the StaticFunction of ClassBased EventHandlers to build
+    // adapters to your systems and empower them to receive events.
+    class EventHandler
+    {
+    public:
+        EventHandler()  : m_Next(0) {}
+        virtual ~EventHandler()     {}
+        // This actually kicks the event to the handler function or object.
+        virtual void HandleEvent(EventId & id, void * data) = 0;
+        // This is required when registering this handler
+        virtual EventId HandlerEventId()                       = 0;
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+        // This is required when registering this handler
+        virtual EventHandler * GetMyEventDestructor()          = 0;
+#endif
+        // Internal, do not use, required for walking and calling handlers
+        EventHandler * GetNext()                 { return m_Next; }
+    private:
+        // Intrusive list holding a linked list of handlers for this EventId
+        // Exists to avoid allocations - Do Not Touch.
+        friend class EventHandlerList;
+        EventHandler * m_Next;
+    };
+
+    // ====================================================================
+    // CLASS DELEGATE - Classes can be the target of events.
+    //
+    // Event handlers are the endpoints of the system. To Unity all
+    // event endpoints look like a single virtual function call.
+    //
+    // This adapter will call the HandleEvent( EVENTTYPE & ) method
+    // on the object specified when an event is triggered.
+    template<typename EVENTTYPE, typename OBJECTTYPE>
+    class ClassBasedEventHandler : public EventHandler
+    {
+    public:
+        ClassBasedEventHandler(OBJECTTYPE * handler = NULL) : m_Handler(handler) {}
+
+        // The actual adapter method, calls into the registered object.
+        virtual void HandleEvent(EventId & id, void * data)
+        { (void)id; m_Handler->HandleEvent(*static_cast<EVENTTYPE*>(data));   }
+
+        // Boilerplate required when registering this handler.
+        virtual EventId HandlerEventId()
+        { return GetEventId<EVENTTYPE>(); }
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+        // Required boilerplate. Used during registration of this object.
+        virtual EventHandler * GetMyEventDestructor()
+        { return GetEventDestructor<EVENTTYPE>(); }
+#endif
+
+        ClassBasedEventHandler<EVENTTYPE, OBJECTTYPE> *
+        SetObject(OBJECTTYPE * handler)
+        { m_Handler = handler; return this; }
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+        OBJECTTYPE * GetHandler()
+        { return m_Handler; }
+#endif
+    protected:
+        OBJECTTYPE * m_Handler;
+    };
+
+    // ====================================================================
+    // FUNCTION DELEGATE - Static functions can be event handlers.
+    //
+    // Event handlers are the endpoints of the system. To Unity all
+    // event endpoints look like a single virtual function call.
+    //
+    // This object wraps a static function turning it into an event endpoint
+    // much like a C# delegate does.
+    // The wrapped function will be called when the event is triggered
+    template<typename EVENTTYPE>
+    class StaticFunctionEventHandler : public EventHandler
+    {
+    public:
+        typedef void (*HandlerFunction)(const EVENTTYPE & payload);
+
+        StaticFunctionEventHandler(HandlerFunction handlerCallback) : m_Handler(handlerCallback)  {}
+
+        virtual void HandleEvent(EventId & id, void * data)
+        { (void)id; m_Handler(*static_cast<EVENTTYPE*>(data)); }
+
+        // Required boilerplate. Used during registration of this object.
+        virtual EventId HandlerEventId()
+        { return GetEventId<EVENTTYPE>(); }
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+        // Required boilerplate. Used during registration of this object.
+        virtual EventHandler * GetMyEventDestructor()
+        { return GetEventDestructor<EVENTTYPE>(); }
+#endif
+
+    protected:
+        HandlerFunction m_Handler;
+    };
+
+    // ============================================================
+    // Some built in event types for adding removing event handlers
+    // from secondary threads. Use these instead of calling AddHandler
+    // from a secondary thread.
+    struct AddEventHandler
+    {
+        AddEventHandler(EventHandler * handler) : m_Handler(handler) {}
+        EventHandler * m_Handler;
+    };
+
+    struct RemoveEventHandler
+    {
+        RemoveEventHandler(EventHandler * handler) : m_Handler(handler) {}
+        EventHandler * m_Handler;
+    };
+
+    // ============================================================
+    // The Event Queue is a lock free multiple write single read
+    // deferred event system. It uses GUIDs to map payloads to
+    // event handler delegates. The system has some
+    // templates to make registering for events fairly painless
+    // but takes care to try to keep template cost very low.
+    //
+    // NOTE: payloads should be very very small and never allocate
+    //       or free memory since they can and will be passed across
+    //       dll boundaries.
+    //
+    // There is a hard limit of kMaxEventQueueEventSize bytes for any
+    // payload being passed through this system but payloads that are
+    // this big are probably being handled improperly.
+    UNITY_DECLARE_INTERFACE(IUnityEventQueue)
+    {
+    public:
+        // size of 8196 required for PS4 system events
+        #define kMaxEventQueueEventSize 8196+sizeof(EventId)
+
+        virtual ~IUnityEventQueue() {
+        }
+
+        // The primary entry point for firing any
+        // event through the system. The templated
+        // version is simply syntatic sugar for extracting
+        // the EventId from the event object.
+        //
+        // This can be called from any thread.
+        template<typename T>
+        void SendEvent(T & payload)
+        {
+            // Ensure we never fire an event that we can't handle size wise.
+            Assert(sizeof(T) <= (kMaxEventQueueEventSize - sizeof(EventId)));
+
+            // NOTE: Keep this small to avoid code bloat.
+            //       every line of code in here should be scrutinized
+            //       as this and GetEventId could easily be sources
+            //       of bloat if allowed to grow.
+            SendEventImpl(UnityEventQueue::GetEventId<T>(), (unsigned char*)(&payload), sizeof(T));
+        }
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+        // Some events want to have a destructor.
+        //
+        // You do this by creating a public Destroy()
+        // method on your Event payload. You then
+        // register the event with REGISTER_EVENT_ID_WITH_CLEANUP
+        //
+        // If your event will have someone listening to it right away
+        // then you do not need to do anything else.
+        //
+        // However, if there is a danger that your event will be fired
+        // before someone starts listening for it then you must
+        // call this method somewhere. This will manually register your
+        // class for cleanup. There is no harm in calling this even
+        // if it is not required. If in doubt and your event payload
+        // requires some form of destruction, call this method!
+        template<typename T>
+        void RegisterCleanup(T & payload)
+        {
+            EventHandler * eh = UnityEventQueue::GetEventDestructor<T>();
+            if (eh != NULL)
+                SetCleanupImpl(eh);
+        }
+
+#endif
+
+        // These are not thread safe and must be done on the same thread
+        // as the dispatch thread. Doing otherwise risks race conditions.
+        // Fire the add handler / remove handler event if you need to
+        // schedule this from a different thread.
+        virtual void AddHandler(EventHandler * handler)    = 0;
+        virtual void RemoveHandler(EventHandler * handler) = 0;
+    protected:
+        virtual void SendEventImpl(EventId id, unsigned char * data, int size) = 0;
+
+#if EVENTQUEUE_SUPPORTS_EVENT_CLEANUP
+        // This is an event destructor. You can register one of these
+        // per event type. This allows events to manage resource if
+        // they absolutely must. In general you should avoid handling
+        // resources in events as events usually imply cross thread activity.
+        virtual void SetCleanupImpl(EventHandler * handler) = 0;
+#endif
+    };
+}
+
+REGISTER_EVENT_ID(0x19D736400584B24BULL, 0x98B9EFBE26D3F3C9ULL, AddEventHandler)
+REGISTER_EVENT_ID(0x8D4A317C4F577F4AULL, 0x851D6E457566A905ULL, RemoveEventHandler)
+
+UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(0x9959C347F5AE374DULL, 0x9BADE6FC8EF49E7FULL, IUnityEventQueue, UnityEventQueue)

--- a/Plugin~/unity/include/IUnityGraphicsMetal.h
+++ b/Plugin~/unity/include/IUnityGraphicsMetal.h
@@ -1,11 +1,17 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
 #pragma once
 #include "IUnityInterface.h"
 
 #ifndef __OBJC__
-#error metal plugin is objc code.
+    #error metal plugin is objc code.
 #endif
 #ifndef __clang__
-#error only clang compiler is supported.
+    #error only clang compiler is supported.
 #endif
 
 @class NSBundle;
@@ -15,10 +21,10 @@
 @protocol MTLTexture;
 @class MTLRenderPassDescriptor;
 
-// Should only be used on the rendering thread unless noted otherwise.
-UNITY_DECLARE_INTERFACE(IUnityGraphicsMetal)
+
+UNITY_DECLARE_INTERFACE(IUnityGraphicsMetalV1)
 {
-    NSBundle*               (UNITY_INTERFACE_API * MetalBundle)();
+    NSBundle* (UNITY_INTERFACE_API * MetalBundle)();
     id<MTLDevice>(UNITY_INTERFACE_API * MetalDevice)();
 
     id<MTLCommandBuffer>(UNITY_INTERFACE_API * CurrentCommandBuffer)();
@@ -40,6 +46,27 @@ UNITY_DECLARE_INTERFACE(IUnityGraphicsMetal)
     // NB: you pass here *native* RenderBuffer, acquired by calling (C#) RenderBuffer.GetNativeRenderBufferPtr
     // AAResolvedTextureFromRenderBuffer will return nil in case of non-AA RenderBuffer or if called for depth RenderBuffer
     // StencilTextureFromRenderBuffer will return nil in case of no-stencil RenderBuffer or if called for color RenderBuffer
+    id<MTLTexture>(UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer buffer);
+    id<MTLTexture>(UNITY_INTERFACE_API * AAResolvedTextureFromRenderBuffer)(UnityRenderBuffer buffer);
+    id<MTLTexture>(UNITY_INTERFACE_API * StencilTextureFromRenderBuffer)(UnityRenderBuffer buffer);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x29F8F3D03833465EULL, 0x92138551C15D823DULL, IUnityGraphicsMetalV1)
+
+
+// deprecated: please use versioned interface above
+
+UNITY_DECLARE_INTERFACE(IUnityGraphicsMetal)
+{
+    NSBundle* (UNITY_INTERFACE_API * MetalBundle)();
+    id<MTLDevice>(UNITY_INTERFACE_API * MetalDevice)();
+
+    id<MTLCommandBuffer>(UNITY_INTERFACE_API * CurrentCommandBuffer)();
+    id<MTLCommandEncoder>(UNITY_INTERFACE_API * CurrentCommandEncoder)();
+    void(UNITY_INTERFACE_API * EndCurrentCommandEncoder)();
+    MTLRenderPassDescriptor* (UNITY_INTERFACE_API * CurrentRenderPassDescriptor)();
+
+    UnityRenderBuffer(UNITY_INTERFACE_API * RenderBufferFromHandle)(void* bufferHandle);
+
     id<MTLTexture>(UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer buffer);
     id<MTLTexture>(UNITY_INTERFACE_API * AAResolvedTextureFromRenderBuffer)(UnityRenderBuffer buffer);
     id<MTLTexture>(UNITY_INTERFACE_API * StencilTextureFromRenderBuffer)(UnityRenderBuffer buffer);

--- a/Plugin~/unity/include/IUnityProfiler.h
+++ b/Plugin~/unity/include/IUnityProfiler.h
@@ -1,0 +1,264 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+#include "IUnityInterface.h"
+
+#include <stdint.h>
+
+// Unity Profiler Native plugin API provides an ability to register callbacks for Unity Profiler events.
+// The basic functionality includes:
+// 1. Ability to create a Unity Profiler Marker.
+// 2. Begin and end sample.
+// 3. Register a thread for profiling.
+// 4. Obtain an information if profiler is available and enabled.
+//
+//  Usage example:
+//
+//  #include <IUnityInterface.h>
+//  #include <IUnityProfiler.h>
+//
+//  static IUnityProfiler* s_UnityProfiler = NULL;
+//  static const UnityProfilerMarkerDesc* s_MyPluginMarker = NULL;
+//  static bool s_IsDevelopmentBuild = false;
+//
+//  static void MyPluginWorkMethod()
+//  {
+//      if (s_IsDevelopmentBuild)
+//          s_UnityProfiler->BeginSample(s_MyPluginMarker);
+//
+//      // Code I want to see in Unity Profiler as "MyPluginMethod".
+//      // ...
+//
+//      if (s_IsDevelopmentBuild)
+//          s_UnityProfiler->EndSample(s_MyPluginMarker);
+//  }
+//
+//  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces)
+//  {
+//      s_UnityProfiler = unityInterfaces->Get<IUnityProfiler>();
+//      if (s_UnityProfiler == NULL)
+//          return;
+//      s_IsDevelopmentBuild = s_UnityProfiler->IsAvailable() != 0;
+//      s_UnityProfiler->CreateMarker(&s_MyPluginMarker, "MyPluginMethod", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
+//  }
+//
+//  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
+//  {
+//  }
+
+
+typedef uint32_t UnityProfilerMarkerId;
+
+enum UnityBuiltinProfilerCategory_
+{
+    kUnityProfilerCategoryRender = 0,
+    kUnityProfilerCategoryScripts = 1,
+    kUnityProfilerCategoryManagedJobs = 2,
+    kUnityProfilerCategoryBurstJobs = 3,
+    kUnityProfilerCategoryGUI = 4,
+    kUnityProfilerCategoryPhysics = 5,
+    kUnityProfilerCategoryAnimation = 6,
+    kUnityProfilerCategoryAI = 7,
+    kUnityProfilerCategoryAudio = 8,
+    kUnityProfilerCategoryAudioJob = 9,
+    kUnityProfilerCategoryAudioUpdateJob = 10,
+    kUnityProfilerCategoryVideo = 11,
+    kUnityProfilerCategoryParticles = 12,
+    kUnityProfilerCategoryGi = 13,
+    kUnityProfilerCategoryNetwork = 14,
+    kUnityProfilerCategoryLoading = 15,
+    kUnityProfilerCategoryOther = 16,
+    kUnityProfilerCategoryGC = 17,
+    kUnityProfilerCategoryVSync = 18,
+    kUnityProfilerCategoryOverhead = 19,
+    kUnityProfilerCategoryPlayerLoop = 20,
+    kUnityProfilerCategoryDirector = 21,
+    kUnityProfilerCategoryVR = 22,
+    kUnityProfilerCategoryAllocation = 23,
+    kUnityProfilerCategoryInternal = 24,
+    kUnityProfilerCategoryFileIO = 25,
+    kUnityProfilerCategoryUISystemLayout = 26,
+    kUnityProfilerCategoryUISystemRender = 27,
+    kUnityProfilerCategoryVFX = 28,
+    kUnityProfilerCategoryBuildInterface = 29,
+    kUnityProfilerCategoryInput = 30,
+    kUnityProfilerCategoryVirtualTexturing = 31,
+};
+typedef uint16_t UnityProfilerCategoryId;
+
+typedef struct UnityProfilerCategoryDesc
+{
+    // Incremental category index.
+    UnityProfilerCategoryId id;
+    // Reserved.
+    uint16_t reserved0;
+    // Internally associated category color which is in 0xRRGGBBAA format.
+    uint32_t rgbaColor;
+    // NULL-terminated string which is associated with the category.
+    const char* name;
+} UnityProfilerCategoryDesc;
+
+enum UnityProfilerMarkerFlag_
+{
+    kUnityProfilerMarkerFlagDefault = 0,
+
+    kUnityProfilerMarkerFlagScriptUser = 1 << 1,         // Markers created with C# API.
+    kUnityProfilerMarkerFlagScriptInvoke = 1 << 5,       // Runtime invocations with ScriptingInvocation::Invoke.
+    kUnityProfilerMarkerFlagScriptEnterLeave = 1 << 6,   // Deep profiler.
+
+    kUnityProfilerMarkerFlagAvailabilityEditor = 1 << 2, // Editor-only marker, doesn't present in dev and non-dev players.
+    kUnityProfilerMarkerFlagAvailabilityNonDev = 1 << 3, // Non-development marker, is present everywhere including release builds.
+
+    kUnityProfilerMarkerFlagWarning = 1 << 4,            // Indicates undesirable, performance-wise suboptimal code path.
+
+    kCounter = 1 << 7,                                   // Marker is also used as a counter.
+
+    kUnityProfilerMarkerFlagVerbosityDebug = 1 << 10,    // Internal debug markers - e.g. JobSystem Idle.
+    kUnityProfilerMarkerFlagVerbosityInternal = 1 << 11, // Internal markers - e.g. Mutex/semaphore waits.
+    kUnityProfilerMarkerFlagVerbosityAdvanced = 1 << 12  // Markers which are useful for advanced users - e.g. Loading.
+};
+typedef uint16_t UnityProfilerMarkerFlags;
+
+enum UnityProfilerMarkerEventType_
+{
+    kUnityProfilerMarkerEventTypeBegin = 0,
+    kUnityProfilerMarkerEventTypeEnd = 1,
+    kUnityProfilerMarkerEventTypeSingle = 2
+};
+typedef uint16_t UnityProfilerMarkerEventType;
+
+typedef struct UnityProfilerMarkerDesc
+{
+    // Per-marker callback chain pointer. Don't use.
+    const void* callback;
+    // Event id.
+    UnityProfilerMarkerId id;
+    // UnityProfilerMarkerFlag_ value.
+    UnityProfilerMarkerFlags flags;
+    // Category index the marker belongs to.
+    UnityProfilerCategoryId categoryId;
+    // NULL-terminated string which is associated with the marker.
+    const char* name;
+    // Metadata descriptions chain. Don't use.
+    const void* metaDataDesc;
+} UnityProfilerMarkerDesc;
+
+enum UnityProfilerMarkerDataType_
+{
+    kUnityProfilerMarkerDataTypeNone = 0,
+    kUnityProfilerMarkerDataTypeInstanceId = 1,
+    kUnityProfilerMarkerDataTypeInt32 = 2,
+    kUnityProfilerMarkerDataTypeUInt32 = 3,
+    kUnityProfilerMarkerDataTypeInt64 = 4,
+    kUnityProfilerMarkerDataTypeUInt64 = 5,
+    kUnityProfilerMarkerDataTypeFloat = 6,
+    kUnityProfilerMarkerDataTypeDouble = 7,
+    kUnityProfilerMarkerDataTypeString = 8,
+    kUnityProfilerMarkerDataTypeString16 = 9,
+    kUnityProfilerMarkerDataTypeBlob8 = 11
+};
+typedef uint8_t UnityProfilerMarkerDataType;
+
+enum UnityProfilerMarkerDataUnit_
+{
+    kUnityProfilerMarkerDataUnitUndefined = 0,
+    kUnityProfilerMarkerDataUnitTimeNanoseconds = 1,
+    kUnityProfilerMarkerDataUnitBytes = 2,
+    kUnityProfilerMarkerDataUnitCount = 3,
+    kUnityProfilerMarkerDataUnitPercent = 4,
+    kUnityProfilerMarkerDataUnitFrequencyHz = 5,
+};
+typedef uint8_t UnityProfilerMarkerDataUnit;
+
+typedef struct UnityProfilerMarkerData
+{
+    UnityProfilerMarkerDataType type;
+    uint8_t reserved0;
+    uint16_t reserved1;
+    uint32_t size;
+    const void* ptr;
+} UnityProfilerMarkerData;
+
+enum UnityProfilerFlowEventType_
+{
+    // The flow began withing a current marker scope (enclosed scope).
+    kUnityProfilerFlowEventTypeBegin = 0,
+    // The flow continues with the next sample.
+    kUnityProfilerFlowEventTypeNext = 1,
+    // The flow ends with the next sample.
+    kUnityProfilerFlowEventTypeEnd = 2,
+};
+typedef uint8_t UnityProfilerFlowEventType;
+
+typedef uint64_t UnityProfilerThreadId;
+
+// Available since 2020.1
+UNITY_DECLARE_INTERFACE(IUnityProfiler)
+{
+    void BeginSample(const UnityProfilerMarkerDesc* markerDesc)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeBegin, 0, NULL);
+    }
+
+    void BeginSample(const UnityProfilerMarkerDesc* markerDesc, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeBegin, eventDataCount, eventData);
+    }
+
+    void EndSample(const UnityProfilerMarkerDesc* markerDesc)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeEnd, 0, NULL);
+    }
+
+    // Create instrumentation event.
+    // \param markerDesc is a pointer to marker description struct.
+    // \param eventType is an event type - UnityProfilerMarkerEventType_.
+    // \param eventDataCount is an event metadata count passed in eventData. Must be less than eventDataCount specified in CreateMarker.
+    // \param eventData is a metadata array of eventDataCount elements.
+    void(UNITY_INTERFACE_API * EmitEvent)(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData);
+
+    // Returns 1 if Unity Profiler is enabled, 0 overwise.
+    int(UNITY_INTERFACE_API * IsEnabled)();
+
+    // Returns 1 if Unity Profiler is available, 0 overwise.
+    // Profiler is available only in Development builds. Release builds have Unity Profiler compiled out.
+    // However individual markers can be available even in Release builds (e.g. GC.Collect) and be collected with
+    // Recorder API or forwarded to platform and other profilers (via IUnityProfilerCallbacks::RegisterMarkerEventCallback API).
+    // You can choose whenever you want or not emit profiler event in Development and Release builds using the cached result of this method.
+    int(UNITY_INTERFACE_API * IsAvailable)();
+
+    // Creates a new Unity Profiler marker.
+    // \param desc Pointer to the const UnityProfilerMarkerDesc* which is set to the created marker in a case of a succesful execution.
+    // \param name Marker name to be displayed in Unity Profiler.
+    // \param flags Marker flags. One of UnityProfilerMarkerFlag_ enum. Use kUnityProfilerMarkerFlagDefault if not sure.
+    // \param eventDataCount Maximum count of potential metadata parameters count.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * CreateMarker)(const UnityProfilerMarkerDesc** desc, const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount);
+
+    // Set a metadata description for the Unity Profiler marker.
+    // \param markerDesc is a pointer to marker description struct.
+    // \param index metadata index to set name for.
+    // \param metadataType Data type. Must be of UnityProfilerMarkerDataType_ enum.
+    // \param name Metadata name.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * SetMarkerMetadataName)(const UnityProfilerMarkerDesc* desc, int index, const char* metadataName, UnityProfilerMarkerDataType metadataType, UnityProfilerMarkerDataUnit metadataUnit);
+
+    // Registers current thread with Unity Profiler.
+    // Has no effect in Release Players.
+    // \param threadId Optional Unity Profiler thread identifier which it written on successful method call. Can be used with UnregisterThread.
+    // \param groupName Thread group name. Unity Profiler aggregates threads with the same group.
+    // \param name Thread name.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * RegisterThread)(UnityProfilerThreadId* threadId, const char* groupName, const char* name);
+
+    // Unregisters current thread from Unity Profiler and cleans up all associated memory.
+    // Has no effect in Release Players.
+    // \param threadId Unity Profiler thread identifier obtained with RegisterThread call. Use 0 to cleanup the current thread.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * UnregisterThread)(UnityProfilerThreadId threadId);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x2CE79ED8316A4833ULL, 0x87076B2013E1571FULL, IUnityProfiler)

--- a/Plugin~/unity/include/IUnityProfilerCallbacks.h
+++ b/Plugin~/unity/include/IUnityProfilerCallbacks.h
@@ -1,0 +1,267 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+#include "IUnityInterface.h"
+
+#include <stdint.h>
+
+// Unity Profiler Native plugin API provides an ability to register callbacks for Unity Profiler events.
+// The basic functionality includes:
+// 1. Category callback - provides information about category name and color.
+// 2. Profiler marker callback - provides information about new marker which is created internally or with C# API.
+// 3. Marker event callback - allows to intercept begin/end events for the particular marker.
+// 4. Frame event callback - provides information about logical CPU frame.
+//
+//  Usage example:
+//
+//  #include <IUnityInterface.h>
+//  #include <IUnityProfilerCallbacks.h>
+//
+//  static IUnityProfilerCallbacks* s_UnityProfilerCallbacks = NULL;
+//
+//  static void UNITY_INTERFACE_API MyProfilerEventCallback(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, unsigned short eventDataCount, const UnityProfilerMarkerData* eventData, void* userData)
+//  {
+//      switch (eventType)
+//      {
+//          case kUnityProfilerMarkerEventTypeBegin:
+//          {
+//              MyProfilerPushMarker(markerDesc->name);
+//              break;
+//          }
+//          case kUnityProfilerMarkerEventTypeEnd:
+//          {
+//              MyProfilerPopMarker(markerDesc->name);
+//              break;
+//          }
+//      }
+//  }
+//
+//  static void UNITY_INTERFACE_API MyProfilerCreateEventCallback(const UnityProfilerMarkerDesc* markerDesc, void* userData)
+//  {
+//      s_UnityProfilerCallbacks->RegisterEventCallback(markerDesc, MyProfilerEventCallback, NULL);
+//  }
+//
+//  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces)
+//  {
+//      s_UnityProfilerCallbacks = unityInterfaces->Get<IUnityProfilerCallbacks>();
+//      s_UnityProfilerCallbacks->RegisterCreateEventCallback(&MyProfilerCreateEventCallback, NULL);
+//  }
+//
+//  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
+//  {
+//      s_UnityProfilerCallbacks->UnregisterCreateEventCallback(&MyProfilerCreateEventCallback, NULL);
+//      s_UnityProfilerCallbacks->UnregisterEventCallback(NULL, &MyProfilerEventCallback, NULL);
+//  }
+
+
+typedef uint32_t UnityProfilerMarkerId;
+typedef uint16_t UnityProfilerCategoryId;
+typedef uint64_t UnityProfilerThreadId;
+
+typedef struct UnityProfilerCategoryDesc
+{
+    // Incremental category index.
+    UnityProfilerCategoryId id;
+    // Reserved.
+    uint16_t reserved0;
+    // Internally associated category color which is in 0xRRGGBBAA format.
+    uint32_t rgbaColor;
+    // NULL-terminated string which is associated with the category.
+    const char* name;
+} UnityProfilerCategoryDesc;
+
+enum UnityProfilerMarkerFlag_
+{
+    kUnityProfilerMarkerFlagDefault = 0,
+
+    kUnityProfilerMarkerFlagScriptUser = 1 << 1,         // Markers created with C# API.
+    kUnityProfilerMarkerFlagScriptInvoke = 1 << 5,       // Runtime invocations with ScriptingInvocation::Invoke.
+    kUnityProfilerMarkerFlagScriptEnterLeave = 1 << 6,   // Deep profiler.
+
+    kUnityProfilerMarkerFlagAvailabilityEditor = 1 << 2, // Editor-only marker, doesn't present in dev and non-dev players.
+    kUnityProfilerMarkerFlagAvailabilityNonDev = 1 << 3, // Non-dev marker, present everywhere.
+
+    kUnityProfilerMarkerFlagWarning = 1 << 4,            // Indicates undesirable, performance-wise suboptimal code path.
+
+    kUnityProfilerMarkerFlagVerbosityDebug    = 1 << 10, // Internal debug markers - e.g. JobSystem Idle.
+    kUnityProfilerMarkerFlagVerbosityInternal = 1 << 11, // Internal markers - e.g. Mutex/semaphore waits.
+    kUnityProfilerMarkerFlagVerbosityAdvanced = 1 << 12  // Markers which are useful for advanced users - e.g. Loading.
+};
+typedef uint16_t UnityProfilerMarkerFlags;
+
+enum UnityProfilerMarkerEventType_
+{
+    kUnityProfilerMarkerEventTypeBegin  = 0,
+    kUnityProfilerMarkerEventTypeEnd    = 1,
+    kUnityProfilerMarkerEventTypeSingle = 2
+};
+typedef uint16_t UnityProfilerMarkerEventType;
+
+typedef struct UnityProfilerMarkerDesc
+{
+    // Per-marker callback chain pointer. Don't use.
+    const void* callback;
+    // Event id.
+    UnityProfilerMarkerId id;
+    // UnityProfilerMarkerFlag_ value.
+    UnityProfilerMarkerFlags flags;
+    // Category index the marker belongs to.
+    UnityProfilerCategoryId categoryId;
+    // NULL-terminated string which is associated with the marker.
+    const char* name;
+    // Metadata descriptions chain. Don't use.
+    const void* metaDataDesc;
+} UnityProfilerMarkerDesc;
+
+enum UnityProfilerMarkerDataType_
+{
+    kUnityProfilerMarkerDataTypeNone = 0,
+    kUnityProfilerMarkerDataTypeInstanceId = 1,
+    kUnityProfilerMarkerDataTypeInt32 = 2,
+    kUnityProfilerMarkerDataTypeUInt32 = 3,
+    kUnityProfilerMarkerDataTypeInt64 = 4,
+    kUnityProfilerMarkerDataTypeUInt64 = 5,
+    kUnityProfilerMarkerDataTypeFloat = 6,
+    kUnityProfilerMarkerDataTypeDouble = 7,
+    kUnityProfilerMarkerDataTypeString = 8,
+    kUnityProfilerMarkerDataTypeString16 = 9,
+    kUnityProfilerMarkerDataTypeBlob8 = 11
+};
+typedef uint8_t UnityProfilerMarkerDataType;
+
+typedef struct UnityProfilerMarkerData
+{
+    UnityProfilerMarkerDataType type;
+    uint8_t reserved0;
+    uint16_t reserved1;
+    uint32_t size;
+    const void* ptr;
+} UnityProfilerMarkerData;
+
+enum UnityProfilerFlowEventType_
+{
+    // The flow began withing a current marker scope (enclosed scope).
+    kUnityProfilerFlowEventTypeBegin = 0,
+    // The flow continues with the next sample.
+    kUnityProfilerFlowEventTypeNext  = 1,
+    // The flow ends with the next sample.
+    kUnityProfilerFlowEventTypeEnd   = 2,
+};
+typedef uint8_t UnityProfilerFlowEventType;
+
+typedef struct UnityProfilerThreadDesc
+{
+    // Thread id c-casted to uint64_t.
+    uint64_t threadId;
+    // Thread group name. NULL-terminated.
+    const char* groupName;
+    // Thread name. NULL-terminated.
+    const char* name;
+} UnityProfilerThreadDesc;
+
+// Called when a new category is created. Up to 4 installed callbacks are supported.
+// \param categoryDesc is a pointer to category description.
+// \param userData is an optional context pointer passed with RegisterCreateCategoryCallback call.
+typedef void (UNITY_INTERFACE_API * IUnityProfilerCreateCategoryCallback)(const UnityProfilerCategoryDesc* categoryDesc, void* userData);
+
+// Called when a new profiler marker is created. Up to 4 installed callbacks are supported.
+// \param markerDesc is a pointer to marker description.
+// \param userData is an optional context pointer passed with RegisterCreateEventCallback call.
+typedef void (UNITY_INTERFACE_API * IUnityProfilerCreateMarkerCallback)(const UnityProfilerMarkerDesc* markerDesc, void* userData);
+
+// Called when a profiler event occurs.
+// \param markerDesc is an marker description struct.
+// \param eventType is an event type - UnityProfilerMarkerEventType_.
+// \param eventDataCount is an event metadata count.
+// \param eventData is a metadata array of eventDataCount elements.
+// \param userData is an optional context pointer passed with RegisterCreateEventCallback call.
+typedef void (UNITY_INTERFACE_API * IUnityProfilerMarkerEventCallback)(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData, void* userData);
+
+// Called when a profiler frame change occurs. Up to 4 installed callbacks are supported.
+// \param userData is an optional context pointer passed with RegisterCreateEventCallback call.
+typedef void (UNITY_INTERFACE_API * IUnityProfilerFrameCallback)(void* userData);
+
+// Called when a profiler frame change occurs. Up to 4 installed callbacks are supported.
+// \param userData is an optional context pointer passed with RegisterCreateEventCallback call.
+typedef void (UNITY_INTERFACE_API * IUnityProfilerThreadCallback)(const UnityProfilerThreadDesc* threadDesc, void* userData);
+
+// Called when a profiler flow event occurs.
+// Flow events connect events across threads allowing to trace related activities initiated from a control(main) thread.
+// \param flowEventType is a flow event type.
+// \param flowId is an unique incremental identifier for the flow chain.
+// \param userData is an optional context pointer passed with RegisterCreateEventCallback call.
+typedef void (UNITY_INTERFACE_API * IUnityProfilerFlowEventCallback)(UnityProfilerFlowEventType flowEventType, uint32_t flowId, void* userData);
+
+// Available since 2019.1
+UNITY_DECLARE_INTERFACE(IUnityProfilerCallbacksV2)
+{
+    // Register a callback which is called when a new category is created.
+    // Returns 0 on success and non-zero in case of error.
+    // Only up to 4 callbacks can be registered.
+    int(UNITY_INTERFACE_API * RegisterCreateCategoryCallback)(IUnityProfilerCreateCategoryCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterCreateCategoryCallback)(IUnityProfilerCreateCategoryCallback callback, void* userData);
+
+    // Register a callback which is called when a new marker is created.
+    // E.g. dynamically created in C# with "new PerformanceMarker(string)" or internally.
+    // Also is called for all existing markers when the callback is registered.
+    // Returns 0 on success and non-zero in case of error.
+    // Only up to 4 callbacks can be registered.
+    int(UNITY_INTERFACE_API * RegisterCreateMarkerCallback)(IUnityProfilerCreateMarkerCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterCreateMarkerCallback)(IUnityProfilerCreateMarkerCallback callback, void* userData);
+
+    // Register a callback which is called every time "PerformanceMarker.Begin(string)" is called or equivalent internal native counterpart.
+    // Returns 0 on success and non-zero in case of error.
+    // \param markerDesc is a pointer to marker description you want to install callback for.
+    int(UNITY_INTERFACE_API * RegisterMarkerEventCallback)(const UnityProfilerMarkerDesc * markerDesc, IUnityProfilerMarkerEventCallback callback, void* userData);
+    // Unregister per-marker callback.
+    // \param markerDesc is a pointer to marker description you want to remove callback from.
+    // \param userData optional context pointer.
+    // If markerDesc is NULL, callback is removed from all events which have (callback, userData) pair.
+    // If both markerDesc and userData are NULL, callback is removed from all events which have callback function pointer.
+    int(UNITY_INTERFACE_API * UnregisterMarkerEventCallback)(const UnityProfilerMarkerDesc * markerDesc, IUnityProfilerMarkerEventCallback callback, void* userData);
+
+    // Register a callback which is called every time Profiler.BeginSample is called or equivalent internal native counterpart.
+    // Returns 0 on success and non-zero in case of error.
+    // Only up to 4 callbacks can be registered.
+    int(UNITY_INTERFACE_API * RegisterFrameCallback)(IUnityProfilerFrameCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterFrameCallback)(IUnityProfilerFrameCallback callback, void* userData);
+
+    // Register a callback which is called every time a new thread is registered with profiler.
+    // Returns 0 on success and non-zero in case of error.
+    // Only up to 4 callbacks can be registered.
+    int(UNITY_INTERFACE_API * RegisterCreateThreadCallback)(IUnityProfilerThreadCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterCreateThreadCallback)(IUnityProfilerThreadCallback callback, void* userData);
+
+    // Register a callback which is called every time Unity generates a flow event.
+    // Returns 0 on success and non-zero in case of error.
+    // Note: Flow events are supported only in Development Players and Editor.
+    int(UNITY_INTERFACE_API * RegisterFlowEventCallback)(IUnityProfilerFlowEventCallback callback, void* userData);
+    // Unregister flow event callback.
+    // \param userData optional context pointer.
+    int(UNITY_INTERFACE_API * UnregisterFlowEventCallback)(IUnityProfilerFlowEventCallback callback, void* userData);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x5DEB59E88F2D4571ULL, 0x81E8583069A5E33CULL, IUnityProfilerCallbacksV2)
+
+// Available since 2018.2
+UNITY_DECLARE_INTERFACE(IUnityProfilerCallbacks)
+{
+    int(UNITY_INTERFACE_API * RegisterCreateCategoryCallback)(IUnityProfilerCreateCategoryCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterCreateCategoryCallback)(IUnityProfilerCreateCategoryCallback callback, void* userData);
+
+    int(UNITY_INTERFACE_API * RegisterCreateMarkerCallback)(IUnityProfilerCreateMarkerCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterCreateMarkerCallback)(IUnityProfilerCreateMarkerCallback callback, void* userData);
+
+    int(UNITY_INTERFACE_API * RegisterMarkerEventCallback)(const UnityProfilerMarkerDesc * markerDesc, IUnityProfilerMarkerEventCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterMarkerEventCallback)(const UnityProfilerMarkerDesc * markerDesc, IUnityProfilerMarkerEventCallback callback, void* userData);
+
+    int(UNITY_INTERFACE_API * RegisterFrameCallback)(IUnityProfilerFrameCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterFrameCallback)(IUnityProfilerFrameCallback callback, void* userData);
+
+    int(UNITY_INTERFACE_API * RegisterCreateThreadCallback)(IUnityProfilerThreadCallback callback, void* userData);
+    int(UNITY_INTERFACE_API * UnregisterCreateThreadCallback)(IUnityProfilerThreadCallback callback, void* userData);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x572FDB38CE3C4B1FULL, 0xA6071A9A7C4F52D8ULL, IUnityProfilerCallbacks)

--- a/Plugin~/unity/include/IUnityProfilerCallbacks.h
+++ b/Plugin~/unity/include/IUnityProfilerCallbacks.h
@@ -6,13 +6,14 @@
 
 #pragma once
 #include "IUnityInterface.h"
+#include "IUnityProfiler.h"
 
 #include <stdint.h>
 
-// Unity Profiler Native plugin API provides an ability to register callbacks for Unity Profiler events.
+// Unity Profiler Callbacks native plugin API provides an ability to register callbacks for Unity Profiler events.
 // The basic functionality includes:
-// 1. Category callback - provides information about category name and color.
-// 2. Profiler marker callback - provides information about new marker which is created internally or with C# API.
+// 1. Profiler category creation callback - provides information about category name and color.
+// 2. Profiler marker creation callback - provides information about new marker which is created internally or with C# API.
 // 3. Marker event callback - allows to intercept begin/end events for the particular marker.
 // 4. Frame event callback - provides information about logical CPU frame.
 //
@@ -40,123 +41,27 @@
 //      }
 //  }
 //
-//  static void UNITY_INTERFACE_API MyProfilerCreateEventCallback(const UnityProfilerMarkerDesc* markerDesc, void* userData)
+//  static void UNITY_INTERFACE_API MyProfilerCreateMarkerCallback(const UnityProfilerMarkerDesc* markerDesc, void* userData)
 //  {
-//      s_UnityProfilerCallbacks->RegisterEventCallback(markerDesc, MyProfilerEventCallback, NULL);
+//      s_UnityProfilerCallbacks->RegisterMarkerEventCallback(markerDesc, MyProfilerEventCallback, NULL);
 //  }
 //
 //  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces)
 //  {
 //      s_UnityProfilerCallbacks = unityInterfaces->Get<IUnityProfilerCallbacks>();
-//      s_UnityProfilerCallbacks->RegisterCreateEventCallback(&MyProfilerCreateEventCallback, NULL);
+//      s_UnityProfilerCallbacks->RegisterCreateMarkerCallback(&MyProfilerCreateMarkerCallback, NULL);
 //  }
 //
 //  extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 //  {
-//      s_UnityProfilerCallbacks->UnregisterCreateEventCallback(&MyProfilerCreateEventCallback, NULL);
-//      s_UnityProfilerCallbacks->UnregisterEventCallback(NULL, &MyProfilerEventCallback, NULL);
+//      s_UnityProfilerCallbacks->UnregisterCreateMarkerCallback(&MyProfilerCreateMarkerCallback, NULL);
+//      s_UnityProfilerCallbacks->UnregisterMarkerEventCallback(NULL, &MyProfilerEventCallback, NULL);
 //  }
-
-
-typedef uint32_t UnityProfilerMarkerId;
-typedef uint16_t UnityProfilerCategoryId;
-typedef uint64_t UnityProfilerThreadId;
-
-typedef struct UnityProfilerCategoryDesc
-{
-    // Incremental category index.
-    UnityProfilerCategoryId id;
-    // Reserved.
-    uint16_t reserved0;
-    // Internally associated category color which is in 0xRRGGBBAA format.
-    uint32_t rgbaColor;
-    // NULL-terminated string which is associated with the category.
-    const char* name;
-} UnityProfilerCategoryDesc;
-
-enum UnityProfilerMarkerFlag_
-{
-    kUnityProfilerMarkerFlagDefault = 0,
-
-    kUnityProfilerMarkerFlagScriptUser = 1 << 1,         // Markers created with C# API.
-    kUnityProfilerMarkerFlagScriptInvoke = 1 << 5,       // Runtime invocations with ScriptingInvocation::Invoke.
-    kUnityProfilerMarkerFlagScriptEnterLeave = 1 << 6,   // Deep profiler.
-
-    kUnityProfilerMarkerFlagAvailabilityEditor = 1 << 2, // Editor-only marker, doesn't present in dev and non-dev players.
-    kUnityProfilerMarkerFlagAvailabilityNonDev = 1 << 3, // Non-dev marker, present everywhere.
-
-    kUnityProfilerMarkerFlagWarning = 1 << 4,            // Indicates undesirable, performance-wise suboptimal code path.
-
-    kUnityProfilerMarkerFlagVerbosityDebug    = 1 << 10, // Internal debug markers - e.g. JobSystem Idle.
-    kUnityProfilerMarkerFlagVerbosityInternal = 1 << 11, // Internal markers - e.g. Mutex/semaphore waits.
-    kUnityProfilerMarkerFlagVerbosityAdvanced = 1 << 12  // Markers which are useful for advanced users - e.g. Loading.
-};
-typedef uint16_t UnityProfilerMarkerFlags;
-
-enum UnityProfilerMarkerEventType_
-{
-    kUnityProfilerMarkerEventTypeBegin  = 0,
-    kUnityProfilerMarkerEventTypeEnd    = 1,
-    kUnityProfilerMarkerEventTypeSingle = 2
-};
-typedef uint16_t UnityProfilerMarkerEventType;
-
-typedef struct UnityProfilerMarkerDesc
-{
-    // Per-marker callback chain pointer. Don't use.
-    const void* callback;
-    // Event id.
-    UnityProfilerMarkerId id;
-    // UnityProfilerMarkerFlag_ value.
-    UnityProfilerMarkerFlags flags;
-    // Category index the marker belongs to.
-    UnityProfilerCategoryId categoryId;
-    // NULL-terminated string which is associated with the marker.
-    const char* name;
-    // Metadata descriptions chain. Don't use.
-    const void* metaDataDesc;
-} UnityProfilerMarkerDesc;
-
-enum UnityProfilerMarkerDataType_
-{
-    kUnityProfilerMarkerDataTypeNone = 0,
-    kUnityProfilerMarkerDataTypeInstanceId = 1,
-    kUnityProfilerMarkerDataTypeInt32 = 2,
-    kUnityProfilerMarkerDataTypeUInt32 = 3,
-    kUnityProfilerMarkerDataTypeInt64 = 4,
-    kUnityProfilerMarkerDataTypeUInt64 = 5,
-    kUnityProfilerMarkerDataTypeFloat = 6,
-    kUnityProfilerMarkerDataTypeDouble = 7,
-    kUnityProfilerMarkerDataTypeString = 8,
-    kUnityProfilerMarkerDataTypeString16 = 9,
-    kUnityProfilerMarkerDataTypeBlob8 = 11
-};
-typedef uint8_t UnityProfilerMarkerDataType;
-
-typedef struct UnityProfilerMarkerData
-{
-    UnityProfilerMarkerDataType type;
-    uint8_t reserved0;
-    uint16_t reserved1;
-    uint32_t size;
-    const void* ptr;
-} UnityProfilerMarkerData;
-
-enum UnityProfilerFlowEventType_
-{
-    // The flow began withing a current marker scope (enclosed scope).
-    kUnityProfilerFlowEventTypeBegin = 0,
-    // The flow continues with the next sample.
-    kUnityProfilerFlowEventTypeNext  = 1,
-    // The flow ends with the next sample.
-    kUnityProfilerFlowEventTypeEnd   = 2,
-};
-typedef uint8_t UnityProfilerFlowEventType;
 
 typedef struct UnityProfilerThreadDesc
 {
     // Thread id c-casted to uint64_t.
-    uint64_t threadId;
+    UnityProfilerThreadId threadId;
     // Thread group name. NULL-terminated.
     const char* groupName;
     // Thread name. NULL-terminated.
@@ -179,7 +84,9 @@ typedef void (UNITY_INTERFACE_API * IUnityProfilerCreateMarkerCallback)(const Un
 // \param eventDataCount is an event metadata count.
 // \param eventData is a metadata array of eventDataCount elements.
 // \param userData is an optional context pointer passed with RegisterCreateEventCallback call.
-typedef void (UNITY_INTERFACE_API * IUnityProfilerMarkerEventCallback)(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData, void* userData);
+typedef void (UNITY_INTERFACE_API* IUnityProfilerMarkerEventCallback)(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData, void* userData);
+
+typedef void (UNITY_INTERFACE_API * IUnityProfilerBulkCounterDataEventCallback)(int counterGroup, size_t size, void* data, void* userData);
 
 // Called when a profiler frame change occurs. Up to 4 installed callbacks are supported.
 // \param userData is an optional context pointer passed with RegisterCreateEventCallback call.

--- a/Plugin~/unity/include/IUnityRenderingExtensions.h
+++ b/Plugin~/unity/include/IUnityRenderingExtensions.h
@@ -1,0 +1,377 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+
+
+#include "IUnityGraphics.h"
+
+/*
+    Low-level Native Plugin Rendering Extensions
+    ============================================
+
+    On top of the Low-level native plugin interface, Unity also supports low level rendering extensions that can receive callbacks when certain events happen.
+    This is mostly used to implement and control low-level rendering in your plugin and enable it to work with Unity’s multithreaded rendering.
+
+    Due to the low-level nature of this extension the plugin might need to be preloaded before the devices get created.
+    Currently the convention is name-based namely the plugin name must be prefixed by “GfxPlugin”. Example: GfxPluginMyFancyNativePlugin.
+
+    <code>
+        // Native plugin code example
+
+        enum PluginCustomCommands
+        {
+            kPluginCustomCommandDownscale = kUnityRenderingExtUserEventsStart,
+            kPluginCustomCommandUpscale,
+
+            // insert your own events here
+
+            kPluginCustomCommandCount
+        };
+
+        static IUnityInterfaces* s_UnityInterfaces = NULL;
+
+        extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API
+        UnityPluginLoad(IUnityInterfaces* unityInterfaces)
+        {
+            // initialization code here...
+        }
+
+        extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API
+        UnityRenderingExtEvent(UnityRenderingExtEventType event, void* data)
+        {
+            switch (event)
+            {
+                case kUnityRenderingExtEventBeforeDrawCall:
+                    // do some stuff
+                    break;
+                case kUnityRenderingExtEventAfterDrawCall:
+                    // undo some stuff
+                    break;
+                case kPluginCustomCommandDownscale:
+                    // downscale some stuff
+                    break;
+                case kPluginCustomCommandUpscale:
+                    // upscale some stuff
+                    break;
+            }
+        }
+    </code>
+*/
+
+
+//     These events will be propagated to all plugins that implement void UnityRenderingExtEvent(UnityRenderingExtEventType event, void* data);
+
+typedef enum UnityRenderingExtEventType
+{
+    kUnityRenderingExtEventSetStereoTarget,                 // issued during SetStereoTarget and carrying the current 'eye' index as parameter
+    kUnityRenderingExtEventSetStereoEye,                    // issued during stereo rendering at the beginning of each eye's rendering loop. It carries the current 'eye' index as parameter
+    kUnityRenderingExtEventStereoRenderingDone,             // issued after the rendering has finished
+    kUnityRenderingExtEventBeforeDrawCall,                  // issued during BeforeDrawCall and carrying UnityRenderingExtBeforeDrawCallParams as parameter
+    kUnityRenderingExtEventAfterDrawCall,                   // issued during AfterDrawCall. This event doesn't carry any parameters
+    kUnityRenderingExtEventCustomGrab,                      // issued during GrabIntoRenderTexture since we can't simply copy the resources
+                                                            //      when custom rendering is used - we need to let plugin handle this. It carries over
+                                                            //      a UnityRenderingExtCustomBlitParams params = { X, source, dest, 0, 0 } ( X means it's irrelevant )
+    kUnityRenderingExtEventCustomBlit,                      // issued by plugin to insert custom blits. It carries over UnityRenderingExtCustomBlitParams as param.
+    kUnityRenderingExtEventUpdateTextureBegin,                                                  // Deprecated.
+    kUnityRenderingExtEventUpdateTextureEnd,                                                    // Deprecated.
+    kUnityRenderingExtEventUpdateTextureBeginV1 = kUnityRenderingExtEventUpdateTextureBegin,    // Deprecated. Issued to update a texture. It carries over UnityRenderingExtTextureUpdateParamsV1
+    kUnityRenderingExtEventUpdateTextureEndV1 = kUnityRenderingExtEventUpdateTextureEnd,        // Deprecated. Issued to signal the plugin that the texture update has finished. It carries over the same UnityRenderingExtTextureUpdateParamsV1 as kUnityRenderingExtEventUpdateTextureBeginV1
+    kUnityRenderingExtEventUpdateTextureBeginV2,                                                // Issued to update a texture. It carries over UnityRenderingExtTextureUpdateParamsV2
+    kUnityRenderingExtEventUpdateTextureEndV2,                                                  // Issued to signal the plugin that the texture update has finished. It carries over the same UnityRenderingExtTextureUpdateParamsV2 as kUnityRenderingExtEventUpdateTextureBeginV2
+
+    // keep this last
+    kUnityRenderingExtEventCount,
+    kUnityRenderingExtUserEventsStart = kUnityRenderingExtEventCount
+} UnityRenderingExtEventType;
+
+
+typedef enum UnityRenderingExtCustomBlitCommands
+{
+    kUnityRenderingExtCustomBlitVRFlush,                    // This event is mostly used in multi GPU configurations ( SLI, etc ) in order to allow the plugin to flush all GPU's targets
+
+    // keep this last
+    kUnityRenderingExtCustomBlitCount,
+    kUnityRenderingExtUserCustomBlitStart = kUnityRenderingExtCustomBlitCount
+} UnityRenderingExtCustomBlitCommands;
+
+/*
+    This will be propagated to all plugins implementing UnityRenderingExtQuery.
+*/
+typedef enum UnityRenderingExtQueryType
+{
+    kUnityRenderingExtQueryOverrideViewport             = 1 << 0,           // The plugin handles setting up the viewport rects. Unity will skip its internal SetViewport calls
+    kUnityRenderingExtQueryOverrideScissor              = 1 << 1,           // The plugin handles setting up the scissor rects. Unity will skip its internal SetScissor calls
+    kUnityRenderingExtQueryOverrideVROcclussionMesh     = 1 << 2,           // The plugin handles its own VR occlusion mesh rendering. Unity will skip rendering its internal VR occlusion mask
+    kUnityRenderingExtQueryOverrideVRSinglePass         = 1 << 3,           // The plugin uses its own single pass stereo technique. Unity will only traverse and render the render node graph once.
+                                                                            //      and it will clear the whole render target not just per-eye on demand.
+    kUnityRenderingExtQueryKeepOriginalDoubleWideWidth_DEPRECATED  = 1 << 4,           // Instructs unity to keep the original double wide width. By default unity will try and have a power-of-two width for mip-mapping requirements.
+    kUnityRenderingExtQueryRequestVRFlushCallback       = 1 << 5,           // Instructs unity to provide callbacks when the VR eye textures need flushing. Useful for multi GPU synchronization.
+} UnityRenderingExtQueryType;
+
+
+typedef enum UnityRenderingExtTextureFormat
+{
+    kUnityRenderingExtFormatNone = 0, kUnityRenderingExtFormatFirst = kUnityRenderingExtFormatNone,
+
+    // sRGB formats
+    kUnityRenderingExtFormatR8_SRGB,
+    kUnityRenderingExtFormatR8G8_SRGB,
+    kUnityRenderingExtFormatR8G8B8_SRGB,
+    kUnityRenderingExtFormatR8G8B8A8_SRGB,
+
+    // 8 bit integer formats
+    kUnityRenderingExtFormatR8_UNorm,
+    kUnityRenderingExtFormatR8G8_UNorm,
+    kUnityRenderingExtFormatR8G8B8_UNorm,
+    kUnityRenderingExtFormatR8G8B8A8_UNorm,
+    kUnityRenderingExtFormatR8_SNorm,
+    kUnityRenderingExtFormatR8G8_SNorm,
+    kUnityRenderingExtFormatR8G8B8_SNorm,
+    kUnityRenderingExtFormatR8G8B8A8_SNorm,
+    kUnityRenderingExtFormatR8_UInt,
+    kUnityRenderingExtFormatR8G8_UInt,
+    kUnityRenderingExtFormatR8G8B8_UInt,
+    kUnityRenderingExtFormatR8G8B8A8_UInt,
+    kUnityRenderingExtFormatR8_SInt,
+    kUnityRenderingExtFormatR8G8_SInt,
+    kUnityRenderingExtFormatR8G8B8_SInt,
+    kUnityRenderingExtFormatR8G8B8A8_SInt,
+
+    // 16 bit integer formats
+    kUnityRenderingExtFormatR16_UNorm,
+    kUnityRenderingExtFormatR16G16_UNorm,
+    kUnityRenderingExtFormatR16G16B16_UNorm,
+    kUnityRenderingExtFormatR16G16B16A16_UNorm,
+    kUnityRenderingExtFormatR16_SNorm,
+    kUnityRenderingExtFormatR16G16_SNorm,
+    kUnityRenderingExtFormatR16G16B16_SNorm,
+    kUnityRenderingExtFormatR16G16B16A16_SNorm,
+    kUnityRenderingExtFormatR16_UInt,
+    kUnityRenderingExtFormatR16G16_UInt,
+    kUnityRenderingExtFormatR16G16B16_UInt,
+    kUnityRenderingExtFormatR16G16B16A16_UInt,
+    kUnityRenderingExtFormatR16_SInt,
+    kUnityRenderingExtFormatR16G16_SInt,
+    kUnityRenderingExtFormatR16G16B16_SInt,
+    kUnityRenderingExtFormatR16G16B16A16_SInt,
+
+    // 32 bit integer formats
+    kUnityRenderingExtFormatR32_UInt,
+    kUnityRenderingExtFormatR32G32_UInt,
+    kUnityRenderingExtFormatR32G32B32_UInt,
+    kUnityRenderingExtFormatR32G32B32A32_UInt,
+    kUnityRenderingExtFormatR32_SInt,
+    kUnityRenderingExtFormatR32G32_SInt,
+    kUnityRenderingExtFormatR32G32B32_SInt,
+    kUnityRenderingExtFormatR32G32B32A32_SInt,
+
+    // HDR formats
+    kUnityRenderingExtFormatR16_SFloat,
+    kUnityRenderingExtFormatR16G16_SFloat,
+    kUnityRenderingExtFormatR16G16B16_SFloat,
+    kUnityRenderingExtFormatR16G16B16A16_SFloat,
+    kUnityRenderingExtFormatR32_SFloat,
+    kUnityRenderingExtFormatR32G32_SFloat,
+    kUnityRenderingExtFormatR32G32B32_SFloat,
+    kUnityRenderingExtFormatR32G32B32A32_SFloat,
+
+    // Luminance and Alpha format
+    kUnityRenderingExtFormatL8_UNorm,
+    kUnityRenderingExtFormatA8_UNorm,
+    kUnityRenderingExtFormatA16_UNorm,
+
+    // BGR formats
+    kUnityRenderingExtFormatB8G8R8_SRGB,
+    kUnityRenderingExtFormatB8G8R8A8_SRGB,
+    kUnityRenderingExtFormatB8G8R8_UNorm,
+    kUnityRenderingExtFormatB8G8R8A8_UNorm,
+    kUnityRenderingExtFormatB8G8R8_SNorm,
+    kUnityRenderingExtFormatB8G8R8A8_SNorm,
+    kUnityRenderingExtFormatB8G8R8_UInt,
+    kUnityRenderingExtFormatB8G8R8A8_UInt,
+    kUnityRenderingExtFormatB8G8R8_SInt,
+    kUnityRenderingExtFormatB8G8R8A8_SInt,
+
+    // 16 bit packed formats
+    kUnityRenderingExtFormatR4G4B4A4_UNormPack16,
+    kUnityRenderingExtFormatB4G4R4A4_UNormPack16,
+    kUnityRenderingExtFormatR5G6B5_UNormPack16,
+    kUnityRenderingExtFormatB5G6R5_UNormPack16,
+    kUnityRenderingExtFormatR5G5B5A1_UNormPack16,
+    kUnityRenderingExtFormatB5G5R5A1_UNormPack16,
+    kUnityRenderingExtFormatA1R5G5B5_UNormPack16,
+
+    // Packed formats
+    kUnityRenderingExtFormatE5B9G9R9_UFloatPack32,
+    kUnityRenderingExtFormatB10G11R11_UFloatPack32,
+
+    kUnityRenderingExtFormatA2B10G10R10_UNormPack32,
+    kUnityRenderingExtFormatA2B10G10R10_UIntPack32,
+    kUnityRenderingExtFormatA2B10G10R10_SIntPack32,
+    kUnityRenderingExtFormatA2R10G10B10_UNormPack32,
+    kUnityRenderingExtFormatA2R10G10B10_UIntPack32,
+    kUnityRenderingExtFormatA2R10G10B10_SIntPack32,
+    kUnityRenderingExtFormatA2R10G10B10_XRSRGBPack32,
+    kUnityRenderingExtFormatA2R10G10B10_XRUNormPack32,
+    kUnityRenderingExtFormatR10G10B10_XRSRGBPack32,
+    kUnityRenderingExtFormatR10G10B10_XRUNormPack32,
+    kUnityRenderingExtFormatA10R10G10B10_XRSRGBPack32,
+    kUnityRenderingExtFormatA10R10G10B10_XRUNormPack32,
+
+    // ARGB formats... TextureFormat legacy
+    kUnityRenderingExtFormatA8R8G8B8_SRGB,
+    kUnityRenderingExtFormatA8R8G8B8_UNorm,
+    kUnityRenderingExtFormatA32R32G32B32_SFloat,
+
+    // Depth Stencil for formats
+    kUnityRenderingExtFormatD16_UNorm,
+    kUnityRenderingExtFormatD24_UNorm,
+    kUnityRenderingExtFormatD24_UNorm_S8_UInt,
+    kUnityRenderingExtFormatD32_SFloat,
+    kUnityRenderingExtFormatD32_SFloat_S8_Uint,
+    kUnityRenderingExtFormatS8_Uint,
+
+    // Compression formats
+    kUnityRenderingExtFormatRGBA_DXT1_SRGB,
+    kUnityRenderingExtFormatRGBA_DXT1_UNorm,
+    kUnityRenderingExtFormatRGBA_DXT3_SRGB,
+    kUnityRenderingExtFormatRGBA_DXT3_UNorm,
+    kUnityRenderingExtFormatRGBA_DXT5_SRGB,
+    kUnityRenderingExtFormatRGBA_DXT5_UNorm,
+    kUnityRenderingExtFormatR_BC4_UNorm,
+    kUnityRenderingExtFormatR_BC4_SNorm,
+    kUnityRenderingExtFormatRG_BC5_UNorm,
+    kUnityRenderingExtFormatRG_BC5_SNorm,
+    kUnityRenderingExtFormatRGB_BC6H_UFloat,
+    kUnityRenderingExtFormatRGB_BC6H_SFloat,
+    kUnityRenderingExtFormatRGBA_BC7_SRGB,
+    kUnityRenderingExtFormatRGBA_BC7_UNorm,
+
+    kUnityRenderingExtFormatRGB_PVRTC_2Bpp_SRGB,
+    kUnityRenderingExtFormatRGB_PVRTC_2Bpp_UNorm,
+    kUnityRenderingExtFormatRGB_PVRTC_4Bpp_SRGB,
+    kUnityRenderingExtFormatRGB_PVRTC_4Bpp_UNorm,
+    kUnityRenderingExtFormatRGBA_PVRTC_2Bpp_SRGB,
+    kUnityRenderingExtFormatRGBA_PVRTC_2Bpp_UNorm,
+    kUnityRenderingExtFormatRGBA_PVRTC_4Bpp_SRGB,
+    kUnityRenderingExtFormatRGBA_PVRTC_4Bpp_UNorm,
+
+    kUnityRenderingExtFormatRGB_ETC_UNorm,
+    kUnityRenderingExtFormatRGB_ETC2_SRGB,
+    kUnityRenderingExtFormatRGB_ETC2_UNorm,
+    kUnityRenderingExtFormatRGB_A1_ETC2_SRGB,
+    kUnityRenderingExtFormatRGB_A1_ETC2_UNorm,
+    kUnityRenderingExtFormatRGBA_ETC2_SRGB,
+    kUnityRenderingExtFormatRGBA_ETC2_UNorm,
+
+    kUnityRenderingExtFormatR_EAC_UNorm,
+    kUnityRenderingExtFormatR_EAC_SNorm,
+    kUnityRenderingExtFormatRG_EAC_UNorm,
+    kUnityRenderingExtFormatRG_EAC_SNorm,
+
+    kUnityRenderingExtFormatRGBA_ASTC4X4_SRGB,
+    kUnityRenderingExtFormatRGBA_ASTC4X4_UNorm,
+    kUnityRenderingExtFormatRGBA_ASTC5X5_SRGB,
+    kUnityRenderingExtFormatRGBA_ASTC5X5_UNorm,
+    kUnityRenderingExtFormatRGBA_ASTC6X6_SRGB,
+    kUnityRenderingExtFormatRGBA_ASTC6X6_UNorm,
+    kUnityRenderingExtFormatRGBA_ASTC8X8_SRGB,
+    kUnityRenderingExtFormatRGBA_ASTC8X8_UNorm,
+    kUnityRenderingExtFormatRGBA_ASTC10X10_SRGB,
+    kUnityRenderingExtFormatRGBA_ASTC10X10_UNorm,
+    kUnityRenderingExtFormatRGBA_ASTC12X12_SRGB,
+    kUnityRenderingExtFormatRGBA_ASTC12X12_UNorm,
+
+    // Video formats
+    kUnityRenderingExtFormatYUV2,
+
+    // Automatic formats, back-end decides
+    kUnityRenderingExtFormatDepthAuto,
+    kUnityRenderingExtFormatShadowAuto,
+    kUnityRenderingExtFormatVideoAuto,
+
+    // ASTC hdr profile
+    kUnityRenderingExtFormatRGBA_ASTC4X4_UFloat,
+    kUnityRenderingExtFormatRGBA_ASTC5X5_UFloat,
+    kUnityRenderingExtFormatRGBA_ASTC6X6_UFloat,
+    kUnityRenderingExtFormatRGBA_ASTC8X8_UFloat,
+    kUnityRenderingExtFormatRGBA_ASTC10X10_UFloat,
+    kUnityRenderingExtFormatRGBA_ASTC12X12_UFloat,
+
+    kUnityRenderingExtFormatLast = kUnityRenderingExtFormatRGBA_ASTC12X12_UFloat, // Remove?
+} UnityRenderingExtTextureFormat;
+
+
+typedef struct UnityRenderingExtBeforeDrawCallParams
+{
+    void*   vertexShader;                           // bound vertex shader (platform dependent)
+    void*   fragmentShader;                         // bound fragment shader (platform dependent)
+    void*   geometryShader;                         // bound geometry shader (platform dependent)
+    void*   hullShader;                             // bound hull shader (platform dependent)
+    void*   domainShader;                           // bound domain shader (platform dependent)
+    int     eyeIndex;                               // the index of the current stereo "eye" being currently rendered.
+} UnityRenderingExtBeforeDrawCallParams;
+
+
+typedef struct UnityRenderingExtCustomBlitParams
+{
+    UnityTextureID source;                          // source texture
+    UnityRenderBuffer destination;                  // destination surface
+    unsigned int command;                           // command for the custom blit - could be any UnityRenderingExtCustomBlitCommands command or custom ones.
+    unsigned int commandParam;                      // custom parameters for the command
+    unsigned int commandFlags;                      // custom flags for the command
+} UnityRenderingExtCustomBlitParams;
+
+// Deprecated. Use UnityRenderingExtTextureUpdateParamsV2 and CommandBuffer.IssuePluginCustomTextureUpdateV2 instead.
+// Only supports DX11, GLES, Metal
+typedef struct UnityRenderingExtTextureUpdateParamsV1
+{
+    void*        texData;                           // source data for the texture update. Must be set by the plugin
+    unsigned int userData;                          // user defined data. Set by the plugin
+
+    unsigned int textureID;                         // texture ID of the texture to be updated.
+    UnityRenderingExtTextureFormat format;          // format of the texture to be updated
+    unsigned int width;                             // width of the texture
+    unsigned int height;                            // height of the texture
+    unsigned int bpp;                               // texture bytes per pixel.
+} UnityRenderingExtTextureUpdateParamsV1;
+
+// Deprecated. Use UnityRenderingExtTextureUpdateParamsV2 and CommandBuffer.IssuePluginCustomTextureUpdateV2 instead.
+// Only supports DX11, GLES, Metal
+typedef UnityRenderingExtTextureUpdateParamsV1 UnityRenderingExtTextureUpdateParams;
+
+// Type of the "data" parameter passed when callbacks registered with CommandBuffer.IssuePluginCustomTextureUpdateV2 are called.
+// Supports DX11, GLES, Metal, and Switch (also possibly PS4, PSVita in the future)
+typedef struct UnityRenderingExtTextureUpdateParamsV2
+{
+    void*        texData;                           // source data for the texture update. Must be set by the plugin
+    intptr_t     textureID;                         // texture ID of the texture to be updated.
+    unsigned int userData;                          // user defined data. Set by the plugin
+    UnityRenderingExtTextureFormat format;          // format of the texture to be updated
+    unsigned int width;                             // width of the texture
+    unsigned int height;                            // height of the texture
+    unsigned int bpp;                               // texture bytes per pixel.
+} UnityRenderingExtTextureUpdateParamsV2;
+
+
+// Certain Unity APIs (GL.IssuePluginEventAndData, CommandBuffer.IssuePluginEventAndData) can callback into native plugins.
+// Provide them with an address to a function of this signature.
+typedef void (UNITY_INTERFACE_API * UnityRenderingEventAndData)(int eventId, void* data);
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// If exported by a plugin, this function will be called for all the events in UnityRenderingExtEventType
+void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityRenderingExtEvent(UnityRenderingExtEventType event, void* data);
+// If exported by a plugin, this function will be called to query the plugin for the queries in UnityRenderingExtQueryType
+bool UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityRenderingExtQuery(UnityRenderingExtQueryType query);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Plugin~/unity/include/IUnityShaderCompilerAccess.h
+++ b/Plugin~/unity/include/IUnityShaderCompilerAccess.h
@@ -1,0 +1,210 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+
+
+#include "IUnityGraphics.h"
+
+
+/*
+    Low-level Native Plugin Shader Compiler Access
+    ==============================================
+
+    On top of the Low-level native plugin interface, Unity also supports low level access to the shader compiler, allowing the user to inject different variants into a shader.
+    It is also an event driven approach in which the plugin will receive callbacks when certain builtin events happen.
+*/
+
+
+enum UnityShaderCompilerExtCompilerPlatform
+{
+    kUnityShaderCompilerExtCompPlatformUnused0 = 0,
+    kUnityShaderCompilerExtCompPlatformUnused1,
+    kUnityShaderCompilerExtCompPlatformUnused2,
+    kUnityShaderCompilerExtCompPlatformUnused3,
+    kUnityShaderCompilerExtCompPlatformD3D11,           // Direct3D 11 (FL10.0 and up), compiled with MS D3DCompiler
+    kUnityShaderCompilerExtCompPlatformGLES20,          // OpenGL ES 2.0 / WebGL 1.0, compiled with MS D3DCompiler + HLSLcc
+    kUnityShaderCompilerExtCompPlatformUnused6,
+    kUnityShaderCompilerExtCompPlatformUnused7,
+    kUnityShaderCompilerExtCompPlatformUnused8,
+    kUnityShaderCompilerExtCompPlatformGLES3Plus,       // OpenGL ES 3.0+ / WebGL 2.0, compiled with MS D3DCompiler + HLSLcc
+    kUnityShaderCompilerExtCompPlatformUnused10,
+    kUnityShaderCompilerExtCompPlatformPS4,             // Sony PS4
+    kUnityShaderCompilerExtCompPlatformXboxOne,         // MS XboxOne
+    kUnityShaderCompilerExtCompPlatformUnused13,
+    kUnityShaderCompilerExtCompPlatformMetal,           // Apple Metal, compiled with MS D3DCompiler + HLSLcc
+    kUnityShaderCompilerExtCompPlatformOpenGLCore,      // Desktop OpenGL 3+, compiled with MS D3DCompiler + HLSLcc
+    kUnityShaderCompilerExtCompPlatformUnused16,
+    kUnityShaderCompilerExtCompPlatformUnused17,
+    kUnityShaderCompilerExtCompPlatformVulkan,          // Vulkan SPIR-V, compiled with MS D3DCompiler + HLSLcc
+    kUnityShaderCompilerExtCompPlatformSwitch,          // Nintendo Switch (NVN)
+    kUnityShaderCompilerExtCompPlatformXboxOneD3D12,    // Xbox One D3D12
+    kUnityShaderCompilerExtCompPlatformCount
+};
+
+
+enum UnityShaderCompilerExtShaderType
+{
+    kUnityShaderCompilerExtShaderNone = 0,
+    kUnityShaderCompilerExtShaderVertex = 1,
+    kUnityShaderCompilerExtShaderFragment = 2,
+    kUnityShaderCompilerExtShaderGeometry = 3,
+    kUnityShaderCompilerExtShaderHull = 4,
+    kUnityShaderCompilerExtShaderDomain = 5,
+    kUnityShaderCompilerExtShaderRayTracing = 6,
+    kUnityShaderCompilerExtShaderTypeCount // keep this last!
+};
+
+
+enum UnityShaderCompilerExtGPUProgramType
+{
+    kUnityShaderCompilerExtGPUProgramTargetUnknown = 0,
+
+    kUnityShaderCompilerExtGPUProgramTargetGLLegacy = 1, // removed
+    kUnityShaderCompilerExtGPUProgramTargetGLES31AEP = 2,
+    kUnityShaderCompilerExtGPUProgramTargetGLES31 = 3,
+    kUnityShaderCompilerExtGPUProgramTargetGLES3 = 4,
+    kUnityShaderCompilerExtGPUProgramTargetGLES = 5,
+    kUnityShaderCompilerExtGPUProgramTargetGLCore32 = 6,
+    kUnityShaderCompilerExtGPUProgramTargetGLCore41 = 7,
+    kUnityShaderCompilerExtGPUProgramTargetGLCore43 = 8,
+    kUnityShaderCompilerExtGPUProgramTargetDX9VertexSM20 = 9, // removed
+    kUnityShaderCompilerExtGPUProgramTargetDX9VertexSM30 = 10, // removed
+    kUnityShaderCompilerExtGPUProgramTargetDX9PixelSM20 = 11, // removed
+    kUnityShaderCompilerExtGPUProgramTargetDX9PixelSM30 = 12, // removed
+    kUnityShaderCompilerExtGPUProgramTargetDX10Level9Vertex = 13,
+    kUnityShaderCompilerExtGPUProgramTargetDX10Level9Pixel = 14,
+    kUnityShaderCompilerExtGPUProgramTargetDX11VertexSM40 = 15,
+    kUnityShaderCompilerExtGPUProgramTargetDX11VertexSM50 = 16,
+    kUnityShaderCompilerExtGPUProgramTargetDX11PixelSM40 = 17,
+    kUnityShaderCompilerExtGPUProgramTargetDX11PixelSM50 = 18,
+    kUnityShaderCompilerExtGPUProgramTargetDX11GeometrySM40 = 19,
+    kUnityShaderCompilerExtGPUProgramTargetDX11GeometrySM50 = 20,
+    kUnityShaderCompilerExtGPUProgramTargetDX11HullSM50 = 21,
+    kUnityShaderCompilerExtGPUProgramTargetDX11DomainSM50 = 22,
+    kUnityShaderCompilerExtGPUProgramTargetMetalVS = 23,
+    kUnityShaderCompilerExtGPUProgramTargetMetalFS = 24,
+    kUnityShaderCompilerExtGPUProgramTargetSPIRV = 25,
+    kUnityShaderCompilerExtGPUProgramTargetUnused1 = 26,
+    kUnityShaderCompilerExtGPUProgramTargetUnused2 = 27,
+    kUnityShaderCompilerExtGPUProgramTargetUnused3 = 28,
+    kUnityShaderCompilerExtGPUProgramTargetUnused4 = 29,
+    kUnityShaderCompilerExtGPUProgramTargetUnused5 = 30,
+    kUnityShaderCompilerExtGPUProgramTargetRayTracing = 31,
+
+    kUnityShaderCompilerExtGPUProgramTargetCount
+};
+
+
+enum UnityShaderCompilerExtGPUProgram
+{
+    kUnityShaderCompilerExtGPUProgramVS = 1 << kUnityShaderCompilerExtShaderVertex,
+    kUnityShaderCompilerExtGPUProgramPS = 1 << kUnityShaderCompilerExtShaderFragment,
+    kUnityShaderCompilerExtGPUProgramGS = 1 << kUnityShaderCompilerExtShaderGeometry,
+    kUnityShaderCompilerExtGPUProgramHS = 1 << kUnityShaderCompilerExtShaderHull,
+    kUnityShaderCompilerExtGPUProgramDS = 1 << kUnityShaderCompilerExtShaderDomain,
+    kUnityShaderCompilerExtGPUProgramCustom = 1 << kUnityShaderCompilerExtShaderTypeCount
+};
+
+
+enum UnityShaderCompilerExtEventType
+{
+    kUnityShaderCompilerExtEventCreateCustomSourceVariant,          // The plugin can create a new variant based on the initial snippet. The callback will receive UnityShaderCompilerExtCustomSourceVariantParams as data.
+    kUnityShaderCompilerExtEventCreateCustomSourceVariantCleanup,   // Typically received after the kUnityShaderCompilerExtEventCreateCustomVariant event so the plugin has a chance to cleanup after itself. (outputSnippet & outputKeyword)
+
+    kUnityShaderCompilerExtEventCreateCustomBinaryVariant,          // The plugin can create a new variant based on the initial snippet. The callback will receive UnityShaderCompilerExtCustomBinaryVariantParams as data.
+    kUnityShaderCompilerExtEventCreateCustomBinaryVariantCleanup,   // Typically received after the kUnityShaderCompilerExtEventCreateCustomVariant event so the plugin has a chance to cleanup after itself. (outputSnippet & outputKeyword)
+    kUnityShaderCompilerExtEventPluginConfigure,                    // Event sent so the plugin can configure itself. It receives IUnityShaderCompilerExtPluginConfigure* as data
+
+    // keep these last
+    kUnityShaderCompilerExtEventCount,
+    kUnityShaderCompilerExtUserEventsStart = kUnityShaderCompilerExtEventCount
+};
+
+
+struct UnityShaderCompilerExtCustomSourceVariantParams
+{
+    char* outputSnippet;                                    // snippet after the plugin has finished processing it.
+    char* outputKeywords;                                   // keywords exported by the plugin for this specific variant
+    const char* inputSnippet;                               // the source shader snippet
+    bool vr;                                                // is VR enabled / supported ?
+    UnityShaderCompilerExtCompilerPlatform platform;        // compiler platform
+    UnityShaderCompilerExtShaderType shaderType;            // source code type
+};
+
+
+struct UnityShaderCompilerExtCustomBinaryVariantParams
+{
+    void**  outputBinaryShader;                             // output of the plugin generated binary shader (platform dependent)
+    const unsigned char* inputByteCode;                     // the shader byteCode (platform dependent)
+    unsigned int inputByteCodeSize;                         // shader bytecode size
+    unsigned int programTypeMask;                           // a mask of UnityShaderCompilerExtGPUProgram values
+    UnityShaderCompilerExtCompilerPlatform platform;        // compiler platform
+};
+
+
+/*
+    This class is queried by unity to get information about the plugin.
+    The plugin has to set all the relevant values during the kUnityShaderCompilerExtEventPluginConfigure event.
+
+    <code>
+
+        extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API
+        UnityShaderCompilerExtEvent(UnityShaderCompilerExtEventType event, void* data)
+        {
+            switch (event)
+            {
+
+                ...
+
+                case kUnityShaderCompilerExtEventPluginConfigure:
+                {
+                    unsigned int GPUCompilerMask = (1 << kUnityShaderCompilerExtGPUProgramTargetDX11VertexSM40)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11VertexSM50)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11PixelSM40)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11PixelSM50)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11GeometrySM40)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11GeometrySM50)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11HullSM50)
+                    | (1 << kUnityShaderCompilerExtGPUProgramTargetDX11DomainSM50);
+
+                    unsigned int ShaderMask = kUnityShaderCompilerExtGPUProgramVS | kUnityShaderCompilerExtGPUProgramDS;
+
+                    IUnityShaderCompilerExtPluginConfigure* pluginConfig = (IUnityShaderCompilerExtPluginConfigure*)data;
+                    pluginConfig->ReserveKeyword(SHADER_KEYWORDS);
+                    pluginConfig->SetGPUProgramCompilerMask(GPUCompilerMask);
+                    pluginConfig->SetShaderProgramMask(ShaderMask);
+                    break;
+                }
+            }
+        }
+
+    </code>
+*/
+
+class IUnityShaderCompilerExtPluginConfigure
+{
+public:
+    virtual ~IUnityShaderCompilerExtPluginConfigure() {}
+    virtual void ReserveKeyword(const char* keyword) = 0;           // Allow the plugin to reserve its keyword so unity can include it in calculating the variants
+    virtual void SetGPUProgramCompilerMask(unsigned int mask) = 0;  // Specifies a bit mask of UnityShaderCompilerExtGPUProgramType programs the plugin supports compiling
+    virtual void SetShaderProgramMask(unsigned int mask) = 0;       // Specifies a bit mask of UnityShaderCompilerExtGPUProgram programs the plugin supports compiling
+};
+
+
+// Interface to help setup / configure both unity and the plugin.
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// If exported by a plugin, this function will be called for all the events in UnityShaderCompilerExtEventType
+void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityShaderCompilerExtEvent(UnityShaderCompilerExtEventType event, void* data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Plugin~/unity/include/LICENSE.md
+++ b/Plugin~/unity/include/LICENSE.md
@@ -1,0 +1,5 @@
+Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+
+Licensed under the Unity Companion License for Unity-dependent projects--see [Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+
+Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.


### PR DESCRIPTION
### Note
This is experimental feature. 
It works only Unity 2020, not work 2019.4LTS.

### Changes
This changes can shows the duration of encoding process on timeline in the profiler window.
![image](https://user-images.githubusercontent.com/1132081/88748332-bd037080-d18b-11ea-96fe-943a0b4b60fa.png)
