### PR TITLE
refactor: Change type of RTCStats dictionary key in RTCStatsReport class

### DIFF
--- a/Editor/PeerStatsView.cs
+++ b/Editor/PeerStatsView.cs
@@ -10,7 +10,7 @@ namespace Unity.WebRTC.Editor
     {
         private readonly WebRTCStats m_parent;
         private readonly RTCPeerConnection m_peerConnection;
-        private ICollection<(RTCStatsType, string)> m_lastUpdateKeys;
+        private ICollection<string> m_lastUpdateKeys;
 
         public PeerStatsView(RTCPeerConnection peer, WebRTCStats parent)
         {
@@ -35,7 +35,7 @@ namespace Unity.WebRTC.Editor
 
                 var container = new VisualElement();
 
-                var popup = new PopupField<(RTCStatsType type, string id)>(m_lastUpdateKeys.ToList(), 0, tuple => $"{tuple.type}_{tuple.id}", tuple => $"{tuple.type}_{tuple.id}");
+                var popup = new PopupField<string>(m_lastUpdateKeys.ToList(), 0, id => $"{id}", id => $"{id}");
 
                 root.Add(popup);
                 root.Add(container);
@@ -43,8 +43,9 @@ namespace Unity.WebRTC.Editor
                 popup.RegisterValueChangedCallback(e =>
                 {
                     container.Clear();
-                    var id = e.newValue.id;
-                    switch (e.newValue.type)
+                    var id = e.newValue;
+                    var type = report.Get(id).Type;
+                    switch (type)
                     {
                         case RTCStatsType.Codec:
                             container.Add(CreateCodecView(id));
@@ -110,7 +111,7 @@ namespace Unity.WebRTC.Editor
                             container.Add(CreateIceServerView(id));
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException($"this type is not supported : {e.newValue.type}");
+                            throw new ArgumentOutOfRangeException($"this type is not supported : {type}");
                     }
                 });
             };
@@ -132,7 +133,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Codec, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCCodecStats codecStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Codec}"));
@@ -166,7 +167,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.InboundRtp, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCInboundRTPStreamStats inboundStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.InboundRtp}"));
@@ -239,7 +240,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.OutboundRtp, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCOutboundRTPStreamStats outboundStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.OutboundRtp}"));
@@ -307,7 +308,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.RemoteInboundRtp, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCRemoteInboundRtpStreamStats remoteInboundStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.RemoteInboundRtp}"));
@@ -334,7 +335,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.RemoteOutboundRtp, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCRemoteOutboundRtpStreamStats remoteOutboundStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.RemoteOutboundRtp}"));
@@ -364,7 +365,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.MediaSource, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCMediaSourceStats mediaSourceStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.MediaSource}"));
@@ -413,7 +414,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Csrc, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCCodecStats csrcStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Csrc}"));
@@ -440,7 +441,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.PeerConnection, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCPeerConnectionStats peerStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Codec}"));
@@ -471,7 +472,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.DataChannel, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCDataChannelStats dataChannelStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.DataChannel}"));
@@ -512,7 +513,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Stream, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCMediaStreamStats streamStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Stream}"));
@@ -544,7 +545,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Track, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCMediaStreamTrackStats trackStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Track}"));
@@ -629,7 +630,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Transceiver, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCTransceiverStats transceiverStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Transceiver}"));
@@ -656,7 +657,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Sender, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCSenderStats senderStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Sender}"));
@@ -683,7 +684,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Receiver, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCReceiverStats receiverStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Receiver}"));
@@ -712,7 +713,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Transport, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCTransportStats transportStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Transport}"));
@@ -759,7 +760,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.SctpTransport, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCTransportStats transportStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Codec}"));
@@ -806,7 +807,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.CandidatePair, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCIceCandidatePairStats candidatePairStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.CandidatePair}"));
@@ -879,7 +880,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.LocalCandidate, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCIceCandidateStats candidateStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.LocalCandidate}"));
@@ -917,7 +918,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.RemoteCandidate, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCIceCandidateStats candidateStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.RemoteCandidate}"));
@@ -955,7 +956,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.Certificate, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCCertificateStats certificateStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Certificate}"));
@@ -989,7 +990,7 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
-                if (!report.Stats.TryGetValue((RTCStatsType.IceServer, id), out var stats) ||
+                if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCCertificateStats outboundStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.IceServer}"));

--- a/Editor/WebRTCStats.cs
+++ b/Editor/WebRTCStats.cs
@@ -183,12 +183,12 @@ namespace Unity.WebRTC.Editor
     public class PeerConnectionRecord
     {
         private readonly RTCConfiguration m_config;
-        private readonly Dictionary<(RTCStatsType, string), StatsRecord> m_statsRecordMap;
+        private readonly Dictionary<string, StatsRecord> m_statsRecordMap;
 
         public PeerConnectionRecord(RTCConfiguration config)
         {
             m_config = config;
-            m_statsRecordMap = new Dictionary<(RTCStatsType, string), StatsRecord>();
+            m_statsRecordMap = new Dictionary<string, StatsRecord>();
         }
 
         public void Update(RTCStatsReport report)

--- a/Runtime/Scripts/RTCStats.cs
+++ b/Runtime/Scripts/RTCStats.cs
@@ -731,7 +731,7 @@ namespace Unity.WebRTC
     public class RTCStatsReport : IDisposable
     {
         private IntPtr self;
-        private readonly Dictionary<(RTCStatsType, string), RTCStats> m_dictStats;
+        private readonly Dictionary<string, RTCStats> m_dictStats;
 
         private bool disposed;
 
@@ -747,12 +747,12 @@ namespace Unity.WebRTC
             IntPtr[] array = ptrStatsArray.AsArray<IntPtr>((int)length);
             byte[] types = ptrStatsTypeArray.AsArray<byte>((int)length);
 
-            m_dictStats = new Dictionary<(RTCStatsType, string), RTCStats>();
+            m_dictStats = new Dictionary<string, RTCStats>();
             for (int i = 0; i < length; i++)
             {
                 RTCStatsType type = (RTCStatsType)types[i];
                 RTCStats stats = StatsFactory.Create(type, array[i]);
-                m_dictStats[(type, stats.Id)] = stats;
+                m_dictStats[stats.Id] = stats;
             }
         }
 
@@ -779,9 +779,17 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
-        //internal
+        public RTCStats Get(string id)
+        {
+            return m_dictStats[id];
+        }
 
-        public IDictionary<(RTCStatsType, string), RTCStats> Stats
+        public bool TryGetValue(string id, out RTCStats stats)
+        {
+            return m_dictStats.TryGetValue(id, out stats);
+        }
+
+        public IDictionary<string, RTCStats> Stats
         {
             get { return m_dictStats; }
         }

--- a/Samples~/StatsSample.cs
+++ b/Samples~/StatsSample.cs
@@ -318,7 +318,7 @@ public class StatsSample : MonoBehaviour
                 List<string> options = new List<string>();
                 foreach (var stat in op1.Value.Stats.Keys)
                 {
-                    options.Add($"{stat.Item1}-{stat.Item2}");
+                    options.Add($"{stat}");
                 }
                 dropdown.ClearOptions();
                 dropdown.AddOptions(options);
@@ -329,13 +329,11 @@ public class StatsSample : MonoBehaviour
                 currentValue = dropdown.value;
             }
 
-            var currentOption = dropdown.options[currentValue].text.Split('-');
+            var id = dropdown.options[currentValue].text;
 
-            var type = (RTCStatsType)Enum.Parse(typeof(RTCStatsType), currentOption[0]);
-            var id = currentOption[1];
-            text.text = "Id:" + op1.Value.Stats[(type, id)].Id + "\n";
-            text.text += "Timestamp:" + op1.Value.Stats[(type, id)].Timestamp + "\n";
-            text.text += op1.Value.Stats[(type, id)].Dict.Aggregate(string.Empty, (str, next) => str + next.Key + ":" + next.Value.ToString() + "\n");
+            text.text = "Id:" + op1.Value.Stats[id].Id + "\n";
+            text.text += "Timestamp:" + op1.Value.Stats[id].Timestamp + "\n";
+            text.text += op1.Value.Stats[id].Dict.Aggregate(string.Empty, (str, next) => str + next.Key + ":" + next.Value.ToString() + "\n");
         }
     }
 


### PR DESCRIPTION
This PR changes type of `RTCStats` dictionary key to `string` instead of composite key.
For this change, developers can use `RTCStatsReport.Get` method to get `RTCStats` value.
 
You can see added API below:

```csharp
RTCStats stats = report.Get(statsId);
```
or
```csharp
if(report.TryGetValue(statsId, out RTCStats stats))
{
   ...
}
```
