### PR TITLE
chore: using graphicformat for setencoderparameter

### DIFF
--- a/BuildScripts~/build_plugin.sh
+++ b/BuildScripts~/build_plugin.sh
@@ -27,6 +27,7 @@ sudo cp googlemock/gtest/*.a "/usr/lib"
 cd "$SOLUTION_DIR"
 cmake -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
+      -DCMAKE_BUILD_TYPE="Release" \
       .
 make
 

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -44,7 +44,7 @@ namespace webrtc
     }
 
     //Can throw exception. The caller is expected to catch it.
-    std::unique_ptr<IEncoder> EncoderFactory::Init(int width, int height, IGraphicsDevice* device, UnityEncoderType encoderType, UnityColorSpace colorSpace)
+    std::unique_ptr<IEncoder> EncoderFactory::Init(int width, int height, IGraphicsDevice* device, UnityEncoderType encoderType, UnityRenderingExtTextureFormat textureFormat)
     {
         std::unique_ptr<IEncoder> encoder;
         const GraphicsDeviceType deviceType = device->GetDeviceType();
@@ -53,9 +53,9 @@ namespace webrtc
             case GRAPHICS_DEVICE_D3D11: {
                 if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
-                    encoder = std::make_unique<NvEncoderD3D11>(width, height, device, colorSpace);
+                    encoder = std::make_unique<NvEncoderD3D11>(width, height, device, textureFormat);
                 } else {
-                    encoder = std::make_unique<SoftwareEncoder>(width, height, device, colorSpace);
+                    encoder = std::make_unique<SoftwareEncoder>(width, height, device, textureFormat);
                 }
                 break;
             }
@@ -64,16 +64,16 @@ namespace webrtc
             case GRAPHICS_DEVICE_D3D12: {
                 if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
-                    encoder = std::make_unique<NvEncoderD3D12>(width, height, device, colorSpace);
+                    encoder = std::make_unique<NvEncoderD3D12>(width, height, device, textureFormat);
                 } else {
-                    encoder = std::make_unique<SoftwareEncoder>(width, height, device, colorSpace);
+                    encoder = std::make_unique<SoftwareEncoder>(width, height, device, textureFormat);
                 }
                 break;
             }
 #endif
 #if defined(SUPPORT_OPENGL_CORE)
             case GRAPHICS_DEVICE_OPENGL: {
-                encoder = std::make_unique<NvEncoderGL>(width, height, device, colorSpace);
+                encoder = std::make_unique<NvEncoderGL>(width, height, device, textureFormat);
                 break;
             }
 #endif
@@ -81,17 +81,17 @@ namespace webrtc
             case GRAPHICS_DEVICE_VULKAN: {
                 if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
-                    encoder = std::make_unique<NvEncoderCuda>(width, height, device, colorSpace);
+                    encoder = std::make_unique<NvEncoderCuda>(width, height, device, textureFormat);
                 }
                 else {
-                    encoder = std::make_unique<SoftwareEncoder>(width, height, device, colorSpace);
+                    encoder = std::make_unique<SoftwareEncoder>(width, height, device, textureFormat);
                 }
                 break;
             }
 #endif            
 #if defined(SUPPORT_METAL)
             case GRAPHICS_DEVICE_METAL: {
-                encoder = std::make_unique<SoftwareEncoder>(width, height, device, colorSpace);
+                encoder = std::make_unique<SoftwareEncoder>(width, height, device, textureFormat);
                 break;
             }
 #endif            

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.h
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.h
@@ -14,7 +14,7 @@ namespace webrtc
     public:
         static EncoderFactory& GetInstance();
         static bool GetHardwareEncoderSupport();
-        std::unique_ptr<IEncoder> Init(int width, int height, IGraphicsDevice* device, UnityEncoderType encoderType, UnityColorSpace colorSpace); //Can throw exception.
+        std::unique_ptr<IEncoder> Init(int width, int height, IGraphicsDevice* device, UnityEncoderType encoderType, UnityRenderingExtTextureFormat textureFormat); //Can throw exception.
     private:
         EncoderFactory() = default;
         EncoderFactory(EncoderFactory const&) = delete;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -24,11 +24,11 @@ namespace webrtc
         const int width,
         const int height,
         IGraphicsDevice* device,
-        UnityColorSpace colorSpace)
+        UnityRenderingExtTextureFormat textureFormat)
     : m_width(width)
     , m_height(height)
     , m_device(device)
-    , m_colorSpace(colorSpace)
+    , m_textureFormat(textureFormat)
     , m_deviceType(type)
     , m_inputType(inputType)
     , m_bufferFormat(bufferFormat)
@@ -374,7 +374,7 @@ namespace webrtc
     {
         for (uint32 i = 0; i < bufferedFrameNum; i++)
         {
-            renderTextures[i] = m_device->CreateDefaultTextureV(m_width, m_height, m_colorSpace);
+            renderTextures[i] = m_device->CreateDefaultTextureV(m_width, m_height, m_textureFormat);
             void* buffer = AllocateInputResourceV(renderTextures[i]);
 
             Frame& frame = bufferedFrames[i];

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -38,7 +38,7 @@ namespace webrtc
             int width,
             int height,
             IGraphicsDevice* device,
-            UnityColorSpace colorSpace);
+            UnityRenderingExtTextureFormat textureFormat);
         virtual ~NvEncoder();
 
         static CodecInitializationResult LoadCodec();
@@ -60,7 +60,7 @@ namespace webrtc
         int m_width;
         int m_height;
         IGraphicsDevice* m_device;
-        UnityColorSpace m_colorSpace;
+        UnityRenderingExtTextureFormat m_textureFormat;
 
         NV_ENC_DEVICE_TYPE m_deviceType;
         NV_ENC_INPUT_RESOURCE_TYPE m_inputType;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
@@ -13,8 +13,8 @@ namespace unity
 namespace webrtc
 {
 
-    NvEncoderCuda::NvEncoderCuda(const uint32_t nWidth, const uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, colorSpace)
+    NvEncoderCuda::NvEncoderCuda(const uint32_t nWidth, const uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
+        NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, textureFormat)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.h
@@ -9,7 +9,7 @@ namespace webrtc
     class NvEncoderCuda : public NvEncoder
     {
     public:
-        NvEncoderCuda(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace);
+        NvEncoderCuda(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
         void InitV() override;
         virtual ~NvEncoderCuda() = default;
     protected:

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.cpp
@@ -9,8 +9,8 @@ namespace unity
 namespace webrtc
 {
     
-    NvEncoderD3D11::NvEncoderD3D11(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_DIRECTX, NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, colorSpace)
+    NvEncoderD3D11::NvEncoderD3D11(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
+        NvEncoder(NV_ENC_DEVICE_TYPE_DIRECTX, NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, textureFormat)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.h
@@ -9,7 +9,7 @@ namespace webrtc
     class NvEncoderD3D11 : public NvEncoder
     {
     public:
-        NvEncoderD3D11(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace);
+        NvEncoderD3D11(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFromat);
         virtual ~NvEncoderD3D11();
     protected:
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.cpp
@@ -9,8 +9,8 @@ namespace unity
 namespace webrtc
 {
 
-    NvEncoderD3D12::NvEncoderD3D12(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_DIRECTX, NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, colorSpace)
+    NvEncoderD3D12::NvEncoderD3D12(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
+        NvEncoder(NV_ENC_DEVICE_TYPE_DIRECTX, NV_ENC_INPUT_RESOURCE_TYPE_DIRECTX, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, textureFormat)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.h
@@ -8,7 +8,7 @@ namespace webrtc
 
     class NvEncoderD3D12 : public NvEncoder {
     public:
-        NvEncoderD3D12(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace);
+        NvEncoderD3D12(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
         virtual ~NvEncoderD3D12();
     protected:
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.cpp
@@ -9,8 +9,8 @@ namespace unity
 namespace webrtc
 {
 
-    NvEncoderGL::NvEncoderGL(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_OPENGL, NV_ENC_INPUT_RESOURCE_TYPE_OPENGL_TEX, NV_ENC_BUFFER_FORMAT_ABGR, nWidth, nHeight, device, colorSpace)
+    NvEncoderGL::NvEncoderGL(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
+        NvEncoder(NV_ENC_DEVICE_TYPE_OPENGL, NV_ENC_INPUT_RESOURCE_TYPE_OPENGL_TEX, NV_ENC_BUFFER_FORMAT_ABGR, nWidth, nHeight, device, textureFormat)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.h
@@ -8,7 +8,7 @@ namespace webrtc
 
     class NvEncoderGL : public NvEncoder {
     public:
-        NvEncoderGL(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace);
+        NvEncoderGL(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
         virtual ~NvEncoderGL();
     protected:
         virtual void* AllocateInputResourceV(ITexture2D* tex) override;

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
@@ -12,17 +12,17 @@ namespace unity
 namespace webrtc
 {
 
-    SoftwareEncoder::SoftwareEncoder(int width, int height, IGraphicsDevice* device, UnityColorSpace colorSpace) :
+    SoftwareEncoder::SoftwareEncoder(int width, int height, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
     m_device(device),
     m_width(width),
     m_height(height),
-    m_colorSpace(colorSpace)
+    m_textureFormat(textureFormat)
     {
     }
 
     void SoftwareEncoder::InitV()
     {
-        m_encodeTex = m_device->CreateCPUReadTextureV(m_width, m_height, m_colorSpace);
+        m_encodeTex = m_device->CreateCPUReadTextureV(m_width, m_height, m_textureFormat);
         m_initializationResult = CodecInitializationResult::Success;
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -14,7 +14,7 @@ namespace webrtc
     class SoftwareEncoder : public IEncoder
     {
     public:
-        SoftwareEncoder(int _width, int _height, IGraphicsDevice* device, UnityColorSpace colorSpace);
+        SoftwareEncoder(int _width, int _height, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
         void InitV() override;
         void SetRates(uint32_t bitRate, int64_t frameRate) override {}
         void UpdateSettings() override {}
@@ -29,7 +29,7 @@ namespace webrtc
         ITexture2D* m_encodeTex;
         int m_width = 1920;
         int m_height = 1080;
-        UnityColorSpace m_colorSpace;
+        UnityRenderingExtTextureFormat m_textureFormat;
         uint64 m_frameCount = 0;
     };
 //---------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.h
+++ b/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.h
@@ -10,7 +10,7 @@ namespace webrtc
 
     class VTEncoderMetal : public IEncoder{
     public:
-        VTEncoderMetal(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace);
+        VTEncoderMetal(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
         ~VTEncoderMetal();
         void SetRates(uint32_t bitRate, int64_t frameRate) override {};
         void UpdateSettings() override {};
@@ -25,7 +25,7 @@ namespace webrtc
         uint64 m_width = 0;
         uint64 m_height = 0;
         IGraphicsDevice* m_device;
-        UnityColorSpace m_colorSpace;
+        UnityRenderingExtTextureFormat m_textureFormat;
         ITexture2D* renderTextures[bufferedFrameNum];
         CVPixelBufferRef pixelBuffers[bufferedFrameNum];
         std::vector<uint8> encodedBuffers[bufferedFrameNum];

--- a/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.mm
+++ b/Plugin~/WebRTCPlugin/Codec/VideoToolbox/VTEncoderMetal.mm
@@ -139,8 +139,8 @@ namespace webrtc
         encoder->CaptureFrame(*encodedFrame);
     }
 
-    VTEncoderMetal::VTEncoderMetal(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityColorSpace colorSpace)
-        : m_device(device), m_width(nWidth), m_height(nHeight), m_colorSpace(colorSpace)
+    VTEncoderMetal::VTEncoderMetal(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat)
+        : m_device(device), m_width(nWidth), m_height(nHeight), m_textureFormat(textureFormat)
     {
         OSStatus status = VTCompressionSessionCreate(NULL, nWidth, nHeight,
                                                      kCMVideoCodecType_H264,
@@ -176,12 +176,11 @@ namespace webrtc
             }
 
             CVMetalTextureRef imageTexture;
-            MTLPixelFormat pixelFormat = m_colorSpace == Linear ? MTLPixelFormatBGRA8Unorm_sRGB : MTLPixelFormatBGRA8Unorm;
             result = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
                                                                textureCache,
                                                                pixelBuffers[i],
                                                                nil,
-                                                               pixelFormat,
+                                                               MTLPixelFormatBGRA8Unorm_sRGB,
                                                                m_width, m_height, 0,
                                                                &imageTexture);
             if(result != kCVReturnSuccess)

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -252,9 +252,9 @@ namespace webrtc
         return m_mapVideoEncoderParameter[track].get();
     }
 
-    void Context::SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height, UnityColorSpace colorSpace)
+    void Context::SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height, UnityRenderingExtTextureFormat textureFormat)
     {
-        m_mapVideoEncoderParameter[track] = std::make_unique<VideoEncoderParameter>(width, height, colorSpace);
+        m_mapVideoEncoderParameter[track] = std::make_unique<VideoEncoderParameter>(width, height, textureFormat);
     }
 
     void Context::SetKeyFrame(uint32_t id)

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -40,9 +40,9 @@ namespace webrtc
     {
         int width;
         int height;
-        UnityColorSpace colorSpace;
-        VideoEncoderParameter(int width, int height, UnityColorSpace colorSpace)
-            : width(width), height(height), colorSpace(colorSpace)
+        UnityRenderingExtTextureFormat textureFormat;
+        VideoEncoderParameter(int width, int height, UnityRenderingExtTextureFormat textureFormat)
+            : width(width), height(height), textureFormat(textureFormat)
         {
         }
     };
@@ -99,7 +99,7 @@ namespace webrtc
         bool FinalizeEncoder(IEncoder* encoder);
         // You must call these methods on Rendering thread.
         const VideoEncoderParameter* GetEncoderParameter(const webrtc::MediaStreamTrackInterface* track);
-        void SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height, UnityColorSpace colorSpace);
+        void SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height, UnityRenderingExtTextureFormat format);
 
         // mutex;
         std::mutex mutex;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -32,7 +32,7 @@ void D3D11GraphicsDevice::ShutdownV() {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ITexture2D* D3D11GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* D3D11GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
 
     ID3D11Texture2D* texture = nullptr;
     D3D11_TEXTURE2D_DESC desc = { 0 };
@@ -50,7 +50,7 @@ ITexture2D* D3D11GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, U
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ITexture2D* D3D11GraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* D3D11GraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
 
     ID3D11Texture2D* texture = nullptr;
     D3D11_TEXTURE2D_DESC desc = { 0 };

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
@@ -15,8 +15,8 @@ public:
     virtual bool InitV() override;
     virtual void ShutdownV() override;
     inline virtual void* GetEncodeDevicePtrV() override;
-    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) override;
-    virtual ITexture2D* CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) override;
+    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
+    virtual ITexture2D* CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
     virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
     virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
     inline virtual GraphicsDeviceType GetDeviceType() const override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -87,7 +87,7 @@ void D3D12GraphicsDevice::ShutdownV() {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ITexture2D* D3D12GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* D3D12GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
 
     return CreateSharedD3D12Texture(w,h);
 }
@@ -214,7 +214,7 @@ void D3D12GraphicsDevice::Barrier(ID3D12Resource* res,
 
 //----------------------------------------------------------------------------------------------------------------------
 
-ITexture2D* D3D12GraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* D3D12GraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
     D3D12Texture2D* tex = CreateSharedD3D12Texture(w,h);
     const HRESULT hr = tex->CreateReadbackResource(m_d3d12Device);
     if (FAILED(hr)){

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -48,12 +48,12 @@ public:
     virtual void ShutdownV() override;
     inline virtual void* GetEncodeDevicePtrV() override;
 
-    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) override;
+    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
     virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
     virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
     inline virtual GraphicsDeviceType GetDeviceType() const override;
 
-    virtual ITexture2D* CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) override;
+    virtual ITexture2D* CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
     virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
 
 private:

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -16,14 +16,14 @@ public:
     virtual ~IGraphicsDevice() = 0;
     virtual bool InitV() = 0;
     virtual void ShutdownV() = 0;
-    virtual ITexture2D* CreateDefaultTextureV(uint32_t width, uint32_t height, UnityColorSpace colorSpace) = 0;
+    virtual ITexture2D* CreateDefaultTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) = 0;
     virtual void* GetEncodeDevicePtrV() = 0;
     virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) = 0;
     virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) = 0;
     virtual GraphicsDeviceType GetDeviceType() const = 0;
 
     //Required for software encoding
-    virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityColorSpace colorSpace) = 0;
+    virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) = 0;
     virtual rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) = 0;
 
 };

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
@@ -18,9 +18,9 @@ namespace webrtc
         virtual void ShutdownV() override;
         inline virtual void* GetEncodeDevicePtrV() override;
 
-        virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) override;
+        virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
         virtual ITexture2D* CreateDefaultTextureFromNativeV(uint32_t w, uint32_t h, void* nativeTexturePtr);
-        virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityColorSpace colorSpace) override;
+        virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) override;
         virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         inline virtual GraphicsDeviceType GetDeviceType() const override;
@@ -32,6 +32,8 @@ namespace webrtc
         
         bool CopyTexture(id<MTLTexture> dest, id<MTLTexture> src);
         IUnityGraphicsMetal* m_unityGraphicsMetal;
+
+        static MTLPixelFormat ConvertFormat(UnityRenderingExtTextureFormat format);
     };
 
     void* MetalGraphicsDevice::GetEncodeDevicePtrV() { return m_device; }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -31,9 +31,9 @@ namespace webrtc
     }
 
 //---------------------------------------------------------------------------------------------------------------------
-    ITexture2D* MetalGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+    ITexture2D* MetalGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
         MTLTextureDescriptor *textureDescriptor = [[MTLTextureDescriptor alloc] init];
-        textureDescriptor.pixelFormat = colorSpace == Linear ? MTLPixelFormatBGRA8Unorm_sRGB : MTLPixelFormatBGRA8Unorm;
+        textureDescriptor.pixelFormat = ConvertFormat(textureFormat);
         textureDescriptor.width = w;
         textureDescriptor.height = h;
         id<MTLTexture> texture = [m_device newTextureWithDescriptor:textureDescriptor];
@@ -107,10 +107,10 @@ namespace webrtc
     }
 
 //---------------------------------------------------------------------------------------------------------------------
-    ITexture2D* MetalGraphicsDevice::CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityColorSpace colorSpace)
+    ITexture2D* MetalGraphicsDevice::CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat)
     {
         MTLTextureDescriptor *textureDescriptor = [[MTLTextureDescriptor alloc] init];
-        textureDescriptor.pixelFormat = colorSpace == Linear ? MTLPixelFormatBGRA8Unorm_sRGB : MTLPixelFormatBGRA8Unorm;
+        textureDescriptor.pixelFormat = ConvertFormat(textureFormat);
         textureDescriptor.width = width;
         textureDescriptor.height = height;
         textureDescriptor.allowGPUOptimizedContents = false;
@@ -146,6 +146,19 @@ namespace webrtc
             bytesPerRow, buffer.data()
         );
         return i420_buffer;
+    }
+
+//---------------------------------------------------------------------------------------------------------------------
+    MTLPixelFormat MetalGraphicsDevice::ConvertFormat(UnityRenderingExtTextureFormat format)
+    {
+        switch(format) {
+            case kUnityRenderingExtFormatB8G8R8A8_SRGB:
+                return MTLPixelFormatBGRA8Unorm_sRGB;
+            case kUnityRenderingExtFormatB8G8R8A8_UNorm:
+                return MTLPixelFormatBGRA8Unorm;
+            default:
+                return MTLPixelFormatInvalid;
+        }
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -35,7 +35,7 @@ void OpenGLGraphicsDevice::ShutdownV() {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ITexture2D* OpenGLGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* OpenGLGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
 
     GLuint tex;
     glGenTextures(1, &tex);
@@ -46,7 +46,7 @@ ITexture2D* OpenGLGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, 
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ITexture2D* OpenGLGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* OpenGLGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
     assert(false && "CreateCPUReadTextureV need to implement on OpenGL");
     return nullptr;
 }
@@ -73,17 +73,17 @@ bool OpenGLGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativ
 bool OpenGLGraphicsDevice::CopyResource(GLuint dstName, GLuint srcName, uint32 width, uint32 height) {
     if(srcName == dstName)
     {
-        LogPrint("Same texture");
+//        LogPrint("Same texture");
         return false;
     }
     if(glIsTexture(srcName) == GL_FALSE)
     {
-        LogPrint("srcName is not texture");
+//        LogPrint("srcName is not texture");
         return false;
     }
     if(glIsTexture(dstName) == GL_FALSE)
     {
-        LogPrint("dstName is not texture");
+//        LogPrint("dstName is not texture");
         return false;
     }
     glCopyImageSubData(

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
@@ -19,8 +19,8 @@ public:
     virtual void ShutdownV();
     inline virtual void* GetEncodeDevicePtrV();
 
-    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace);
-    virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityColorSpace colorSpace);
+    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat);
+    virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat);
     virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src);
     virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex);
     virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<UnityVulkanImage> VulkanGraphicsDevice::AccessTexture(void* ptr)
 }
 
 //Returns null if failed
-ITexture2D* VulkanGraphicsDevice::CreateDefaultTextureV(const uint32_t w, const uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* VulkanGraphicsDevice::CreateDefaultTextureV(const uint32_t w, const uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
 
     VulkanTexture2D* vulkanTexture = new VulkanTexture2D(w, h);
     if (!vulkanTexture->Init(m_physicalDevice, m_device)) {
@@ -113,7 +113,7 @@ ITexture2D* VulkanGraphicsDevice::CreateDefaultTextureV(const uint32_t w, const 
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ITexture2D* VulkanGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityColorSpace colorSpace) {
+ITexture2D* VulkanGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
     VulkanTexture2D* vulkanTexture = new VulkanTexture2D(w, h);
     if (!vulkanTexture->InitCpuRead(m_physicalDevice, m_device)) {
         vulkanTexture->Shutdown();

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -21,8 +21,8 @@ public:
     virtual bool InitV() override;
     virtual void ShutdownV() override;
     inline virtual void* GetEncodeDevicePtrV() override;
-    virtual ITexture2D* CreateDefaultTextureV(const uint32_t w, const uint32_t h, UnityColorSpace colorSpace) override;
-    virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityColorSpace colorSpace) override;
+    virtual ITexture2D* CreateDefaultTextureV(const uint32_t w, const uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
+    virtual ITexture2D* CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) override;
 
     std::unique_ptr<UnityVulkanImage> AccessTexture(void* ptr) const;
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -188,7 +188,7 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
             const VideoEncoderParameter* param = s_context->GetEncoderParameter(track);
             const UnityEncoderType encoderType = s_context->GetEncoderType();
             s_mapEncoder[track] = EncoderFactory::GetInstance().Init(
-                param->width, param->height, s_gfxDevice, encoderType, param->colorSpace);
+                param->width, param->height, s_gfxDevice, encoderType, param->textureFormat);
             if (!s_context->InitializeEncoder(s_mapEncoder[track].get(), track))
             {
                 // DebugLog("Encoder initialization faild.");

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -105,9 +105,9 @@ extern "C"
         return context->GetInitializationResult(track);
     }
 
-    UNITY_INTERFACE_EXPORT void ContextSetVideoEncoderParameter(Context* context, MediaStreamTrackInterface* track, int width, int height, UnityColorSpace colorSpace)
+    UNITY_INTERFACE_EXPORT void ContextSetVideoEncoderParameter(Context* context, MediaStreamTrackInterface* track, int width, int height, UnityRenderingExtTextureFormat textureFormat)
     {
-        context->SetEncoderParameter(track, width, height, colorSpace);
+        context->SetEncoderParameter(track, width, height, textureFormat);
     }
 
     UNITY_INTERFACE_EXPORT MediaStreamInterface* ContextCreateMediaStream(Context* context, const char* streamId)

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -68,6 +68,7 @@
 #pragma endregion
 
 #include "PlatformBase.h"
+#include "IUnityRenderingExtensions.h"
 
 #if defined(SUPPORT_D3D11)
 #include <comdef.h>
@@ -155,13 +156,6 @@ namespace webrtc
     {
         UnityEncoderSoftware = 0,
         UnityEncoderHardware = 1,
-    };
-
-    enum UnityColorSpace
-    {
-        Uninitialized = -1,
-        Gamma = 0,
-        Linear = 1,
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -23,7 +23,7 @@ protected:
         GraphicsDeviceTestBase::SetUp();
         EXPECT_NE(nullptr, m_device);
 
-        encoder_ = EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_colorSpace);
+        encoder_ = EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_textureFormat);
         EXPECT_NE(nullptr, encoder_);
 
         context = std::make_unique<Context>();
@@ -33,7 +33,7 @@ protected:
     }
 };
 TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_NE(nullptr, tex);
     const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
@@ -46,7 +46,7 @@ TEST_P(ContextTest, CreateAndDeleteMediaStream) {
 
 
 TEST_P(ContextTest, CreateAndDeleteVideoTrack) {
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_NE(nullptr, tex.get());
     const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
     EXPECT_NE(nullptr, track);
@@ -70,7 +70,7 @@ TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
 }
 
 TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     const auto stream = context->CreateMediaStream("videostream");
     const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
     const auto videoTrack = reinterpret_cast<webrtc::VideoTrackInterface*>(track);
@@ -113,7 +113,7 @@ TEST_P(ContextTest, EqualRendererGetById) {
 }
 
 TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
     const auto renderer = context->CreateVideoRenderer();
     track->AddOrUpdateSink(renderer, rtc::VideoSinkWants());

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -16,7 +16,7 @@ TEST_P(GraphicsDeviceTest, GraphicsDeviceIsNotNull) {
 TEST_P(GraphicsDeviceTest, CreateDefaultTextureV) {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_TRUE(tex->IsSize(width, height));
     EXPECT_NE(nullptr, tex->GetEncodeTexturePtrV());
     EXPECT_NE(nullptr, tex->GetNativeTexturePtrV());
@@ -27,7 +27,7 @@ TEST_P(GraphicsDeviceTest, CreateDefaultTextureV) {
 TEST_P(GraphicsDeviceTest, CreateCPUReadTextureV) {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateCPUReadTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateCPUReadTextureV(width, height, m_textureFormat));
     EXPECT_TRUE(tex->IsSize(width, height));
     EXPECT_NE(nullptr, tex->GetNativeTexturePtrV());
     EXPECT_FALSE(tex->IsSize(0, 0));
@@ -41,24 +41,24 @@ TEST_P(GraphicsDeviceTest, CreateCPUReadTextureV) {
 TEST_P(GraphicsDeviceTest, CopyResourceV) {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> src(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
-    const std::unique_ptr<ITexture2D> dst(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> src(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> dst(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_TRUE(m_device->CopyResourceV(dst.get(), src.get()));
 }
 
 TEST_P(GraphicsDeviceTest, CopyResourceNativeV) {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> src(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
-    const std::unique_ptr<ITexture2D> dst(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> src(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> dst(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_TRUE(m_device->CopyResourceFromNativeV(dst.get(), src->GetNativeTexturePtrV()));
 }
 
 TEST_P(GraphicsDeviceTest, ConvertRGBToI420) {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> src(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
-    const std::unique_ptr <ITexture2D> dst(m_device->CreateCPUReadTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> src(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr <ITexture2D> dst(m_device->CreateCPUReadTextureV(width, height, m_textureFormat));
     EXPECT_TRUE(m_device->CopyResourceFromNativeV(dst.get(), src->GetNativeTexturePtrV()));
     const auto frameBuffer = m_device->ConvertRGBToI420(dst.get());
     EXPECT_NE(nullptr, frameBuffer);

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -359,7 +359,7 @@ void* CreateDevice(UnityGfxRenderer renderer)
 
 GraphicsDeviceTestBase::GraphicsDeviceTestBase()
 {
-    std::tie(m_unityGfxRenderer, m_encoderType, m_colorSpace) = GetParam();
+    std::tie(m_unityGfxRenderer, m_encoderType, m_textureFormat) = GetParam();
     const auto pGraphicsDevice = CreateDevice(m_unityGfxRenderer);
     const auto unityInterface = CreateUnityInterface(m_unityGfxRenderer);
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -12,7 +12,7 @@ using testing::Values;
 
 class IGraphicsDevice;
 class GraphicsDeviceTestBase
-    : public testing::TestWithParam<tuple<UnityGfxRenderer, UnityEncoderType, UnityColorSpace> >
+    : public testing::TestWithParam<tuple<UnityGfxRenderer, UnityEncoderType, UnityRenderingExtTextureFormat> >
 {
 public:
     GraphicsDeviceTestBase();
@@ -21,37 +21,37 @@ protected:
     IGraphicsDevice* m_device;
     UnityEncoderType m_encoderType;
     UnityGfxRenderer m_unityGfxRenderer;
-    UnityColorSpace m_colorSpace;
+    UnityRenderingExtTextureFormat m_textureFormat;
 };
 
-static tuple<UnityGfxRenderer, UnityEncoderType, UnityColorSpace> VALUES_TEST_ENV[] = {
+static tuple<UnityGfxRenderer, UnityEncoderType, UnityRenderingExtTextureFormat> VALUES_TEST_ENV[] = {
 #if defined(SUPPORT_D3D11)
-    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Linear },
-    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Linear },
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB},
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm },
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererD3D11, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm },
 #endif // defined(SUPPORT_D3D11)
 #if defined(SUPPORT_D3D12)
-    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Linear },
-    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Linear },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererD3D12, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm },
 #endif // defined(SUPPORT_D3D12)
 #if defined(SUPPORT_METAL)
-    { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Linear }
+    { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererMetal, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm }
 #endif // defined(SUPPORT_METAL)
 // todo::(kazuki) windows support
 // todo::(kazuki) software encoder support
 #if defined(SUPPORT_OPENGL_UNIFIED) & defined(UNITY_LINUX)
-    { kUnityGfxRendererOpenGLCore, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererOpenGLCore, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Linear },
+    { kUnityGfxRendererOpenGLCore, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererOpenGLCore, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm },
 #endif // defined(SUPPORT_OPENGL_UNIFIED)
 #if defined(SUPPORT_VULKAN)
-    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderHardware, UnityColorSpace::Linear },
-    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Gamma },
-    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderSoftware, UnityColorSpace::Linear }
+    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderHardware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm },
+    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_SRGB },
+    { kUnityGfxRendererVulkan, UnityEncoderType::UnityEncoderSoftware, UnityRenderingExtTextureFormat::kUnityRenderingExtFormatB8G8R8A8_UNorm }
 #endif // defined(SUPPORT_VULKAN)
 };
 

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -23,7 +23,7 @@ protected:
 
         const auto width = 256;
         const auto height = 256;
-        encoder_ = EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_colorSpace);
+        encoder_ = EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_textureFormat);
         EXPECT_NE(nullptr, encoder_);
     }
     void TearDown() override {
@@ -37,7 +37,7 @@ TEST_P(NvEncoderTest, IsSupported) {
 TEST_P(NvEncoderTest, CopyBuffer) {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_colorSpace));
+    const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     const auto result = encoder_->CopyBuffer(tex->GetNativeTexturePtrV());
     EXPECT_TRUE(result);
 }

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -23,8 +23,8 @@ class VideoRendererTest : public GraphicsDeviceTestBase
 {
 public:
     VideoRendererTest() :
-        encoder_(EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_colorSpace)),
-        m_texture(m_device->CreateDefaultTextureV(width, height, m_colorSpace))
+        encoder_(EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_textureFormat)),
+        m_texture(m_device->CreateDefaultTextureV(width, height, m_textureFormat))
     {
         m_trackSource = new rtc::RefCountedObject<UnityVideoTrackSource>(
             m_texture->GetNativeTexturePtrV(),

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -28,8 +28,8 @@ class VideoTrackSourceTest : public GraphicsDeviceTestBase
 {
 public:
     VideoTrackSourceTest() :
-        encoder_(EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_colorSpace)),
-        m_texture(m_device->CreateDefaultTextureV(width, height, m_colorSpace))
+        encoder_(EncoderFactory::GetInstance().Init(width, height, m_device, m_encoderType, m_textureFormat)),
+        m_texture(m_device->CreateDefaultTextureV(width, height, m_textureFormat))
     {
         m_trackSource = new rtc::RefCountedObject<UnityVideoTrackSource>(
             m_texture->GetNativeTexturePtrV(),

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 
 namespace Unity.WebRTC
 {
@@ -184,9 +185,9 @@ namespace Unity.WebRTC
             NativeMethods.ContextDeleteStatsReport(self, report);
         }
 
-        public void SetVideoEncoderParameter(IntPtr track, int width, int height, ColorSpace colorSpace)
+        public void SetVideoEncoderParameter(IntPtr track, int width, int height, GraphicsFormat format)
         {
-            NativeMethods.ContextSetVideoEncoderParameter(self, track, width, height, colorSpace);
+            NativeMethods.ContextSetVideoEncoderParameter(self, track, width, height, format);
         }
 
         public CodecInitializationResult GetInitializationResult(IntPtr track)

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 
 namespace Unity.WebRTC
 {
@@ -25,7 +26,7 @@ namespace Unity.WebRTC
 
         internal VideoStreamTrack(string label, UnityEngine.Texture source, UnityEngine.RenderTexture dest, int width,
             int height)
-            : this(label, dest.GetNativeTexturePtr(), width, height)
+            : this(label, dest.GetNativeTexturePtr(), width, height, source.graphicsFormat)
         {
             m_needFlip = true;
             m_sourceTexture = source;
@@ -134,11 +135,11 @@ namespace Unity.WebRTC
         /// <param name="ptr"></param>
         /// <param name="width"></param>
         /// <param name="height"></param>
-        public VideoStreamTrack(string label, IntPtr ptr, int width, int height)
+        /// <param name="format"></param>
+        public VideoStreamTrack(string label, IntPtr ptr, int width, int height, GraphicsFormat format)
             : base(WebRTC.Context.CreateVideoTrack(label, ptr))
         {
-            ColorSpace colorSpace = QualitySettings.activeColorSpace;
-            WebRTC.Context.SetVideoEncoderParameter(self, width, height, colorSpace);
+            WebRTC.Context.SetVideoEncoderParameter(self, width, height, format);
             WebRTC.Context.InitializeEncoder(self);
             tracks.Add(this);
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
 namespace Unity.WebRTC
@@ -522,7 +523,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteStatsReport(IntPtr context, IntPtr report);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height, ColorSpace colorSpace);
+        public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height, GraphicsFormat format);
         [DllImport(WebRTC.Lib)]
         public static extern CodecInitializationResult GetInitializationResult(IntPtr context, IntPtr track);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -22,7 +22,6 @@ namespace Unity.WebRTC.RuntimeTest
     class NativeAPITestWithSoftwareEncoder
     {
         protected EncoderType encoderType;
-        private ColorSpace colorSpace;
 
         private static RenderTexture CreateRenderTexture(int width, int height)
         {
@@ -42,7 +41,6 @@ namespace Unity.WebRTC.RuntimeTest
         public void Init()
         {
             NativeMethods.RegisterDebugLog(DebugLog);
-            colorSpace = QualitySettings.activeColorSpace;
         }
 
         [TearDown]
@@ -372,7 +370,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(CodecInitializationResult.NotInitialized, NativeMethods.GetInitializationResult(context, track));
 
             // todo:: You must call `InitializeEncoder` method after `NativeMethods.ContextCaptureVideoStream`
-            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, colorSpace);
+            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, renderTexture.graphicsFormat);
             VideoEncoderMethods.InitializeEncoder(callback, track);
             yield return new WaitForSeconds(1.0f);
 
@@ -425,7 +423,7 @@ namespace Unity.WebRTC.RuntimeTest
             var renderEvent = NativeMethods.GetRenderEventFunc(context);
             var updateTextureEvent = NativeMethods.GetUpdateTextureFunc(context);
 
-            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, colorSpace);
+            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, renderTexture.graphicsFormat);
             VideoEncoderMethods.InitializeEncoder(renderEvent, track);
             yield return new WaitForSeconds(1.0f);
 


### PR DESCRIPTION
depend on https://github.com/Unity-Technologies/com.unity.webrtc/pull/227

Using graphics format for `SetEncoderParameter` instead of  color space.