### PR TITLE
fix: fixed crash when using debug build plugin

### DIFF
--- a/BuildScripts~/build_plugin.cmd
+++ b/BuildScripts~/build_plugin.cmd
@@ -16,18 +16,21 @@ cd %SOLUTION_DIR%
 git clone https://github.com/google/googletest.git
 cd googletest
 git checkout 2fe3bd994b3189899d93f1d5a881e725e046fdc2
-cmake . -G "Visual Studio 15 2017" -A x64 -B "build64"
+cmake . -G "Visual Studio 15 2017" -A x64 -B "build64" -DCMAKE_CXX_FLAGS_DEBUG="/MTd /Zi -D_ITERATOR_DEBUG_LEVEL=0"
 cmake --build build64 --config Release
+cmake --build build64 --config Debug
 mkdir include\gtest
 xcopy /e googletest\include\gtest include\gtest
 mkdir include\gmock
 xcopy /e googlemock\include\gmock include\gmock
 mkdir lib
 xcopy /e build64\googlemock\Release lib
+xcopy /e build64\googlemock\Debug lib
 xcopy /e build64\googlemock\gtest\Release lib
+xcopy /e build64\googlemock\gtest\Debug lib
 
 echo -------------------
-echo Build com.unity.webrtc Plugin 
+echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
 cmake . -G "Visual Studio 15 2017" -A x64 -B "build64"

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -22,9 +22,6 @@
 #endif
 
 #include "GraphicsDevice/IGraphicsDevice.h"
-#if defined(SUPPORT_METAL)
-#include "VideoToolbox/VTEncoderMetal.h"
-#endif
 
 namespace unity
 {

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -5,6 +5,8 @@
 #include "PeerConnectionObject.h"
 #include "Codec/IEncoder.h"
 
+using namespace ::webrtc;
+
 namespace unity
 {
 namespace webrtc
@@ -63,7 +65,7 @@ namespace webrtc
         void DeleteMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         void ProcessAudioData(const float* data, int32 size);
-
+        UnityVideoTrackSource* GetVideoSource(const MediaStreamTrackInterface* track);
 
         // PeerConnection
         PeerConnectionObject* CreatePeerConnection(const webrtc::PeerConnectionInterface::RTCConfiguration& config);
@@ -104,7 +106,6 @@ namespace webrtc
         std::list<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> m_mediaSteamTrackList;
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
         std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;
-        std::map<const webrtc::MediaStreamTrackInterface*, UnityVideoTrackSource*> m_mapVideoCapturer;
         std::map<const std::string, rtc::scoped_refptr<webrtc::MediaStreamInterface>> m_mapMediaStream;
         std::map<const webrtc::MediaStreamInterface*, std::unique_ptr<MediaStreamObserver>> m_mapMediaStreamObserver;
         std::map<const webrtc::PeerConnectionInterface*, rtc::scoped_refptr<SetSessionDescriptionObserver>> m_mapSetSessionDescriptionObserver;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -83,9 +83,12 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
 {
     if (s_context == nullptr)
         return;
-    std::lock_guard<std::mutex> lock(s_context->mutex);
-    if(!ContextManager::GetInstance()->Exists(s_context))
+    if (!ContextManager::GetInstance()->Exists(s_context))
         return;
+    std::unique_lock<std::mutex> lock(s_context->mutex, std::try_to_lock);
+    if(!lock.owns_lock()) {
+        return;
+    }
     const auto track = reinterpret_cast<::webrtc::MediaStreamTrackInterface*>(data);
     const auto event = static_cast<VideoStreamRenderEventID>(eventID);
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -69,7 +69,9 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnit
     if (s_UnityProfiler != nullptr)
     {
         s_IsDevelopmentBuild = s_UnityProfiler->IsAvailable() != 0;
-        s_UnityProfiler->CreateMarker(&s_MarkerEncode, "Encode", kUnityProfilerCategoryRender, kUnityProfilerMarkerFlagDefault, 0);
+        s_UnityProfiler->CreateMarker(
+            &s_MarkerEncode, "Encode", kUnityProfilerCategoryRender,
+            kUnityProfilerMarkerFlagDefault, 0);
     }
 
     OnGraphicsDeviceEvent(kUnityGfxDeviceEventInitialize);
@@ -86,11 +88,13 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
     if (!ContextManager::GetInstance()->Exists(s_context))
         return;
     std::unique_lock<std::mutex> lock(s_context->mutex, std::try_to_lock);
-    if(!lock.owns_lock()) {
+    if(!lock.owns_lock())
         return;
-    }
-    const auto track = reinterpret_cast<::webrtc::MediaStreamTrackInterface*>(data);
-    const auto event = static_cast<VideoStreamRenderEventID>(eventID);
+
+    MediaStreamTrackInterface* track =
+        static_cast<MediaStreamTrackInterface*>(data);
+    const VideoStreamRenderEventID event =
+        static_cast<VideoStreamRenderEventID>(eventID);
 
     switch(event)
     {
@@ -103,7 +107,8 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
             s_device = GraphicsDevice::GetInstance().GetDevice();
             const VideoEncoderParameter* param = s_context->GetEncoderParameter(track);
             const UnityEncoderType encoderType = s_context->GetEncoderType();
-            s_mapEncoder[track] = EncoderFactory::GetInstance().Init(param->width, param->height, s_device, encoderType);
+            s_mapEncoder[track] = EncoderFactory::GetInstance().Init(
+                param->width, param->height, s_device, encoderType);
             if (!s_context->InitializeEncoder(s_mapEncoder[track].get(), track))
             {
                 LogPrint("Encoder initialization faild.");

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -26,7 +26,7 @@ UnityVideoTrackSource::UnityVideoTrackSource(
 UnityVideoTrackSource::~UnityVideoTrackSource()
 {
     {
-        std::unique_lock<std::shared_mutex> lock(m_mutex);
+        std::unique_lock<std::mutex> lock(m_mutex);
     }
 };
 
@@ -62,7 +62,7 @@ void UnityVideoTrackSource::OnFrameCaptured()
 {
     // todo::(kazuki)
     // OnFrame(frame);
-    std::unique_lock<std::shared_mutex> lock(m_mutex, std::try_to_lock);
+    std::unique_lock<std::mutex> lock(m_mutex, std::try_to_lock);
     if (!lock.owns_lock()) {
         return;
     }

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -23,7 +23,12 @@ UnityVideoTrackSource::UnityVideoTrackSource(
 //  DETACH_FROM_THREAD(thread_checker_);
 }
 
-UnityVideoTrackSource::~UnityVideoTrackSource() = default;
+UnityVideoTrackSource::~UnityVideoTrackSource()
+{
+    {
+        std::unique_lock<std::shared_mutex> lock(m_mutex);
+    }
+};
 
 UnityVideoTrackSource::SourceState UnityVideoTrackSource::state() const
 {

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -1,5 +1,8 @@
 #include "pch.h"
 #include "UnityVideoTrackSource.h"
+
+#include <mutex>
+
 #include "Codec/IEncoder.h"
 
 namespace unity
@@ -54,7 +57,10 @@ void UnityVideoTrackSource::OnFrameCaptured()
 {
     // todo::(kazuki)
     // OnFrame(frame);
-
+    std::unique_lock<std::shared_mutex> lock(m_mutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return;
+    }
     if (encoder_ == nullptr)
     {
         LogPrint("encoder is null");

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <shared_mutex>
+#include <mutex>
 #include "Codec/IEncoder.h"
 #include "rtc_base/timestamp_aligner.h"
 
@@ -85,7 +85,7 @@ class UnityVideoTrackSource :
   const bool is_screencast_;
   const absl::optional<bool> needs_denoising_;
 
-  std::shared_mutex m_mutex;
+  std::mutex m_mutex;
   IEncoder* encoder_;
   void* frame_;
 };

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <shared_mutex>
 #include "Codec/IEncoder.h"
 #include "rtc_base/timestamp_aligner.h"
 
@@ -83,6 +84,8 @@ class UnityVideoTrackSource :
 
   const bool is_screencast_;
   const absl::optional<bool> needs_denoising_;
+
+  std::shared_mutex m_mutex;
   IEncoder* encoder_;
   void* frame_;
 };

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -18,6 +18,8 @@ file(GLOB sources
 # Apple/Unix specific source files
 if(MSVC)
   file(GLOB append_source
+    NvCodec/*.h
+    NvCodec/*.cpp
     ../WebRTCPlugin/GraphicsDevice/Vulkan/*.h
     ../WebRTCPlugin/GraphicsDevice/Vulkan/*.cpp
     ../WebRTCPlugin/GraphicsDevice/Vulkan/Cuda/*.h

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -1,8 +1,9 @@
 #include "pch.h"
-#include "../GraphicsDeviceTestBase.h"
-#include "../WebRTCPlugin/GraphicsDevice/ITexture2D.h"
-#include "../WebRTCPlugin/Codec/EncoderFactory.h"
-#include "../WebRTCPlugin/Codec/IEncoder.h"
+#include "GraphicsDeviceTestBase.h"
+#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/ITexture2D.h"
+#include "Codec/EncoderFactory.h"
+#include "Codec/IEncoder.h"
 
 namespace unity
 {
@@ -35,7 +36,7 @@ TEST_P(NvEncoderTest, CopyBuffer) {
     const auto width = 256;
     const auto height = 256;
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height));
-    const auto result = encoder_->CopyBuffer(tex->GetEncodeTexturePtrV());
+    const auto result = encoder_->CopyBuffer(tex->GetNativeTexturePtrV());
     EXPECT_TRUE(result);
 }
 


### PR DESCRIPTION
This pull request fixes bugs occurred when using debug build plugin.

- Add command to build `googletest` for debug
- Manage a list of references of `MediaStreamTrackInterface` to check the track whether disposed or not
- Add a mutex to `UnityVideoTrackSource` to avoid access from render thread after dispose it