### PR TITLE
Removes bitrate parameter from CameraExtension capture methods

### DIFF
--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -187,7 +187,7 @@ namespace Unity.WebRTC
 
     public static class CameraExtension
     {
-        public static VideoStreamTrack CaptureStreamTrack(this Camera cam, int width, int height, int bitrate,
+        public static VideoStreamTrack CaptureStreamTrack(this Camera cam, int width, int height,
             RenderTextureDepth depth = RenderTextureDepth.DEPTH_24)
         {
             switch (depth)
@@ -209,11 +209,11 @@ namespace Unity.WebRTC
         }
 
 
-        public static MediaStream CaptureStream(this Camera cam, int width, int height, int bitrate,
+        public static MediaStream CaptureStream(this Camera cam, int width, int height,
             RenderTextureDepth depth = RenderTextureDepth.DEPTH_24)
         {
             var stream = new MediaStream(WebRTC.Context.CreateMediaStream("videostream"));
-            var track = cam.CaptureStreamTrack(width, height, bitrate, depth);
+            var track = cam.CaptureStreamTrack(width, height, depth);
             stream.AddTrack(track);
             return stream;
         }


### PR DESCRIPTION
* The bitrate parameter is currently mandatory but is not used. It's also an unusual parameter to require at the application layer since the WebRTC plumbing typically employs a dynamic bit rate based on RTCP feedback.

* If it is intended to give the application a level of control over the encoder parameters it would probably make more sense to allow the frame rate to be set and/or employ an enum with values like "real-time", "best-quality" etc.