### PR TITLE
fix: crash when hangup open webrtcstatuswindow

### DIFF
--- a/Editor/PeerListView.cs
+++ b/Editor/PeerListView.cs
@@ -29,8 +29,13 @@ namespace Unity.WebRTC.Editor
             m_parent.OnPeerList += peerList =>
             {
                 container.Clear();
-                foreach (var peerConnection in peerList)
+                foreach (var weakReference in peerList)
                 {
+                    if (!weakReference.TryGetTarget(out var peerConnection))
+                    {
+                        continue;
+                    }
+
                     var button = new Button(() =>
                     {
                         OnChangePeer?.Invoke(peerConnection);

--- a/Editor/WebRTCStats.cs
+++ b/Editor/WebRTCStats.cs
@@ -12,7 +12,7 @@ using UnityEngine.UIElements;
 
 namespace Unity.WebRTC.Editor
 {
-    public delegate void OnPeerListHandler(IEnumerable<RTCPeerConnection> peerList);
+    public delegate void OnPeerListHandler(IEnumerable<WeakReference<RTCPeerConnection>> peerList);
 
     public delegate void OnStatsReportHandler(RTCPeerConnection peer, RTCStatsReport statsReport);
 
@@ -118,8 +118,13 @@ namespace Unity.WebRTC.Editor
                 {
                     OnPeerList?.Invoke(peerList);
 
-                    foreach (var peer in peerList)
+                    foreach (var weakReference in peerList)
                     {
+                        if (!weakReference.TryGetTarget(out var peer))
+                        {
+                            continue;
+                        }
+
                         var op = peer.GetStats();
                         yield return op;
 

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -101,7 +101,7 @@ namespace webrtc
             }           
         }
         encoder->InitV();
-        return encoder;
+        return std::move(encoder);
     }
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -30,8 +30,6 @@ namespace webrtc
     , m_bufferFormat(bufferFormat)
     , m_clock(webrtc::Clock::GetRealTimeClock())
     {
-        LogPrint(StringFormat("width is %d, height is %d", width, height).c_str());
-        checkf(width > 0 && height > 0, "Invalid width or height!");
     }
 
     void NvEncoder::InitV()
@@ -122,6 +120,8 @@ namespace webrtc
 
     NvEncoder::~NvEncoder()
     {
+        RTC_LOG(LS_INFO) << "NvEncoder destructor";
+
         ReleaseEncoderResources();
         if (pEncoderInterface)
         {
@@ -152,7 +152,7 @@ namespace webrtc
         NvEncodeAPIGetMaxSupportedVersion(&version);
         if (currentVersion > version)
         {
-            LogPrint("Current Driver Version does not support this NvEncodeAPI version, please upgrade driver");
+            RTC_LOG(LS_INFO) << "Current Driver Version does not support this NvEncodeAPI version, please upgrade driver";
             return CodecInitializationResult::DriverVersionDoesNotSupportAPI;
         }
 
@@ -165,7 +165,7 @@ namespace webrtc
 
         if (!NvEncodeAPICreateInstance)
         {
-            LogPrint("Cannot find NvEncodeAPICreateInstance() entry in NVENC library");
+            RTC_LOG(LS_INFO) << "Cannot find NvEncodeAPICreateInstance() entry in NVENC library";
             return CodecInitializationResult::APINotFound;
         }
         bool result = (NvEncodeAPICreateInstance(pNvEncodeAPI.get()) == NV_ENC_SUCCESS);
@@ -194,7 +194,7 @@ namespace webrtc
 
         if (module == nullptr)
         {
-            LogPrint("NVENC library file is not found. Please ensure NV driver is installed");
+            RTC_LOG(LS_INFO) << "NVENC library file is not found. Please ensure NV driver is installed";
             return false;
         }
         s_hModule = module;
@@ -334,7 +334,7 @@ namespace webrtc
         registerResource.resourceToRegister = buffer;
 
         if (!registerResource.resourceToRegister)
-            LogPrint("resource is not initialized");
+            RTC_LOG(LS_INFO) << "resource is not initialized";
         registerResource.width = m_width;
         registerResource.height = m_height;
         if (inputType !=NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY)

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Collections;
 
 namespace Unity.WebRTC
 {
     internal class Context : IDisposable
     {
         internal IntPtr self;
-        internal Hashtable table;
+        internal WeakReferenceTable table;
 
         private int id;
         private bool disposed;
@@ -28,7 +27,7 @@ namespace Unity.WebRTC
         {
             self = ptr;
             this.id = id;
-            this.table = new Hashtable();
+            this.table = new WeakReferenceTable();
         }
 
         ~Context()
@@ -44,8 +43,10 @@ namespace Unity.WebRTC
             }
             if (self != IntPtr.Zero)
             {
-                foreach(var value in table.Values)
+                foreach (var value in table.CopiedValues)
                 {
+                    if (value == null)
+                        continue;
                     var disposable = value as IDisposable;
                     disposable.Dispose();
                 }

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -31,7 +31,6 @@ namespace Unity.WebRTC
         ~MediaStream()
         {
             this.Dispose();
-            WebRTC.Table.Remove(self);
         }
 
         public void Dispose()
@@ -43,6 +42,7 @@ namespace Unity.WebRTC
             if(self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Context.DeleteMediaStream(this);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
             this.disposed = true;

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -58,7 +58,6 @@ namespace Unity.WebRTC
         ~MediaStreamTrack()
         {
             this.Dispose();
-            WebRTC.Table.Remove(self);
         }
 
         public virtual void Dispose()
@@ -71,6 +70,7 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Context.DeleteMediaStreamTrack(self);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
 

--- a/Runtime/Scripts/RTCDataChannel.cs
+++ b/Runtime/Scripts/RTCDataChannel.cs
@@ -115,7 +115,6 @@ namespace Unity.WebRTC
         ~RTCDataChannel()
         {
             this.Dispose();
-            WebRTC.Table.Remove(self);
         }
 
         public void Dispose()
@@ -128,6 +127,7 @@ namespace Unity.WebRTC
             {
                 Close();
                 WebRTC.Context.DeleteDataChannel(self);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
             this.disposed = true;

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -42,7 +42,6 @@ namespace Unity.WebRTC
         ~RTCPeerConnection()
         {
             this.Dispose();
-            WebRTC.Table.Remove(self);
         }
 
         /// <summary>
@@ -59,6 +58,7 @@ namespace Unity.WebRTC
             {
                 Close();
                 WebRTC.Context.DeletePeerConnection(self);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
 

--- a/Runtime/Scripts/RTCStats.cs
+++ b/Runtime/Scripts/RTCStats.cs
@@ -759,7 +759,6 @@ namespace Unity.WebRTC
         ~RTCStatsReport()
         {
             this.Dispose();
-            WebRTC.Table.Remove(self);
         }
 
         public void Dispose()
@@ -772,6 +771,7 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Context.DeleteStatsReport(self);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -173,6 +173,7 @@ namespace Unity.WebRTC
 
                 tracks.Remove(this);
                 WebRTC.Context.DeleteMediaStreamTrack(self);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
 
@@ -233,7 +234,6 @@ namespace Unity.WebRTC
         ~UnityVideoRenderer()
         {
             this.Dispose();
-            WebRTC.Table.Remove(self);
         }
 
         public void Dispose()
@@ -251,6 +251,7 @@ namespace Unity.WebRTC
                 }
 
                 WebRTC.Context.DeleteVideoRenderer(self);
+                WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }
 

--- a/Runtime/Scripts/WeakReferenceTable.cs
+++ b/Runtime/Scripts/WeakReferenceTable.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections;
+
+namespace Unity.WebRTC
+{
+    static class WeakReferenceExtension
+    {
+        public static object NullOrValue(this WeakReference reference)
+        {
+            return reference.IsAlive ? reference.Target : null;
+        }
+    }
+
+    internal class WeakReferenceTable
+    {
+        private Hashtable m_table = new Hashtable();
+
+        public void Add(object key, object value)
+        {
+            m_table.Add(key, new WeakReference(value));
+        }
+
+        public void Remove(object key)
+        {
+            m_table.Remove(key);
+        }
+
+        public object this[object key]
+        {
+            get
+            {
+                WeakReference reference = m_table[key] as WeakReference;
+                return reference.NullOrValue();
+            }
+        }
+
+        public ICollection CopiedValues
+        {
+            get
+            {
+                var array = new object[m_table.Count];
+                int i = 0;
+                foreach (var value in m_table.Values)
+                {
+                    var reference = value as WeakReference;
+                    array[i] = reference.NullOrValue();
+                    i++;
+                }
+                return array;
+            }
+        }
+
+        public void Clear()
+        {
+            m_table.Clear();
+        }
+
+        public bool ContainsKey(object key)
+        {
+            return m_table.ContainsKey(key);
+        }
+    }
+}

--- a/Runtime/Scripts/WeakReferenceTable.cs.meta
+++ b/Runtime/Scripts/WeakReferenceTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28cb7c32e4f32f448aa8626fabf33e52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -427,18 +427,18 @@ namespace Unity.WebRTC
             }
         }
 
-        public static IReadOnlyList<RTCPeerConnection> PeerList
+        public static IReadOnlyList<WeakReference<RTCPeerConnection>> PeerList
         {
             get
             {
-                var list = new List<RTCPeerConnection>();
+                var list = new List<WeakReference<RTCPeerConnection>>();
                 if (Table?.Values != null)
                 {
                     foreach (var value in Table?.Values)
                     {
                         if (value is RTCPeerConnection peer)
                         {
-                            list.Add(peer);
+                            list.Add(new WeakReference<RTCPeerConnection>(peer));
                         }
                     }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -402,7 +402,7 @@ namespace Unity.WebRTC
         }
 
         internal static Context Context { get { return s_context; } }
-        internal static Hashtable Table { get { return s_context?.table; } }
+        internal static WeakReferenceTable Table { get { return s_context?.table; } }
 
         public static bool SupportHardwareEncoder
         {
@@ -432,9 +432,10 @@ namespace Unity.WebRTC
             get
             {
                 var list = new List<WeakReference<RTCPeerConnection>>();
-                if (Table?.Values != null)
+                var values = Table?.CopiedValues;
+                if (values != null)
                 {
-                    foreach (var value in Table?.Values)
+                    foreach (var value in values)
                     {
                         if (value is RTCPeerConnection peer)
                         {

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -120,6 +120,10 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.IsNotEmpty(parameters.TransactionId);
             Assert.AreEqual(1, peer.GetTransceivers().Count());
             Assert.NotNull(peer.GetTransceivers().First());
+
+            track.Dispose();
+            stream.Dispose();
+            peer.Dispose();
         }
 
         [Test]
@@ -268,6 +272,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             RTCSessionDescription invalid = new RTCSessionDescription { sdp = "this is invalid parameter" };
             Assert.Throws<RTCErrorException>(() => peer.SetLocalDescription(ref invalid));
+
+            peer.Dispose();
         }
 
         [UnityTest]
@@ -320,6 +326,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             RTCSessionDescription invalid = new RTCSessionDescription { sdp = "this is invalid parameter" };
             Assert.Throws<RTCErrorException>(() => peer.SetRemoteDescription(ref invalid));
+
+            peer.Dispose();
         }
 
 


### PR DESCRIPTION
Add fix to this PR.
https://github.com/Unity-Technologies/com.unity.webrtc/pull/225

The cause of issue is that instances of the reference table are not removed even if dispose the instance.
In this PR, move the method call of `WebRTC.Table.Remove` into Dispose method. 