### PR TITLE
feat: Throw an exception when occurred error while setting a session description to a connection

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -151,30 +151,38 @@ namespace webrtc
         }
     }
 
-    void PeerConnectionObject::SetLocalDescription(const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer)
+    RTCErrorType PeerConnectionObject::SetLocalDescription(
+        const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer, char* error[])
     {
-        webrtc::SdpParseError error;
-        auto _desc = webrtc::CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error);
+        webrtc::SdpParseError error_;
+        auto _desc = webrtc::CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error_);
         if (!_desc.get())
         {
             DebugLog("Can't parse received session description message.");
-            DebugLog("SdpParseError:\n%s", error.description.c_str());
-            return;
+            DebugLog("SdpParseError:\n%s", error_.description.c_str());
+            *error = new char[error_.description.size()];
+            error_.description.copy(*error, error_.description.size());
+            return RTCErrorType::SYNTAX_ERROR;
         }
         connection->SetLocalDescription(observer, _desc.release());
+        return RTCErrorType::NONE;
     }
 
-    void PeerConnectionObject::SetRemoteDescription(const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer)
+    RTCErrorType PeerConnectionObject::SetRemoteDescription(
+        const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer, char* error[])
     {
-        webrtc::SdpParseError error;
-        auto _desc = webrtc::CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error);
+        webrtc::SdpParseError error_;
+        auto _desc = ::webrtc::CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error_);
         if (!_desc.get())
         {
             DebugLog("Can't parse received session description message.");
-            DebugLog("SdpParseError:\n%s", error.description.c_str());
-            return;
+            DebugLog("SdpParseError:\n%s", error_.description.c_str());
+            *error = new char[error_.description.size()];
+            error_.description.copy(*error, error_.description.size());
+            return RTCErrorType::SYNTAX_ERROR;
         }
         connection->SetRemoteDescription(observer, _desc.release());
+        return RTCErrorType::NONE;
     }
 
     webrtc::RTCErrorType PeerConnectionObject::SetConfiguration(const std::string& config)

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -154,14 +154,15 @@ namespace webrtc
     RTCErrorType PeerConnectionObject::SetLocalDescription(
         const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer, char* error[])
     {
-        webrtc::SdpParseError error_;
-        auto _desc = webrtc::CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error_);
+        SdpParseError error_;
+        std::unique_ptr<SessionDescriptionInterface> _desc =
+            CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error_);
         if (!_desc.get())
         {
             DebugLog("Can't parse received session description message.");
             DebugLog("SdpParseError:\n%s", error_.description.c_str());
-            *error = new char[error_.description.size()];
-            error_.description.copy(*error, error_.description.size());
+
+            *error = ConvertString(error_.description);
             return RTCErrorType::SYNTAX_ERROR;
         }
         connection->SetLocalDescription(observer, _desc.release());
@@ -171,14 +172,15 @@ namespace webrtc
     RTCErrorType PeerConnectionObject::SetRemoteDescription(
         const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer, char* error[])
     {
-        webrtc::SdpParseError error_;
-        auto _desc = ::webrtc::CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error_);
+        SdpParseError error_;
+        std::unique_ptr<SessionDescriptionInterface> _desc =
+            CreateSessionDescription(ConvertSdpType(desc.type), desc.sdp, &error_);
         if (!_desc.get())
         {
             DebugLog("Can't parse received session description message.");
             DebugLog("SdpParseError:\n%s", error_.description.c_str());
-            *error = new char[error_.description.size()];
-            error_.description.copy(*error, error_.description.size());
+
+            *error = ConvertString(error_.description);
             return RTCErrorType::SYNTAX_ERROR;
         }
         connection->SetRemoteDescription(observer, _desc.release());

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -3,6 +3,8 @@
 #include "DataChannelObject.h"
 #include "PeerConnectionStatsCollectorCallback.h"
 
+using namespace ::webrtc;
+
 namespace unity
 {
 namespace webrtc
@@ -26,9 +28,12 @@ namespace webrtc
         ~PeerConnectionObject();
 
         void Close();
-        void SetLocalDescription(const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer);
+        RTCErrorType SetLocalDescription(
+            const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer, char* error[]);
+        RTCErrorType SetRemoteDescription(
+            const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer, char* error[]);
+        
         bool GetSessionDescription(const webrtc::SessionDescriptionInterface* sdp, RTCSessionDescription& desc) const;
-        void SetRemoteDescription(const RTCSessionDescription& desc, webrtc::SetSessionDescriptionObserver* observer);
         webrtc::RTCErrorType SetConfiguration(const std::string& config);
         std::string GetConfiguration() const;
         void CreateOffer(const RTCOfferOptions& options);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -359,11 +359,6 @@ extern "C"
         return ConvertString(str);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionSetRemoteDescription(Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc)
-    {
-        obj->SetRemoteDescription(*desc, context->GetObserver(obj->connection));
-    }
-
     UNITY_INTERFACE_EXPORT void PeerConnectionGetStats(PeerConnectionObject* obj)
     {
         obj->connection->GetStats(PeerConnectionStatsCollectorCallback::Create(obj));
@@ -544,9 +539,16 @@ extern "C"
         return member->type();
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionSetLocalDescription(Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc)
+    UNITY_INTERFACE_EXPORT RTCErrorType PeerConnectionSetLocalDescription(
+        Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc, char* error[])
     {
-        obj->SetLocalDescription(*desc, context->GetObserver(obj->connection));
+        return obj->SetLocalDescription(*desc, context->GetObserver(obj->connection), error);
+    }
+    
+    UNITY_INTERFACE_EXPORT RTCErrorType PeerConnectionSetRemoteDescription(
+        Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc, char* error[])
+    {
+        return obj->SetRemoteDescription(*desc, context->GetObserver(obj->connection), error);
     }
 
     UNITY_INTERFACE_EXPORT bool PeerConnectionGetLocalDescription(PeerConnectionObject* obj, RTCSessionDescription* desc)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -34,58 +34,59 @@ namespace webrtc
             delegateSetResolution(width, length);
         }
     }
-    
+
+    template<class T>
+    T** ConvertPtrArrayFromRefPtrArray(
+        std::vector<rtc::scoped_refptr<T>> vec, size_t* length)
+    {
+        *length = vec.size();
+        const auto buf = CoTaskMemAlloc(sizeof(T*) * vec.size());
+        const auto ret = static_cast<T**>(buf);
+        std::copy(vec.begin(), vec.end(), ret);
+        return ret;
+    }
+
+    template<typename T>
+    T* ConvertArray(std::vector<T> vec, size_t* length)
+    {
+        *length = vec.size();
+        size_t size = sizeof(T*) * vec.size();
+        auto dst = CoTaskMemAlloc(size);
+        auto src = vec.data();
+        std::memcpy(dst, src, size);
+        return static_cast<T*>(dst);
+    }
+
+    ///
+    /// avoid compile erorr for vector<bool>
+    /// https://en.cppreference.com/w/cpp/container/vector_bool
+    bool* ConvertArray(std::vector<bool> vec, size_t* length)
+    {
+        *length = vec.size();
+        size_t size = sizeof(bool*) * vec.size();
+        auto dst = CoTaskMemAlloc(size);
+        bool* ret = static_cast<bool*>(dst);
+        for (size_t i = 0; i < vec.size(); i++)
+        {
+            ret[i] = vec[i];
+        }
+        return ret;
+    }
+
+    char* ConvertString(const std::string str)
+    {
+        const size_t size = str.size();
+        char* ret = static_cast<char*>(CoTaskMemAlloc(size + sizeof(char)));
+        str.copy(ret, size);
+        ret[size] = '\0';
+        return ret;
+    }
+
 } // end namespace webrtc
 } // end namespace unity
 
 using namespace unity::webrtc;
 using namespace ::webrtc;
-
-template<class T>
-T** ConvertPtrArrayFromRefPtrArray(std::vector<rtc::scoped_refptr<T>> vec, size_t* length)
-{
-    *length = vec.size();
-    const auto buf = CoTaskMemAlloc(sizeof(T*) * vec.size());
-    const auto ret = static_cast<T**>(buf);
-    std::copy(vec.begin(), vec.end(), ret);
-    return ret;
-}
-
-template<typename T>
-T* ConvertArray(std::vector<T> vec, size_t* length)
-{
-    *length = vec.size();
-    size_t size = sizeof(T*) * vec.size();
-    auto dst = CoTaskMemAlloc(size);
-    auto src = vec.data();
-    std::memcpy(dst, src, size);
-    return static_cast<T*>(dst);
-}
-
-///
-/// avoid compile erorr for vector<bool>
-/// https://en.cppreference.com/w/cpp/container/vector_bool
-bool* ConvertArray(std::vector<bool> vec, size_t* length)
-{
-    *length = vec.size();
-    size_t size = sizeof(bool*) * vec.size();
-    auto dst = CoTaskMemAlloc(size);
-    bool* ret = static_cast<bool*>(dst);
-    for (size_t i = 0; i < vec.size(); i++)
-    {
-        ret[i] = vec[i];
-    }
-    return ret;
-}
-
-char* ConvertString(const std::string str)
-{
-    const size_t size = str.size();
-    char* ret = static_cast<char*>(CoTaskMemAlloc(size + sizeof(char)));
-    str.copy(ret, size);
-    ret[size] = '\0';
-    return ret;
-}
 
 extern "C"
 {

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -131,6 +131,14 @@ namespace webrtc
         return std::string(buf.get(), buf.get() + size - 1);
     }
 
+    template<class T>
+    T** ConvertPtrArrayFromRefPtrArray(
+        std::vector<rtc::scoped_refptr<T>> vec, size_t* length);
+    template<typename T>
+    T* ConvertArray(std::vector<T> vec, size_t* length);
+    bool* ConvertArray(std::vector<bool> vec, size_t* length);
+    char* ConvertString(const std::string str);
+
     using byte = unsigned char;
     using uint8 = unsigned char;
     using uint16 = unsigned short int;

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -78,13 +78,24 @@ namespace Unity.WebRTC
             NativeMethods.ContextDeletePeerConnection(self, ptr);
         }
 
-        public void PeerConnectionSetLocalDescription(IntPtr ptr, ref RTCSessionDescription desc)
+        public RTCError PeerConnectionSetLocalDescription(
+            IntPtr ptr, ref RTCSessionDescription desc)
         {
-            NativeMethods.PeerConnectionSetLocalDescription(self, ptr, ref desc);
+            IntPtr ptrError = IntPtr.Zero;
+            RTCErrorType errorType = NativeMethods.PeerConnectionSetLocalDescription(
+                self, ptr, ref desc, ref ptrError);
+            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
+            return new RTCError { errorType =  errorType, message = message};
         }
-        public void PeerConnectionSetRemoteDescription(IntPtr ptr, ref RTCSessionDescription desc)
+
+        public RTCError PeerConnectionSetRemoteDescription(
+            IntPtr ptr, ref RTCSessionDescription desc)
         {
-            NativeMethods.PeerConnectionSetRemoteDescription(self, ptr, ref desc);
+            IntPtr ptrError = IntPtr.Zero;
+            RTCErrorType errorType = NativeMethods.PeerConnectionSetRemoteDescription(
+                self, ptr, ref desc, ref ptrError);
+            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
+            return new RTCError { errorType =  errorType, message = message};
         }
 
         public void PeerConnectionRegisterOnSetSessionDescSuccess(IntPtr ptr, DelegateNativePeerConnectionSetSessionDescSuccess callback)

--- a/Runtime/Scripts/RTCErrorException.cs
+++ b/Runtime/Scripts/RTCErrorException.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Unity.WebRTC
+{
+    /// <summary>
+    /// This exception class contains properties which determines
+    /// a error type occurred while handling WebRTC operations.
+    /// </summary>
+    public class RTCErrorException : Exception
+    {
+        private RTCError m_error;
+
+        internal RTCErrorException(ref RTCError error) : base(error.message)
+        {
+            m_error = error;
+        }
+
+        /// <summary>
+        /// This property specifies the WebRTC-specific error code.
+        /// </summary>
+        public RTCErrorType ErrorType { get { return m_error.errorType; } }
+    }
+}

--- a/Runtime/Scripts/RTCErrorException.cs.meta
+++ b/Runtime/Scripts/RTCErrorException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b6a73724406f445898d93fb54352276
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -583,6 +583,10 @@ namespace Unity.WebRTC
         /// An AsyncOperation which resolves with an <see cref="RTCSessionDescription"/>
         /// object providing a description of the session.
         /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when an argument has an invalid value.
+        /// For example, when passed the sdp which is null or empty.
+        /// </exception>
         /// <exception cref="RTCErrorException">
         /// Thrown when an argument has an invalid value.
         /// For example, when passed the sdp which is not be able to parse.
@@ -591,6 +595,9 @@ namespace Unity.WebRTC
         public RTCSetSessionDescriptionAsyncOperation SetLocalDescription(
             ref RTCSessionDescription desc)
         {
+            if(string.IsNullOrEmpty(desc.sdp))
+                throw new ArgumentException("sdp is null or empty");
+
             var op = new RTCSetSessionDescriptionAsyncOperation(this);
             RTCError error = WebRTC.Context.PeerConnectionSetLocalDescription(
                 self, ref desc);
@@ -611,6 +618,10 @@ namespace Unity.WebRTC
         /// An AsyncOperation which resolves with an <see cref="RTCSessionDescription"/>
         /// object providing a description of the session.
         /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when an argument has an invalid value.
+        /// For example, when passed the sdp which is null or empty.
+        /// </exception>
         /// <exception cref="RTCErrorException">
         /// Thrown when an argument has an invalid value.
         /// For example, when passed the sdp which is not be able to parse.
@@ -619,6 +630,9 @@ namespace Unity.WebRTC
         public RTCSetSessionDescriptionAsyncOperation SetRemoteDescription(
             ref RTCSessionDescription desc)
         {
+            if (string.IsNullOrEmpty(desc.sdp))
+                throw new ArgumentException("sdp is null or empty");
+
             var op = new RTCSetSessionDescriptionAsyncOperation(this);
             RTCError error = WebRTC.Context.PeerConnectionSetRemoteDescription(
                 self, ref desc);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -575,17 +575,58 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        ///
+        /// This method changes the session description
+        /// of the local connection to negotiate with other connections.
         /// </summary>
         /// <param name="desc"></param>
-        /// <returns></returns>
+        /// <returns>
+        /// An AsyncOperation which resolves with an <see cref="RTCSessionDescription"/>
+        /// object providing a description of the session.
+        /// </returns>
+        /// <exception cref="RTCErrorException">
+        /// Thrown when an argument has an invalid value.
+        /// For example, when passed the sdp which is not be able to parse.
+        /// </exception>
         /// <seealso cref="LocalDescription"/>
         public RTCSetSessionDescriptionAsyncOperation SetLocalDescription(
             ref RTCSessionDescription desc)
         {
             var op = new RTCSetSessionDescriptionAsyncOperation(this);
-            WebRTC.Context.PeerConnectionSetLocalDescription(self, ref desc);
-            return op;
+            RTCError error = WebRTC.Context.PeerConnectionSetLocalDescription(
+                self, ref desc);
+            if (error.errorType == RTCErrorType.None)
+            {
+                return op;
+            }
+            throw new RTCErrorException(ref error);
+        }
+
+
+        /// <summary>
+        /// This method changes the session description
+        /// of the remote connection to negotiate with local connections.
+        /// </summary>
+        /// <param name="desc"></param>
+        /// <returns>
+        /// An AsyncOperation which resolves with an <see cref="RTCSessionDescription"/>
+        /// object providing a description of the session.
+        /// </returns>
+        /// <exception cref="RTCErrorException">
+        /// Thrown when an argument has an invalid value.
+        /// For example, when passed the sdp which is not be able to parse.
+        /// </exception>
+        /// <seealso cref="RemoteDescription"/>
+        public RTCSetSessionDescriptionAsyncOperation SetRemoteDescription(
+            ref RTCSessionDescription desc)
+        {
+            var op = new RTCSetSessionDescriptionAsyncOperation(this);
+            RTCError error = WebRTC.Context.PeerConnectionSetRemoteDescription(
+                self, ref desc);
+            if (error.errorType == RTCErrorType.None)
+            {
+                return op;
+            }
+            throw new RTCErrorException(ref error);
         }
 
         /// <summary>
@@ -717,18 +758,6 @@ namespace Unity.WebRTC
                 }
                 throw new InvalidOperationException("PendingRemoteDescription is not exist");
             }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="desc"></param>
-        /// <returns></returns>
-        public RTCSetSessionDescriptionAsyncOperation SetRemoteDescription(ref RTCSessionDescription desc)
-        {
-            var op = new RTCSetSessionDescriptionAsyncOperation(this);
-            WebRTC.Context.PeerConnectionSetRemoteDescription(self, ref desc);
-            return op;
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativePeerConnectionSetSessionDescSuccess))]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -544,7 +544,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterOnIceCandidate(IntPtr ptr, DelegateNativeOnIceCandidate callback);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionSetLocalDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc);
+        public static extern RTCErrorType PeerConnectionSetLocalDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc, ref IntPtr error);
+        [DllImport(WebRTC.Lib)]
+        public static extern RTCErrorType PeerConnectionSetRemoteDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc, ref IntPtr error);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionGetStats(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
@@ -569,8 +571,6 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool PeerConnectionGetCurrentRemoteDescription(IntPtr ptr, ref RTCSessionDescription desc);
-        [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionSetRemoteDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr PeerConnectionAddTrack(IntPtr pc, IntPtr track, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string streamId);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -1,8 +1,10 @@
+using System;
 using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 using System.Linq;
+using Object = UnityEngine.Object;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -219,6 +221,18 @@ namespace Unity.WebRTC.RuntimeTest
             peer.Dispose();
         }
 
+        [Test]
+        [Category("PeerConnection")]
+        public void SetLocalDescriptionThrowException()
+        {
+            var peer = new RTCPeerConnection();
+            RTCSessionDescription empty = new RTCSessionDescription();
+            Assert.Throws<ArgumentException>(() => peer.SetLocalDescription(ref empty));
+
+            RTCSessionDescription invalid = new RTCSessionDescription { sdp = "this is invalid parameter" };
+            Assert.Throws<RTCErrorException>(() => peer.SetLocalDescription(ref invalid));
+        }
+
         [UnityTest]
         [Timeout(1000)]
         [Category("PeerConnection")]
@@ -258,6 +272,19 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.Dispose();
             peer2.Dispose();
         }
+
+        [Test]
+        [Category("PeerConnection")]
+        public void SetRemoteDescriptionThrowException()
+        {
+            var peer = new RTCPeerConnection();
+            RTCSessionDescription empty = new RTCSessionDescription();
+            Assert.Throws<ArgumentException>(() => peer.SetRemoteDescription(ref empty));
+
+            RTCSessionDescription invalid = new RTCSessionDescription { sdp = "this is invalid parameter" };
+            Assert.Throws<RTCErrorException>(() => peer.SetRemoteDescription(ref invalid));
+        }
+
 
         [UnityTest]
         [Timeout(1000)]


### PR DESCRIPTION
This pull request Changes behavior of methods `SetRemoteDescription` and `SetLocalDescription`.
These methods occurred crashes when passed an invalid parameter. For this changes, methods handle the invalid parameter properly.

### Test for SetLocalDescription
```csharp
var peer = new RTCPeerConnection();
RTCSessionDescription empty = new RTCSessionDescription();
Assert.Throws<ArgumentException>(() => peer.SetLocalDescription(ref empty));

RTCSessionDescription invalid = new RTCSessionDescription { sdp = "this is invalid parameter" };
Assert.Throws<RTCErrorException>(() => peer.SetLocalDescription(ref invalid));
```

### Test for SetRemoteDescription
```csharp
var peer = new RTCPeerConnection();
RTCSessionDescription empty = new RTCSessionDescription();
Assert.Throws<ArgumentException>(() => peer.SetRemoteDescription(ref empty));

RTCSessionDescription invalid = new RTCSessionDescription { sdp = "this is invalid parameter" };
Assert.Throws<RTCErrorException>(() => peer.SetRemoteDescription(ref invalid));
```