### PR TITLE
fix: Add RTCDataChannel API to fix the behaviour of the "Send" method

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -224,7 +224,10 @@ namespace webrtc
         }
         if (nvEncInitializeParams.frameRateNum != m_frameRate)
         {
-            nvEncInitializeParams.frameRateNum = m_frameRate;
+            // nvcodec do not allow a framerate over 240
+            const uint32_t kMaxFramerate = 240;
+            uint32_t targetFramerate = std::min(m_frameRate, kMaxFramerate);
+            nvEncInitializeParams.frameRateNum = targetFramerate;
             settingChanged = true;
         }
 
@@ -234,7 +237,8 @@ namespace webrtc
             std::memcpy(&nvEncReconfigureParams.reInitEncodeParams, &nvEncInitializeParams, sizeof(nvEncInitializeParams));
             nvEncReconfigureParams.version = NV_ENC_RECONFIGURE_PARAMS_VER;
             errorCode = pNvEncodeAPI->nvEncReconfigureEncoder(pEncoderInterface, &nvEncReconfigureParams);
-            checkf(NV_RESULT(errorCode), StringFormat("Failed to reconfigure encoder setting %d %d %d", errorCode, m_targetBitrate, m_frameRate).c_str());
+            checkf(NV_RESULT(errorCode), StringFormat("Failed to reconfigure encoder setting %d %d %d",
+                errorCode, nvEncInitializeParams.frameRateNum, nvEncConfig.rcParams.averageBitRate).c_str());
         }
     }
 

--- a/Plugin~/WebRTCPlugin/DataChannelObject.h
+++ b/Plugin~/WebRTCPlugin/DataChannelObject.h
@@ -35,6 +35,12 @@ namespace webrtc
         {
             dataChannel->Send(webrtc::DataBuffer(std::string(data)));
         }
+
+        webrtc::DataChannelInterface::DataState GetReadyState() const
+        {
+            return dataChannel->state();
+        }
+
         void Send(const byte* data, int len)
         {
             rtc::CopyOnWriteBuffer buf(data, len);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -730,6 +730,12 @@ extern "C"
         return ConvertString(dataChannelObj->GetLabel());
     }
 
+    UNITY_INTERFACE_EXPORT DataChannelInterface::DataState DataChannelGetReadyState(
+        DataChannelObject* dataChannelObj)
+    {
+        return dataChannelObj->GetReadyState();
+    }
+
     UNITY_INTERFACE_EXPORT void DataChannelSend(DataChannelObject* dataChannelObj, const char* msg)
     {
         dataChannelObj->Send(msg);

--- a/Runtime/Scripts/RTCDataChannel.cs
+++ b/Runtime/Scripts/RTCDataChannel.cs
@@ -49,7 +49,21 @@ namespace Unity.WebRTC
         {
             get => NativeMethods.DataChannelGetID(self);
         }
+
         public string Label { get; private set; }
+
+        /// <summary>
+        /// The property returns an enum of the <c>RTCDataChannelState</c> which shows 
+        /// the state of the channel.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Send(string)"/> method must be called when the state is <b>Open</b>.
+        /// </remarks>
+        /// <seealso cref="RTCDataChannelState"/>
+        public RTCDataChannelState ReadyState
+        {
+            get => NativeMethods.DataChannelGetReadyState(self);
+        }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeOnMessage))]
         static void DataChannelNativeOnMessage(IntPtr ptr, byte[] msg, int len)
@@ -120,13 +134,39 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// The method Sends data across the data channel to the remote peer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The method throws <c>InvalidOperationException</c> when <see cref="ReadyState"/>
+        ///  is not <b>Open</b>.
+        /// </exception>
+        /// <param name="msg"></param>
+        /// <seealso cref="ReadyState"/>
         public void Send(string msg)
         {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
             NativeMethods.DataChannelSend(self, msg);
         }
 
+        /// <summary>
+        /// The method Sends data across the data channel to the remote peer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The method throws <c>InvalidOperationException</c> when <see cref="ReadyState"/>
+        ///  is not <b>Open</b>.
+        /// </exception>
+        /// <param name="msg"></param>
+        /// <seealso cref="ReadyState"/>
         public void Send(byte[] msg)
         {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
             NativeMethods.DataChannelSendBinary(self, msg, msg.Length);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -148,6 +148,14 @@ namespace Unity.WebRTC
         BundlePolicyMaxCompat
     }
 
+    public enum RTCDataChannelState
+    {
+        Connecting,
+        Open,
+        Closing,
+        Closed
+    }
+
     public struct RTCSessionDescription
     {
         public RTCSdpType type;
@@ -609,6 +617,8 @@ namespace Unity.WebRTC
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr DataChannelGetLabel(IntPtr ptr);
+        [DllImport(WebRTC.Lib)]
+        public static extern RTCDataChannelState DataChannelGetReadyState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern void DataChannelSend(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr)]string msg);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
@@ -47,6 +48,26 @@ namespace Unity.WebRTC.RuntimeTest
             RTCDataChannelInit option1 = default;
             Assert.Throws<System.ArgumentException>(() => peer.CreateDataChannel("test1", ref option1));
             peer.Close();
+        }
+
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator SendMessageThrowExceptionAfterCloseDataChannel()
+        {
+            var test = new MonoBehaviourTest<SignalingPeers>();
+            yield return test;
+            RTCDataChannel channel = test.component.AddDataChannel(0);
+            byte[] message1 = { 1, 2, 3 };
+            string message2 = "123";
+
+            Assert.DoesNotThrow(() => channel.Send(message1));
+            Assert.DoesNotThrow(() => channel.Send(message2));
+            channel.Close();
+            Assert.Throws<InvalidOperationException>(() => channel.Send(message1));
+            Assert.Throws<InvalidOperationException>(() => channel.Send(message2));
+
+            test.component.Dispose();
+            yield return 0;
         }
 
         [UnityTest]

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -20,6 +20,12 @@ namespace Unity.WebRTC.RuntimeTest
             m_stream = stream;
         }
 
+        public RTCDataChannel AddDataChannel(int indexPeer)
+        {
+            var option = new RTCDataChannelInit(true);
+            return peers[indexPeer].CreateDataChannel("test1", ref option);
+        }
+
         public RTCStatsReportAsyncOperation GetPeerStats(int indexPeer)
         {
             return peers[indexPeer].GetStats();
@@ -84,9 +90,12 @@ namespace Unity.WebRTC.RuntimeTest
                 peers[1].AddTrack(e.Track);
             };
 
-            foreach (var track in m_stream.GetTracks())
+            if (m_stream != null)
             {
-                peers[0].AddTrack(track, m_stream);
+                foreach (var track in m_stream.GetTracks())
+                {
+                    peers[0].AddTrack(track, m_stream);
+                }
             }
 
             RTCOfferOptions options1 = default;
@@ -124,9 +133,12 @@ namespace Unity.WebRTC.RuntimeTest
             yield return op8;
             Assert.True(op8.IsCompleted);
 
-            var op9 = new WaitUntilWithTimeout(() => GetPeerSenders(0).Any(), 5000);
-            yield return op9;
-            Assert.True(op9.IsCompleted);
+            if (m_stream != null)
+            {
+                var op9 = new WaitUntilWithTimeout(() => GetPeerSenders(0).Any(), 5000);
+                yield return op9;
+                Assert.True(op9.IsCompleted);
+            }
 
             IsTestFinished = true;
         }


### PR DESCRIPTION
Related issue #167 .

### Problem 

`RTCDataChannel.Send` method must be called when `RTCDataChannel.ReadyState` is **Open**, but this state had not checked until now.

### Fix

For fixing the issue, the new property `RTCDataChannel.ReadyState` is implemented and published.