### PR TITLE
test: add test about addtransceiver

### DIFF
--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -678,10 +678,6 @@ extern "C"
     {
         obj->RegisterOnTrack(callback);
     }
-    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* TransceiverGetTrack(RtpTransceiverInterface* transceiver)
-    {
-        return transceiver->receiver()->track().get();
-    }
 
     UNITY_INTERFACE_EXPORT bool TransceiverGetCurrentDirection(RtpTransceiverInterface* transceiver, RtpTransceiverDirection* direction)
     {
@@ -777,7 +773,12 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* SenderGetTrack(RtpSenderInterface* sender)
     {
-        return sender->track();
+        return sender->track().get();
+    }
+
+    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* ReceiverGetTrack(RtpReceiverInterface* receiver)
+    {
+        return receiver->track().get();
     }
 
     UNITY_INTERFACE_EXPORT int DataChannelGetID(DataChannelObject* dataChannelObj)

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -109,8 +109,6 @@ namespace Unity.WebRTC
 
     public class RTCTrackEvent
     {
-        public MediaStreamTrack Track { get; }
-
         public RTCRtpTransceiver Transceiver { get; }
 
         public RTCRtpReceiver Receiver
@@ -121,10 +119,16 @@ namespace Unity.WebRTC
             }
         }
 
+        public MediaStreamTrack Track
+        {
+            get
+            {
+                return Receiver.Track;
+            }
+        }
+
         internal RTCTrackEvent(IntPtr ptrTransceiver, RTCPeerConnection peer)
         {
-            IntPtr ptrTrack = NativeMethods.TransceiverGetTrack(ptrTransceiver);
-            Track = WebRTC.FindOrCreate(ptrTrack, MediaStreamTrack.Create);
             Transceiver = new RTCRtpTransceiver(ptrTransceiver, peer);
         }
     }

--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -18,5 +18,14 @@ namespace Unity.WebRTC
         {
             return peer.GetStats(this);
         }
+
+        public MediaStreamTrack Track
+        {
+            get
+            {
+                IntPtr ptrTrack = NativeMethods.ReceiverGetTrack(self);
+                return WebRTC.FindOrCreate(ptrTrack, MediaStreamTrack.Create);
+            }
+        }
     }
 }

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -24,7 +24,7 @@ namespace Unity.WebRTC
             get
             {
                 IntPtr ptr = NativeMethods.SenderGetTrack(self);
-                return WebRTC.FindOrCreate<MediaStreamTrack>(ptr, _ptr => new MediaStreamTrack(_ptr));
+                return WebRTC.FindOrCreate(ptr, MediaStreamTrack.Create);
             }
         }
 

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -63,18 +63,6 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
-        public MediaStreamTrack Track
-        {
-            get
-            {
-                IntPtr ptrTrack = NativeMethods.TransceiverGetTrack(self);
-                return WebRTC.FindOrCreate(ptrTrack, MediaStreamTrack.Create);
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
         /// <param name="direction"></param>
         public void SetDirection(RTCRtpTransceiverDirection direction)
         {

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
-using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
-using UnityEngine;
 
 namespace Unity.WebRTC
 {
@@ -56,13 +52,13 @@ namespace Unity.WebRTC
             }
         }
 
-        public RenderTexture InitializeReceiver()
+        public UnityEngine.RenderTexture InitializeReceiver()
         {
             if (IsDecoderInitialized)
                 throw new InvalidOperationException("Already initialized receiver");
 
             m_needFlip = true;
-            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             m_sourceTexture = CreateRenderTexture(1280, 720, format);
             m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
 
@@ -119,7 +115,7 @@ namespace Unity.WebRTC
             : this(label,
                 source,
                 CreateRenderTexture(source.width, source.height,
-                    WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType)),
+                    WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
                 source.width,
                 source.height)
         {
@@ -187,7 +183,7 @@ namespace Unity.WebRTC
 
     public static class CameraExtension
     {
-        public static VideoStreamTrack CaptureStreamTrack(this Camera cam, int width, int height, int bitrate,
+        public static VideoStreamTrack CaptureStreamTrack(this UnityEngine.Camera cam, int width, int height, int bitrate,
             RenderTextureDepth depth = RenderTextureDepth.DEPTH_24)
         {
             switch (depth)
@@ -201,15 +197,15 @@ namespace Unity.WebRTC
             }
 
             int depthValue = (int)depth;
-            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-            var rt = new RenderTexture(width, height, depthValue, format);
+            var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
+            var rt = new UnityEngine.RenderTexture(width, height, depthValue, format);
             rt.Create();
             cam.targetTexture = rt;
             return new VideoStreamTrack(cam.name, rt);
         }
 
 
-        public static MediaStream CaptureStream(this Camera cam, int width, int height, int bitrate,
+        public static MediaStream CaptureStream(this UnityEngine.Camera cam, int width, int height, int bitrate,
             RenderTextureDepth depth = RenderTextureDepth.DEPTH_24)
         {
             var stream = new MediaStream(WebRTC.Context.CreateMediaStream("videostream"));

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -601,8 +601,6 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterOnTrack(IntPtr ptr, DelegateNativeOnTrack callback);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr TransceiverGetTrack(IntPtr transceiver);
-        [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool TransceiverGetCurrentDirection(IntPtr transceiver, ref RTCRtpTransceiverDirection direction);
         [DllImport(WebRTC.Lib)]
@@ -618,6 +616,8 @@ namespace Unity.WebRTC
         public static extern void SenderGetParameters(IntPtr sender, out IntPtr parameters);
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType SenderSetParameters(IntPtr sender, IntPtr parameters);
+        [DllImport(WebRTC.Lib)]
+        public static extern IntPtr ReceiverGetTrack(IntPtr receiver);
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Samples~/VideoReceiveSample.cs
+++ b/Samples~/VideoReceiveSample.cs
@@ -69,10 +69,9 @@ public class VideoReceiveSample : MonoBehaviour
 
         receiveStream.OnAddTrack = e =>
         {
-            if (e.Track.Kind == TrackKind.Video)
+            if (e.Track is VideoStreamTrack track)
             {
-                var videoStreamTrack = (VideoStreamTrack)e.Track;
-                receiveImage.texture = videoStreamTrack.InitializeReceiver();
+                receiveImage.texture = track.InitializeReceiver();
             }
         };
     }

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -128,7 +128,9 @@ namespace Unity.WebRTC.RuntimeTest
             var transceiver = peer.AddTransceiver(TrackKind.Audio);
             Assert.NotNull(transceiver);
             Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
-            MediaStreamTrack track = transceiver.Track;
+            RTCRtpReceiver receiver = transceiver.Receiver;
+            Assert.NotNull(receiver);
+            MediaStreamTrack track = receiver.Track;
             Assert.NotNull(track);
             Assert.AreEqual(TrackKind.Audio, track.Kind);
             Assert.True(track is AudioStreamTrack);
@@ -145,7 +147,9 @@ namespace Unity.WebRTC.RuntimeTest
             var transceiver = peer.AddTransceiver(TrackKind.Video);
             Assert.NotNull(transceiver);
             Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
-            MediaStreamTrack track = transceiver.Track;
+            RTCRtpReceiver receiver = transceiver.Receiver;
+            Assert.NotNull(receiver);
+            MediaStreamTrack track = receiver.Track;
             Assert.NotNull(track);
             Assert.AreEqual(TrackKind.Video, track.Kind);
             Assert.True(track is VideoStreamTrack);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -120,6 +120,39 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.NotNull(peer.GetTransceivers().First());
         }
 
+        [Test]
+        [Category("PeerConnection")]
+        public void AddTransceiverTrackKindAudio()
+        {
+            var peer = new RTCPeerConnection();
+            var transceiver = peer.AddTransceiver(TrackKind.Audio);
+            Assert.NotNull(transceiver);
+            Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
+            MediaStreamTrack track = transceiver.Track;
+            Assert.NotNull(track);
+            Assert.AreEqual(TrackKind.Audio, track.Kind);
+            Assert.True(track is AudioStreamTrack);
+
+            Assert.AreEqual(1, peer.GetTransceivers().Count());
+            Assert.NotNull(peer.GetTransceivers().First());
+        }
+
+        [Test]
+        [Category("PeerConnection")]
+        public void AddTransceiverTrackKindVideo()
+        {
+            var peer = new RTCPeerConnection();
+            var transceiver = peer.AddTransceiver(TrackKind.Video);
+            Assert.NotNull(transceiver);
+            Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
+            MediaStreamTrack track = transceiver.Track;
+            Assert.NotNull(track);
+            Assert.AreEqual(TrackKind.Video, track.Kind);
+            Assert.True(track is VideoStreamTrack);
+
+            Assert.AreEqual(1, peer.GetTransceivers().Count());
+            Assert.NotNull(peer.GetTransceivers().First());
+        }
 
         [UnityTest]
         [Timeout(1000)]

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -27,7 +27,9 @@ namespace Unity.WebRTC.RuntimeTest
             var peer = new RTCPeerConnection();
             var transceiver = peer.AddTransceiver(TrackKind.Video);
             Assert.NotNull(transceiver);
-            MediaStreamTrack track = transceiver.Track;
+            RTCRtpReceiver receiver = transceiver.Receiver;
+            Assert.NotNull(receiver);
+            MediaStreamTrack track = receiver.Track;
             Assert.NotNull(track);
             Assert.AreEqual(TrackKind.Video, track.Kind);
             var videoTrack = track as VideoStreamTrack;


### PR DESCRIPTION
- add test about `AddTransceiver` that specify only track kind on peerconnection
- change `TransceiverGetTrack` to `ReceiverGetTrack`, this is to match https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver