### PR TITLE
refactor: Add ScopedProfiler class to make simple to use profiler

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -157,7 +157,6 @@ namespace webrtc
     Context::Context(int uid, UnityEncoderType encoderType)
         : m_uid(uid)
         , m_encoderType(encoderType)
-        , m_clock(Clock::GetRealTimeClock())
     {
         m_workerThread.reset(new rtc::Thread(rtc::SocketServer::CreateDefault()));
         m_workerThread->Start();
@@ -245,16 +244,6 @@ namespace webrtc
     bool Context::FinalizeEncoder(IEncoder* encoder)
     {
         m_mapIdAndEncoder.erase(encoder->Id());
-        return true;
-    }
-
-    bool Context::EncodeFrame(MediaStreamTrackInterface* track)
-    {
-        UnityVideoTrackSource* source = GetVideoSource(track);
-        if (source == nullptr)
-            return false;
-        int64_t timestamp_us = m_clock->TimeInMicroseconds();
-        source->OnFrameCaptured(timestamp_us);
         return true;
     }
 

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -4,6 +4,7 @@
 #include "DummyVideoEncoder.h"
 #include "PeerConnectionObject.h"
 #include "UnityVideoRenderer.h"
+#include "UnityVideoTrackSource.h"
 #include "Codec/IEncoder.h"
 
 using namespace ::webrtc;
@@ -16,7 +17,6 @@ namespace webrtc
     class Context;
     class IGraphicsDevice;
     class MediaStreamObserver;
-    class UnityVideoTrackSource;
     class SetSessionDescriptionObserver;
     class ContextManager
     {
@@ -94,7 +94,6 @@ namespace webrtc
         bool InitializeEncoder(IEncoder* encoder, webrtc::MediaStreamTrackInterface* track);
         bool FinalizeEncoder(IEncoder* encoder);
         // You must call these methods on Rendering thread.
-        bool EncodeFrame(webrtc::MediaStreamTrackInterface* track);
         const VideoEncoderParameter* GetEncoderParameter(const webrtc::MediaStreamTrackInterface* track);
         void SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height);
 
@@ -121,7 +120,6 @@ namespace webrtc
  
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
         std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;
-        Clock* m_clock;
 
         // todo(kazuki): remove these callback methods by moving hardware encoder instance to DummyVideoEncoder.
         //               attention point is multi-threaded opengl implementation with nvcodec.

--- a/Plugin~/WebRTCPlugin/ScopedProfiler.cpp
+++ b/Plugin~/WebRTCPlugin/ScopedProfiler.cpp
@@ -1,0 +1,25 @@
+#include "pch.h"
+#include "ScopedProfiler.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    IUnityProfiler* ScopedProfiler::UnityProfiler = nullptr;
+
+    ScopedProfiler::ScopedProfiler(const UnityProfilerMarkerDesc& desc)
+    : m_desc(&desc)
+    {
+        if (UnityProfiler == nullptr || UnityProfiler->IsAvailable() == 0)
+            return;
+        UnityProfiler->BeginSample(m_desc);
+    }
+
+    ScopedProfiler::~ScopedProfiler()
+    {
+        if (UnityProfiler == nullptr || UnityProfiler->IsAvailable() == 0)
+            return;
+        UnityProfiler->EndSample(m_desc);
+    }
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPlugin/ScopedProfiler.h
+++ b/Plugin~/WebRTCPlugin/ScopedProfiler.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <IUnityProfiler.h>
+
+namespace unity
+{
+namespace webrtc
+{
+
+class ScopedProfiler
+{
+public:
+    static IUnityProfiler* UnityProfiler;
+
+    ScopedProfiler(const UnityProfilerMarkerDesc &desc);
+    ~ScopedProfiler();
+private:
+    void operator =(const ScopedProfiler& src) const {}
+    ScopedProfiler(const ScopedProfiler& src) {}
+
+    const UnityProfilerMarkerDesc* m_desc;
+};
+
+} // end namespace webrtc
+} // end namespace unity


### PR DESCRIPTION
`IUnityProfiler` class is very useful to profile CPU load of the specific operations. 
But we have to write tedious code like this.

```cpp
if (s_IsDevelopmentBuild && s_UnityProfiler != nullptr)
    s_UnityProfiler->BeginSample(marker);
//
// write code 
//
if (s_IsDevelopmentBuild && s_UnityProfiler != nullptr)
    s_UnityProfiler->EndSample(marker);
```

Also this code has risk which no call `EndSample`.

`ScopedProfiler` class imitates `std::lock_guard` class which releases a resource when call destructor.
 
```cpp
{
    ScopedProfiler profiler(*marker);
    //
    // write code 
    //
}
```