### PR TITLE
Add a nullptr check for profiler in development build

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -188,13 +188,13 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         }
         case VideoStreamRenderEventID::Encode:
         {
-            if (s_IsDevelopmentBuild)
+            if (s_IsDevelopmentBuild && s_UnityProfiler != nullptr)
                 s_UnityProfiler->BeginSample(s_MarkerEncode);
             if(!s_context->EncodeFrame(track))
             {
                 // DebugLog("Encode frame failed");
             }
-            if (s_IsDevelopmentBuild)
+            if (s_IsDevelopmentBuild && s_UnityProfiler != nullptr)
                 s_UnityProfiler->EndSample(s_MarkerEncode);
 
             return;


### PR DESCRIPTION
When doing some testing on the native plugin I had closed the profiler and started getting null pointer exceptions.