### PR TITLE
chore: fix rtcerror message handling

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -62,7 +62,7 @@ namespace webrtc
         //RTCError _error = { RTCErrorDetailType::IdpTimeout };
         if (onCreateSDFailure != nullptr)
         {
-            onCreateSDFailure(this);
+            onCreateSDFailure(this, error.type(), error.message());
         }
     }
 

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -9,7 +9,7 @@ namespace webrtc
 {
 
     using DelegateCreateSDSuccess = void(*)(PeerConnectionObject*, RTCSdpType, const char*);
-    using DelegateCreateSDFailure = void(*)(PeerConnectionObject*);
+    using DelegateCreateSDFailure = void(*)(PeerConnectionObject*, webrtc::RTCErrorType, const char*);
     using DelegateLocalSdpReady = void(*)(PeerConnectionObject*, const char*, const char*);
     using DelegateIceCandidate = void(*)(PeerConnectionObject*, const char*, const char*, const int);
     using DelegateOnIceConnectionChange = void(*)(PeerConnectionObject*, webrtc::PeerConnectionInterface::IceConnectionState);

--- a/Plugin~/WebRTCPlugin/SetSessionDescriptionObserver.cpp
+++ b/Plugin~/WebRTCPlugin/SetSessionDescriptionObserver.cpp
@@ -39,7 +39,7 @@ namespace webrtc
     {
         for (auto delegate : m_vectorDelegateSetSDFailure)
         {
-            delegate(m_connection, error);
+            delegate(m_connection, error.type(), error.message());
         }
     }
     

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -11,7 +11,6 @@ namespace webrtc
     class PeerConnectionObject;
     enum class RTCSdpType;
     enum class RTCPeerConnectionEventType;
-    struct RTCError;
     struct MediaStreamEvent;
 
     using DelegateDebugLog = void(*)(const char*);
@@ -19,7 +18,7 @@ namespace webrtc
     using DelegateMediaStreamOnAddTrack = void(*)(webrtc::MediaStreamInterface*, webrtc::MediaStreamTrackInterface*);
     using DelegateMediaStreamOnRemoveTrack = void(*)(webrtc::MediaStreamInterface*, webrtc::MediaStreamTrackInterface*);
     using DelegateSetSessionDescSuccess = void(*)(PeerConnectionObject*);
-    using DelegateSetSessionDescFailure = void(*)(PeerConnectionObject*, webrtc::RTCError);
+    using DelegateSetSessionDescFailure = void(*)(PeerConnectionObject*, webrtc::RTCErrorType, const char*);
 
     void debugLog(const char* buf);
     void SetResolution(int32* width, int32* length);
@@ -110,15 +109,6 @@ namespace webrtc
         Video
     };
 
-    struct RTCError
-    {
-        RTCErrorDetailType errorDetail;
-        long sdpLineNumber;
-        long httpRequestStatusCode;
-        long sctpCauseCode;
-        unsigned long receivedAlert;
-        unsigned long sentAlert;
-    };
 
     struct RTCSessionDescription
     {

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -205,7 +205,7 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
-        /// <seealso cref="RTCIceCandidate​"/>
+        /// <seealso cref="RTCIceCandidate"/>
         public DelegateOnIceCandidate OnIceCandidate
         {
             private get => onIceCandidate;
@@ -556,13 +556,14 @@ namespace Unity.WebRTC
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateCreateSDFailure))]
-        static void OnFailureCreateSessionDesc(IntPtr ptr)
+        static void OnFailureCreateSessionDesc(IntPtr ptr, RTCErrorType type, string message)
         {
             WebRTC.Sync(ptr, () =>
             {
                 if (WebRTC.Table[ptr] is RTCPeerConnection connection)
                 {
                     connection.m_opSessionDesc.IsError = true;
+                    connection.m_opSessionDesc.Error = new RTCError{errorType = type, message = message};
                     connection.m_opSessionDesc.Done();
                 }
             });

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -738,12 +738,13 @@ namespace Unity.WebRTC
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativePeerConnectionSetSessionDescFailure))]
-        static void OnSetSessionDescFailure(IntPtr ptr, RTCError error)
+        static void OnSetSessionDescFailure(IntPtr ptr, RTCErrorType type, string message)
         {
             WebRTC.Sync(ptr, () =>
             {
                 if (WebRTC.Table[ptr] is RTCPeerConnection connection)
                 {
+                    RTCError error = new RTCError { errorType = type, message = message };
                     connection.OnSetSessionDescriptionFailure(error);
                 }
             });

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -72,9 +72,10 @@ namespace Unity.WebRTC
     public struct RTCError
     {
         public int errorType;
-        public string message;
-        public long errorDetailType;
-        public long sctpCauseCode;
+        public IntPtr messagePtr;
+        public int errorDetailType;
+        public ushort sctpCauseCode;
+        public string message => messagePtr.AsAnsiStringWithFreeMem();
     }
 
     public enum RTCPeerConnectionState

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -71,11 +71,8 @@ namespace Unity.WebRTC
 
     public struct RTCError
     {
-        public int errorType;
-        public IntPtr messagePtr;
-        public int errorDetailType;
-        public ushort sctpCauseCode;
-        public string message => messagePtr.AsAnsiStringWithFreeMem();
+        public RTCErrorType errorType;
+        public string message;
     }
 
     public enum RTCPeerConnectionState
@@ -122,7 +119,8 @@ namespace Unity.WebRTC
         InvalidModification,
         NetworkError,
         ResourceExhausted,
-        InternalError
+        InternalError,
+        OperationErrorWithData
     }
 
     public enum RTCPeerConnectionEventType
@@ -461,7 +459,7 @@ namespace Unity.WebRTC
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativePeerConnectionSetSessionDescSuccess(IntPtr ptr);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void DelegateNativePeerConnectionSetSessionDescFailure(IntPtr ptr, RTCError error);
+    internal delegate void DelegateNativePeerConnectionSetSessionDescFailure(IntPtr ptr, RTCErrorType type, [MarshalAs(UnmanagedType.LPStr)] string message);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnIceConnectionChange(IntPtr ptr, RTCIceConnectionState state);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -455,7 +455,7 @@ namespace Unity.WebRTC
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateCreateGetStats(IntPtr ptr, RTCSdpType type, [MarshalAs(UnmanagedType.LPStr)] string sdp);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void DelegateCreateSDFailure(IntPtr ptr);
+    internal delegate void DelegateCreateSDFailure(IntPtr ptr, RTCErrorType type, [MarshalAs(UnmanagedType.LPStr)] string message);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativePeerConnectionSetSessionDescSuccess(IntPtr ptr);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -85,7 +85,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativePeerConnectionSetSessionDescFailure))]
-        static void PeerConnectionSetSessionDescFailure(IntPtr connection, RTCError error)
+        static void PeerConnectionSetSessionDescFailure(IntPtr connection, RTCErrorType type, string message)
         {
         }
 


### PR DESCRIPTION
Changed to use primitive elements instead of RTCError.
I was going to take it as Struct, but it didn't work out...