### PR TITLE
Add callback to native video source for encoded frames 

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -47,8 +47,11 @@ class UnityVideoTrackSource :
     // todo(kazuki)::
     void OnFrameCaptured();
 
-    // todo(kazuki)::
-    //void DelegateOnFrame(const ::webrtc::VideoFrame& frame) { OnFrame(frame); }
+    /*
+    * Gets called after for every frame capture immediately prior to handing
+    * the frame over to the WebRTC pipeline.
+    * @param[in] frame: the frame after post-capture processing.
+    */
     void DelegateOnFrame(const ::webrtc::VideoFrame& frame);
 
     // todo(kazuki)::
@@ -64,6 +67,12 @@ class UnityVideoTrackSource :
         return encoder_->GetCodecInitializationResult();
     }
 
+    /*
+    * Sets the post capture callback for this video source.
+    * @param[in] track: the base track for this video source. It's required to match
+    *  the managed and native tracks.
+    * @param[in] callback: the callback to invoke after the post frame capture processing.
+    */
     void SetVideoFrameOnEncodeCallback(::webrtc::MediaStreamTrackInterface* track, DelegateOnVideoFrameEncode callback);
 
     using ::webrtc::VideoTrackSourceInterface::AddOrUpdateSink;

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -3,6 +3,8 @@
 #include <mutex>
 #include "Codec/IEncoder.h"
 #include "rtc_base/timestamp_aligner.h"
+#include "WebRTCPlugin.h"
+#include "api/media_stream_interface.h"
 
 namespace unity {
 namespace webrtc {
@@ -46,7 +48,8 @@ class UnityVideoTrackSource :
     void OnFrameCaptured();
 
     // todo(kazuki)::
-    void DelegateOnFrame(const ::webrtc::VideoFrame& frame) { OnFrame(frame); }
+    //void DelegateOnFrame(const ::webrtc::VideoFrame& frame) { OnFrame(frame); }
+    void DelegateOnFrame(const ::webrtc::VideoFrame& frame);
 
     // todo(kazuki)::
     void SetEncoder(IEncoder* encoder);
@@ -60,6 +63,8 @@ class UnityVideoTrackSource :
         }
         return encoder_->GetCodecInitializationResult();
     }
+
+    void SetVideoFrameOnEncodeCallback(::webrtc::MediaStreamTrackInterface* track, DelegateOnVideoFrameEncode callback);
 
     using ::webrtc::VideoTrackSourceInterface::AddOrUpdateSink;
     using ::webrtc::VideoTrackSourceInterface::RemoveSink;
@@ -88,6 +93,9 @@ class UnityVideoTrackSource :
     std::mutex m_mutex;
     IEncoder* encoder_;
     void* frame_;
+    ::webrtc::MediaStreamTrackInterface* track_;
+    DelegateOnVideoFrameEncode on_encode_;
+    std::mutex m_onEncodeMutex;
 
 #if defined(SUPPORT_VULKAN)
     UnityVulkanImage unityVulkanImage_;

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -843,6 +843,15 @@ extern "C"
         }
     }
 
+    /*
+    * This function sets a frame encoded callback on a video source. The purpose of the
+    * callback is to supply video frames from the end of the post-capture processing
+    * stage to managed scripts.
+    * @param[in] context: the singleton WebRTC context.
+    * @param[in] track: the base media stream track for the video source. It's used to match
+    *  the native track with the managed track.
+    * @param[in] callback: the on frame encoded callback function to set on the video source.
+    */
     UNITY_INTERFACE_EXPORT void SetOnVideoFrameEncodedCallback(Context* context, MediaStreamTrackInterface* track, DelegateOnVideoFrameEncode callback)
     {
         auto videoSource = context->GetVideoSource(track);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -6,6 +6,7 @@
 #include "Context.h"
 #include "Codec/EncoderFactory.h"
 #include "GraphicsDevice/GraphicsUtility.h"
+#include "UnityVideoTrackSource.h"
 
 #if defined(SUPPORT_VULKAN)
 #include "GraphicsDevice/Vulkan/VulkanGraphicsDevice.h"
@@ -840,6 +841,12 @@ extern "C"
         {
             ContextManager::GetInstance()->curContext->ProcessAudioData(data, size);
         }
+    }
+
+    UNITY_INTERFACE_EXPORT void SetOnVideoFrameEncodedCallback(Context* context, MediaStreamTrackInterface* track, DelegateOnVideoFrameEncode callback)
+    {
+        auto videoSource = context->GetVideoSource(track);
+        videoSource->SetVideoFrameOnEncodeCallback(track, callback);
     }
 }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -12,6 +12,7 @@ namespace webrtc
     enum class RTCSdpType;
     enum class RTCPeerConnectionEventType;
     struct MediaStreamEvent;
+    class UnityVideoTrackSource;
 
     using DelegateDebugLog = void(*)(const char*);
     using DelegateSetResolution = void(*)(int32*, int32*);
@@ -19,6 +20,7 @@ namespace webrtc
     using DelegateMediaStreamOnRemoveTrack = void(*)(webrtc::MediaStreamInterface*, webrtc::MediaStreamTrackInterface*);
     using DelegateSetSessionDescSuccess = void(*)(PeerConnectionObject*);
     using DelegateSetSessionDescFailure = void(*)(PeerConnectionObject*, webrtc::RTCErrorType, const char*);
+    using DelegateOnVideoFrameEncode = void(*)(::webrtc::MediaStreamTrackInterface*, int encoderTypeID, int width, int height, const uint8_t* buffer, int bufferSize);
 
     void debugLog(const char* buf);
     void SetResolution(int32* width, int32* length);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -193,6 +193,20 @@ namespace Unity.WebRTC
             return NativeMethods.GetInitializationResult(self, track);
         }
 
+        /// <summary>
+        /// Sets a callback method for on encoded frame events on a native video source instance. The
+        /// callback gets fired after the post-capture operations have been performed. For software encoding
+        /// the callback will receive an I420 buffer. For hardware encoding it will receive an encoded sample.
+        /// </summary>
+        /// <param name="track">A pointer to the video stream track that was returned when the video
+        /// track was created.</param>
+        /// <param name="callback">The function pointer that will be set on the native video source for on frame
+        /// encoded events.</param>
+        public void SetOnVideoFrameEncodedCallback(IntPtr track, DelegateNativeOnVideoFrameEncoded callback)
+        {
+            NativeMethods.SetOnVideoFrameEncodedCallback(self, track, callback);
+        }
+
         internal void InitializeEncoder(IntPtr track)
         {
             renderFunction = renderFunction == IntPtr.Zero ? GetRenderEventFunc() : renderFunction;

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -485,6 +485,8 @@ namespace Unity.WebRTC
     internal delegate void DelegateNativeMediaStreamOnAddTrack(IntPtr stream, IntPtr track);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeMediaStreamOnRemoveTrack(IntPtr stream, IntPtr track);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void DelegateNativeOnVideoFrameEncoded(IntPtr videoStreamTrack, int encoderID, int width, int height, IntPtr buffer, int bufferSize);
 
     internal static class NativeMethods
     {
@@ -735,6 +737,8 @@ namespace Unity.WebRTC
         public static extern IntPtr StatsMemberGetDoubleArray(IntPtr member, ref uint length);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsMemberGetStringArray(IntPtr member, ref uint length);
+        [DllImport(WebRTC.Lib)]
+        public static extern void SetOnVideoFrameEncodedCallback(IntPtr context, IntPtr videoStreamTrack, DelegateNativeOnVideoFrameEncoded callback);
     }
 
     internal static class VideoEncoderMethods


### PR DESCRIPTION
This PR is an attempt at implementing the feature request from #204.

It adds the ability to set a callback on the native `UnityVideoSource` class so managed scripts can get video frames after the post-capture processing.

**TLDR; Currently looking for feedback as to whether the approach in this PR will be considered and thus whether reamingin issues should be solved and more testing carried out.**

Initial testing indicates this approach or something similar is very worthwhile. A comparison was done between capturing video frames from a camera purely in a C# and contrasted with the native callback in this PR. The difference in frame rates was over 5x, approx 15fps compared to approx 80 fps. The test was done at 480p on Window 10.

The Unity WebRTC plugins use of a native graphic device texture for video capture makes the difference between an acceptable streaming experience and a sub-standard one. If something along the lines of this hook can be incorporated into this plugin it will open up video streaming from Unity camera textures to managed script streaming applications such as WebRTC, RTSP, SIP etc.

This PR is flagged as Work In Progress as their are outstanding issues that could take a large chunk of time to solve and I'd like to get some initial feedback before expending that time. The main issues are:

 - The editor freezes after the initial execution. It seems to be a problem with the managed assembly unload not completing cleanly.

 - Testing so far has only been with software encoding and processing I420 buffers which are then handed off to `libvpx` for encoding. The next step is to attempt to handle the H264 encoded samples received when NVenc hardware encoding is used and stream those directly.

Screenshot of native callback and the editor running at approx 80fps (the frame rate is double checked with Chrome's webrtc diagnostics page). Note the screenshot shows 63fps, my screen capture must have caused it to drop from around 80.

![unity_videosource_withwebrtcplugin](https://user-images.githubusercontent.com/197660/95794446-d5415100-0cdf-11eb-891f-52a9ac86d496.png)

Screenshot with managed only capture and editor running at approx 15 fps.

![unity_videosource_noplugin](https://user-images.githubusercontent.com/197660/95794480-f43fe300-0cdf-11eb-9c57-1a051ae4fd51.png)



