### PR TITLE
fix: delete entry point about codec initialization result

### DIFF
--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -57,11 +57,6 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
-        public CodecInitializationResult GetCodecInitializationResult()
-        {
-            return NativeMethods.ContextGetCodecInitializationResult(self);
-        }
-
         public EncoderType GetEncoderType()
         {
             return NativeMethods.ContextGetEncoderType(self);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -407,7 +407,7 @@ namespace Unity.WebRTC
         /// This property will be removed next major version up.
         /// </summary>
         /// <exception cref="NotImplementedException"></exception>
-        [Obsolete]
+        [Obsolete("Use 'VideoStreamTrack.IsInitialized' instead.", true)]
         public static CodecInitializationResult CodecInitializationResult
         {
             get

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -401,6 +401,21 @@ namespace Unity.WebRTC
             }
         }
 
+        /// <summary>
+        /// Not implement this property.
+        /// Please check each track about initialization. (VideoStreamTrack.IsInitialized)
+        /// This property will be removed next major version up.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        [Obsolete]
+        public static CodecInitializationResult CodecInitializationResult
+        {
+            get
+            {
+                throw new NotImplementedException("This property is obsoleted. Please use VideoStreamTrack.IsInitialized instead of this");
+            }
+        }
+
         public static IReadOnlyList<RTCPeerConnection> PeerList
         {
             get

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -401,19 +401,6 @@ namespace Unity.WebRTC
             }
         }
 
-        public static CodecInitializationResult CodecInitializationResult
-        {
-            get
-            {
-                if (s_context.IsNull)
-                {
-                    return CodecInitializationResult.NotInitialized;
-                }
-                var result = Context.GetCodecInitializationResult();
-                return result;
-            }
-        }
-
         public static IReadOnlyList<RTCPeerConnection> PeerList
         {
             get
@@ -475,8 +462,6 @@ namespace Unity.WebRTC
 
     internal static class NativeMethods
     {
-        [DllImport(WebRTC.Lib)]
-        public static extern CodecInitializationResult ContextGetCodecInitializationResult(IntPtr context);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool GetHardwareEncoderSupport();


### PR DESCRIPTION
Forum issue: https://forum.unity.com/threads/unity-render-streaming-introduction-faq.742481/page-9#post-6172726

The EntryPoint has already been removed from the library.
Now that we are supporting multi-track, we need to check initialization each track.