### PR TITLE
feat: add "minBitrate" parameter to RTCRtpEncodingParameters class

### DIFF
--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
@@ -134,8 +134,7 @@ namespace webrtc
     {
         int64_t frameRate = parameters.framerate_fps;
 
-        m_bitrateAdjuster->SetTargetBitrateBps(parameters.bitrate.get_sum_bps());
-        uint32_t bitRate = m_bitrateAdjuster->GetAdjustedBitrateBps();
+        uint32_t bitRate = parameters.bitrate.get_sum_bps();
 
         m_setRates(m_encoderId, bitRate, frameRate);
     }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -659,6 +659,8 @@ extern "C"
         bool active;
         bool hasValueMaxBitrate;
         uint64_t maxBitrate;
+        bool hasValueMinBitrate;
+        uint64_t minBitrate;
         bool hasValueMaxFramerate;
         uint32_t maxFramerate;
         bool hasValueScaleResolutionDownBy;
@@ -685,6 +687,8 @@ extern "C"
             dst->encodings[i].active = src.encodings[i].active;
             dst->encodings[i].hasValueMaxBitrate = src.encodings[i].max_bitrate_bps.has_value();
             dst->encodings[i].maxBitrate = src.encodings[i].max_bitrate_bps.value_or(0);
+            dst->encodings[i].hasValueMinBitrate = src.encodings[i].min_bitrate_bps.has_value();
+            dst->encodings[i].minBitrate = src.encodings[i].min_bitrate_bps.value_or(0);
             dst->encodings[i].hasValueMaxFramerate = src.encodings[i].max_framerate.has_value();
             dst->encodings[i].maxFramerate = src.encodings[i].max_framerate.value_or(0);
             dst->encodings[i].hasValueScaleResolutionDownBy = src.encodings[i].scale_resolution_down_by.has_value();
@@ -704,6 +708,8 @@ extern "C"
             dst.encodings[i].active = src->encodings[i].active;
             if(src->encodings[i].hasValueMaxBitrate)
                 dst.encodings[i].max_bitrate_bps = static_cast<int>(src->encodings[i].maxBitrate);
+            if (src->encodings[i].hasValueMinBitrate)
+                dst.encodings[i].min_bitrate_bps = static_cast<int>(src->encodings[i].minBitrate);
             if (src->encodings[i].hasValueMaxFramerate)
                 dst.encodings[i].max_framerate = static_cast<int>(src->encodings[i].maxFramerate);
             if (src->encodings[i].hasValueScaleResolutionDownBy)

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -8,6 +8,7 @@ namespace Unity.WebRTC
     {
         public bool active;
         public ulong? maxBitrate;
+        public ulong? minBitrate;
         public uint? maxFramerate;
         public double? scaleResolutionDownBy;
         public string rid;
@@ -17,6 +18,8 @@ namespace Unity.WebRTC
             active = parameter.active;
             if (parameter.hasValueMaxBitrate)
                 maxBitrate = parameter.maxBitrate;
+            if (parameter.hasValueMinBitrate)
+                minBitrate = parameter.minBitrate;
             if (parameter.hasValueMaxFramerate)
                 maxFramerate = parameter.maxFramerate;
             if (parameter.hasValueScaleResolutionDownBy)
@@ -31,6 +34,9 @@ namespace Unity.WebRTC
             instance.hasValueMaxBitrate = maxBitrate.HasValue;
             if(maxBitrate.HasValue)
                 instance.maxBitrate = maxBitrate.Value;
+            instance.hasValueMinBitrate = minBitrate.HasValue;
+            if (minBitrate.HasValue)
+                instance.minBitrate = minBitrate.Value;
             instance.hasValueMaxFramerate = maxFramerate.HasValue;
             if (maxFramerate.HasValue)
                 instance.maxFramerate = maxFramerate.Value;
@@ -100,6 +106,9 @@ namespace Unity.WebRTC
         [MarshalAs(UnmanagedType.U1)]
         public bool hasValueMaxBitrate;
         public ulong maxBitrate;
+        [MarshalAs(UnmanagedType.U1)]
+        public bool hasValueMinBitrate;
+        public ulong minBitrate;
         [MarshalAs(UnmanagedType.U1)]
         public bool hasValueMaxFramerate;
         public uint maxFramerate;

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -293,6 +293,8 @@ namespace Unity.WebRTC.RuntimeTest
                 encodings[i].active = true;
                 encodings[i].hasValueMaxBitrate = true;
                 encodings[i].maxBitrate = 10000000;
+                encodings[i].hasValueMinBitrate = true;
+                encodings[i].minBitrate = 10000000;
                 encodings[i].hasValueMaxFramerate = true;
                 encodings[i].maxFramerate = 30;
                 encodings[i].hasValueScaleResolutionDownBy = true;

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -105,6 +105,16 @@ namespace Unity.WebRTC.RuntimeTest
 
             RTCRtpSendParameters parameters = sender.GetParameters();
             Assert.NotNull(parameters);
+            Assert.NotNull(parameters.Encodings);
+            foreach (var encoding in parameters.Encodings)
+            {
+                Assert.True(encoding.active);
+                Assert.Null(encoding.maxBitrate);
+                Assert.Null(encoding.minBitrate);
+                Assert.Null(encoding.maxFramerate);
+                Assert.Null(encoding.scaleResolutionDownBy);
+                Assert.IsNotEmpty(encoding.rid);
+            }
             Assert.IsNotEmpty(parameters.TransactionId);
             Assert.AreEqual(1, peer.GetTransceivers().Count());
             Assert.NotNull(peer.GetTransceivers().First());


### PR DESCRIPTION
Related issue #191 .

This pull request adds a parameter `minBitrate` to `RTCRtpEncodingParameters` class to control a bitrate of video streaming more freely by user.
`RTCRtpEncodingParameters` class has already a parameter `maxBitrate` to control the bitrate, but this affects to the actual bitrate gradually. In contrast, `minBitrate` parameter affects the bitrate immediatelly.

### Using maxBitrate
![image](https://user-images.githubusercontent.com/1132081/94222535-9a41ce00-ff28-11ea-82b9-43cef08f9d91.png)

### Using minBitrate
![image](https://user-images.githubusercontent.com/1132081/94222549-a3329f80-ff28-11ea-9a55-2ed13d846fa9.png)

