### PR TITLE
fix: Check hardware encoder support when initialize

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -39,7 +39,11 @@ namespace webrtc
         // todo(kazuki): check VideoToolbox compatibility
         return true;
 #else
-        return NvEncoder::LoadModule();
+        if(!NvEncoder::LoadModule())
+        {
+            return false;
+        }
+        return NvEncoder::CheckDriverVersion();
 #endif
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -43,6 +43,7 @@ namespace webrtc
 
         static CodecInitializationResult LoadCodec();
         static bool LoadModule();
+        static bool CheckDriverVersion();
         static void UnloadModule();
         static uint32_t GetNumChromaPlanes(NV_ENC_BUFFER_FORMAT);
         static uint32_t GetChromaHeight(const NV_ENC_BUFFER_FORMAT bufferFormat, const uint32_t lumaHeight);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -17,6 +17,11 @@ namespace Unity.WebRTC
 
         public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware)
         {
+            if (encoderType == EncoderType.Hardware && !NativeMethods.GetHardwareEncoderSupport())
+            {
+                throw new ArgumentException("Hardware encoder is not supported");
+            }
+
             var ptr = NativeMethods.ContextCreate(id, encoderType);
             return new Context(ptr, id);
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -233,7 +233,7 @@ namespace Unity.WebRTC
 #elif UNITY_STANDALONE
         internal const string Lib = "webrtc";
 #endif
-        private static Context s_context;
+        private static Context s_context = null;
         private static SynchronizationContext s_syncContext;
         internal static Material flipMat;
 


### PR DESCRIPTION
Related issue.
https://github.com/Unity-Technologies/com.unity.webrtc/issues/199

This issue occurred in the specific environment which not installed NVIDIA driver like Parallel Desktop.
To avoid invalid situations, throw an exception from `WebRTC.Initialize`.