### PR TITLE
feat: Hardware encoder on macos support

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -36,7 +36,8 @@ namespace webrtc
     bool EncoderFactory::GetHardwareEncoderSupport()
     {
 #if defined(SUPPORT_METAL)
-        return false;
+        // todo(kazuki): check VideoToolbox compatibility
+        return true;
 #else
         return NvEncoder::LoadModule();
 #endif
@@ -88,7 +89,7 @@ namespace webrtc
                 break;
             }
 #endif            
-#if defined(SUPPORT_METAL) && defined(SUPPORT_SOFTWARE_ENCODER)
+#if defined(SUPPORT_METAL)
             case GRAPHICS_DEVICE_METAL: {
                 encoder = std::make_unique<SoftwareEncoder>(width, height, device);
                 break;

--- a/Plugin~/WebRTCPlugin/Codec/IEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/IEncoder.h
@@ -23,7 +23,7 @@ namespace webrtc
         virtual void SetRates(uint32_t bitRate, int64_t frameRate) = 0;
         virtual void UpdateSettings() = 0;
         virtual bool CopyBuffer(void* frame) = 0;
-        virtual bool EncodeFrame() = 0;
+        virtual bool EncodeFrame(int64_t timestamp_us) = 0;
         virtual bool IsSupported() const = 0;
         virtual void SetIdrFrame() = 0;
         virtual uint64 GetCurrentFrameCount() const = 0;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -49,7 +49,7 @@ namespace webrtc
         void SetRates(uint32_t bitRate, int64_t frameRate) override;
         void UpdateSettings() override;
         bool CopyBuffer(void* frame) override;
-        bool EncodeFrame() override;
+        bool EncodeFrame(int64_t timestamp_us) override;
         bool IsSupported() const override { return m_isNvEncoderSupported; }
         void SetIdrFrame()  override { isIdrFrame = true; }
         uint64 GetCurrentFrameCount() const override { return frameCount; }
@@ -71,7 +71,7 @@ namespace webrtc
         void ReleaseEncoderResources();
 
         void ReleaseFrameInputBuffer(Frame& frame);
-        void ProcessEncodedFrame(Frame& frame);
+        void ProcessEncodedFrame(Frame& frame, int64_t timestamp_us);
         NV_ENC_REGISTERED_PTR RegisterResource(NV_ENC_INPUT_RESOURCE_TYPE type, void *pBuffer);
         void MapResources(InputFrame& inputFrame);
         NV_ENC_OUTPUT_PTR InitializeBitstreamBuffer();

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
@@ -29,13 +29,19 @@ namespace webrtc
         return true;
     }
 
-    bool SoftwareEncoder::EncodeFrame()
+    bool SoftwareEncoder::EncodeFrame(int64_t timestamp_us)
     {
         const rtc::scoped_refptr<webrtc::I420Buffer> i420Buffer = m_device->ConvertRGBToI420(m_encodeTex);
         if (nullptr == i420Buffer)
             return false;
 
-        webrtc::VideoFrame frame = webrtc::VideoFrame::Builder().set_video_frame_buffer(i420Buffer).set_rotation(webrtc::kVideoRotation_0).set_timestamp_us(0).build();
+        webrtc::VideoFrame frame =
+            webrtc::VideoFrame::Builder()
+            .set_video_frame_buffer(i420Buffer)
+            .set_rotation(webrtc::kVideoRotation_0)
+            .set_timestamp_us(timestamp_us)
+            .build();
+            
         CaptureFrame(frame);
         m_frameCount++;
         return true;

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -19,7 +19,7 @@ namespace webrtc
         void SetRates(uint32_t bitRate, int64_t frameRate) override {}
         void UpdateSettings() override {}
         bool CopyBuffer(void* frame) override;
-        bool EncodeFrame() override;
+        bool EncodeFrame(int64_t timestamp_us) override;
         bool IsSupported() const override { return true; }
         void SetIdrFrame() override {}
         uint64 GetCurrentFrameCount() const override { return m_frameCount; }

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -12,7 +12,6 @@
 #include "UnityVideoEncoderFactory.h"
 #include "UnityVideoDecoderFactory.h"
 #include "UnityVideoTrackSource.h"
-#include "GraphicsDevice/GraphicsUtility.h"
 
 using namespace ::webrtc;
 
@@ -156,6 +155,7 @@ namespace webrtc
     Context::Context(int uid, UnityEncoderType encoderType)
         : m_uid(uid)
         , m_encoderType(encoderType)
+        , m_clock(Clock::GetRealTimeClock())
     {
         m_workerThread.reset(new rtc::Thread(rtc::SocketServer::CreateDefault()));
         m_workerThread->Start();
@@ -251,7 +251,8 @@ namespace webrtc
         UnityVideoTrackSource* source = GetVideoSource(track);
         if (source == nullptr)
             return false;
-        source->OnFrameCaptured();
+        int64_t timestamp_us = m_clock->TimeInMicroseconds();
+        source->OnFrameCaptured(timestamp_us);
         return true;
     }
 

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -166,16 +166,12 @@ namespace webrtc
 
         m_audioDevice = new rtc::RefCountedObject<DummyAudioDevice>();
 
-#if defined(SUPPORT_METAL) && defined(SUPPORT_SOFTWARE_ENCODER)
-        //Always use SoftwareEncoder on Mac for now.
-        std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory = webrtc::CreateBuiltinVideoEncoderFactory();
-        std::unique_ptr<webrtc::VideoDecoderFactory> videoDecoderFactory = std::make_unique<UnityVideoDecoderFactory>();
-#else
         std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory =
             m_encoderType == UnityEncoderType::UnityEncoderHardware ?
-            std::make_unique<UnityVideoEncoderFactory>(static_cast<IVideoEncoderObserver*>(this)) : webrtc::CreateBuiltinVideoEncoderFactory();
-        std::unique_ptr<webrtc::VideoDecoderFactory> videoDecoderFactory = std::make_unique<UnityVideoDecoderFactory>();
-#endif
+            std::make_unique<UnityVideoEncoderFactory>(static_cast<IVideoEncoderObserver*>(this))
+            : webrtc::CreateBuiltinVideoEncoderFactory();
+        std::unique_ptr<webrtc::VideoDecoderFactory> videoDecoderFactory =
+            std::make_unique<UnityVideoDecoderFactory>();
 
         m_peerConnectionFactory = webrtc::CreatePeerConnectionFactory(
                                 m_workerThread.get(),

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -121,7 +121,7 @@ namespace webrtc
  
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
         std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;
-        std::unique_ptr<Clock> m_clock;
+        Clock* m_clock;
 
         // todo(kazuki): remove these callback methods by moving hardware encoder instance to DummyVideoEncoder.
         //               attention point is multi-threaded opengl implementation with nvcodec.

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -121,6 +121,7 @@ namespace webrtc
  
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
         std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;
+        std::unique_ptr<Clock> m_clock;
 
         // todo(kazuki): remove these callback methods by moving hardware encoder instance to DummyVideoEncoder.
         //               attention point is multi-threaded opengl implementation with nvcodec.

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -124,20 +124,22 @@ namespace webrtc
 //---------------------------------------------------------------------------------------------------------------------
     rtc::scoped_refptr<webrtc::I420Buffer> MetalGraphicsDevice::ConvertRGBToI420(ITexture2D* tex){
         id<MTLTexture> nativeTex = (__bridge id<MTLTexture>)tex->GetNativeTexturePtrV();
-        const uint32_t BYTES_PER_PIXEL = 4;
-        
+        if (nil == nativeTex)
+            return nullptr;
+
+        const uint32_t BYTES_PER_PIXEL = 4;        
         const uint32_t width  = tex->GetWidth();
         const uint32_t height = tex->GetHeight();
         const uint32_t bytesPerRow = width * BYTES_PER_PIXEL;
         const uint32_t bufferSize = bytesPerRow * height;
-        
 
         std::vector<uint8_t> buffer;
         buffer.resize(bufferSize);
-        if (nil == nativeTex)
-            return nullptr;
         
-        [nativeTex getBytes:buffer.data() bytesPerRow:bytesPerRow fromRegion:MTLRegionMake2D(0,0,width,height) mipmapLevel:0];
+        [nativeTex getBytes:buffer.data()
+            bytesPerRow:bytesPerRow
+            fromRegion:MTLRegionMake2D(0,0,width,height)
+            mipmapLevel:0];
 
         rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = GraphicsUtility::ConvertRGBToI420Buffer(
             width, height,

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -8,14 +8,14 @@ namespace webrtc
 
 //---------------------------------------------------------------------------------------------------------------------
 
-    MetalTexture2D::MetalTexture2D(uint32_t w, uint32_t h, id<MTLTexture> tex) : ITexture2D(w,h)
-            , m_texture(tex)
+    MetalTexture2D::MetalTexture2D(uint32_t w, uint32_t h, id<MTLTexture> tex)
+    : ITexture2D(w,h) , m_texture(tex)
     {
     }
 
     MetalTexture2D::~MetalTexture2D()
     {
-        [m_texture release];
+        m_texture = nullptr;
     }
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -56,9 +56,6 @@ namespace webrtc
         std::vector<webrtc::SdpVideoFormat> filtered;
         std::copy_if(formats.begin(), formats.end(), std::back_inserter(filtered),
             [](webrtc::SdpVideoFormat format) {
-                if(format.parameters.count("profile-level-id") == 0)
-                    return false;
-                std::string id = format.parameters.at("profile-level-id");
                 if(format.name.find("H264") == std::string::npos)
                     return false;
                 return true;

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -63,7 +63,7 @@ namespace webrtc
         return filtered;
 #else
         return { webrtc::CreateH264Format(
-            webrtc::H264::kProfileConstrainedHigh,
+            webrtc::H264::kProfileConstrainedBaseline,
             webrtc::H264::kLevel5_1, "1") };
 #endif
     }

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.h
@@ -23,9 +23,10 @@ namespace webrtc
         virtual std::vector<webrtc::SdpVideoFormat> GetHardwareEncoderFormats() const;
 
         UnityVideoEncoderFactory(IVideoEncoderObserver* observer);
+        ~UnityVideoEncoderFactory();
     private:
         IVideoEncoderObserver* m_observer;
-        const std::unique_ptr<VideoEncoderFactory> internal_encoder_factory_;
+        std::unique_ptr<VideoEncoderFactory> internal_encoder_factory_;
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -19,8 +19,7 @@ UnityVideoTrackSource::UnityVideoTrackSource(
     is_screencast_(is_screencast),
     needs_denoising_(needs_denoising),
     encoder_(nullptr),
-    frame_(frame),
-    clock_(webrtc::Clock::GetRealTimeClock())
+    frame_(frame)
 {
 //  DETACH_FROM_THREAD(thread_checker_);
 
@@ -68,7 +67,7 @@ void UnityVideoTrackSource::SetEncoder(IEncoder* encoder)
 }
 
 
-void UnityVideoTrackSource::OnFrameCaptured()
+void UnityVideoTrackSource::OnFrameCaptured(int64_t timestamp_us)
 {
     // todo::(kazuki)
     // OnFrame(frame);
@@ -86,7 +85,6 @@ void UnityVideoTrackSource::OnFrameCaptured()
         LogPrint("Copy texture buffer is failed");
         return;
     }
-    int64_t timestamp_us = clock_->TimeInMicroseconds();
     if (!encoder_->EncodeFrame(timestamp_us))
     {
         LogPrint("Encode frame is failed");

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -16,10 +16,11 @@ UnityVideoTrackSource::UnityVideoTrackSource(
     bool is_screencast,
     absl::optional<bool> needs_denoising) :
     AdaptedVideoTrackSource(/*required_alignment=*/1),
-    frame_(frame),
-    encoder_(nullptr),
     is_screencast_(is_screencast),
-    needs_denoising_(needs_denoising)
+    needs_denoising_(needs_denoising),
+    encoder_(nullptr),
+    frame_(frame),
+    clock_(webrtc::Clock::GetRealTimeClock())
 {
 //  DETACH_FROM_THREAD(thread_checker_);
 
@@ -85,7 +86,8 @@ void UnityVideoTrackSource::OnFrameCaptured()
         LogPrint("Copy texture buffer is failed");
         return;
     }
-    if (!encoder_->EncodeFrame())
+    int64_t timestamp_us = clock_->TimeInMicroseconds();
+    if (!encoder_->EncodeFrame(timestamp_us))
     {
         LogPrint("Encode frame is failed");
         return;

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -92,6 +92,7 @@ class UnityVideoTrackSource :
 #if defined(SUPPORT_VULKAN)
     UnityVulkanImage unityVulkanImage_;
 #endif
+  webrtc::Clock* clock_;
 };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -43,7 +43,7 @@ class UnityVideoTrackSource :
     absl::optional<bool> needs_denoising() const override;
 
     // todo(kazuki)::
-    void OnFrameCaptured();
+    void OnFrameCaptured(int64_t timestampe_us);
 
     // todo(kazuki)::
     void DelegateOnFrame(const ::webrtc::VideoFrame& frame) { OnFrame(frame); }

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -5,6 +5,8 @@
 #include "Codec/EncoderFactory.h"
 #include "Codec/IEncoder.h"
 
+using namespace ::webrtc;
+
 namespace unity
 {
 namespace webrtc
@@ -42,7 +44,7 @@ TEST_P(NvEncoderTest, CopyBuffer) {
 
 TEST_P(NvEncoderTest, EncodeFrame) {
     auto before = encoder_->GetCurrentFrameCount();
-    EXPECT_TRUE(encoder_->EncodeFrame());
+    EXPECT_TRUE(encoder_->EncodeFrame(0));
     const auto after = encoder_->GetCurrentFrameCount();
     EXPECT_EQ(before + 1, after);
 }

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -67,7 +67,7 @@ protected:
 
     void SendTestFrame(int width, int height)
     {
-        m_trackSource->OnFrameCaptured();
+        m_trackSource->OnFrameCaptured(0);
     }
 };
 


### PR DESCRIPTION
This pull request is changes to provide a hardware encoder using [VideoToolbox](https://developer.apple.com/documentation/videotoolbox) on MacOS.

VideoToolbox is supported almost Mac devices.
You can use it if you set a value `EncoderType.Hardware` to `WebRTC.Initialize` method. 
In this case, the video codec is as H.264 codec.