### PR TITLE
fix: video streaming receiver is not worked with vulkan API

### DIFF
--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -16,10 +16,10 @@ namespace Unity.WebRTC
 
         UnityVideoRenderer m_renderer;
 
-        private static UnityEngine.RenderTexture CreateRenderTexture(int width, int height,
-            UnityEngine.RenderTextureFormat format)
+        private static RenderTexture CreateRenderTexture(int width, int height,
+            RenderTextureFormat format)
         {
-            var tex = new UnityEngine.RenderTexture(width, height, 0, format);
+            var tex = new RenderTexture(width, height, 0, format);
             tex.Create();
             return tex;
         }
@@ -54,15 +54,31 @@ namespace Unity.WebRTC
             }
         }
 
-        public UnityEngine.RenderTexture InitializeReceiver(int width, int height)
+        //public UnityEngine.RenderTexture InitializeReceiver(int width, int height)
+        //{
+        //    if (IsDecoderInitialized)
+        //        throw new InvalidOperationException("Already initialized receiver");
+
+        //    m_needFlip = true;
+        //    var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
+        //    m_sourceTexture = CreateRenderTexture(width, height, format);
+        //    m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
+
+        //    m_renderer = new UnityVideoRenderer(WebRTC.Context.CreateVideoRenderer(), this);
+
+        //    return m_destTexture;
+        //}
+
+        public UnityEngine.Texture InitializeReceiver(int width, int height)
         {
             if (IsDecoderInitialized)
                 throw new InvalidOperationException("Already initialized receiver");
 
             m_needFlip = true;
-            var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
-            m_sourceTexture = CreateRenderTexture(width, height, format);
-            m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
+            var format = WebRTC.GetSupportedTextureFormat(SystemInfo.graphicsDeviceType);
+            m_sourceTexture = new Texture2D(width, height, format, false);
+            var format2 = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format2);
 
             m_renderer = new UnityVideoRenderer(WebRTC.Context.CreateVideoRenderer(), this);
 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -17,7 +17,7 @@ namespace Unity.WebRTC
         UnityVideoRenderer m_renderer;
 
         private static RenderTexture CreateRenderTexture(int width, int height,
-            RenderTextureFormat format)
+            GraphicsFormat format)
         {
             var tex = new RenderTexture(width, height, 0, format);
             tex.Create();
@@ -54,21 +54,6 @@ namespace Unity.WebRTC
             }
         }
 
-        //public UnityEngine.RenderTexture InitializeReceiver(int width, int height)
-        //{
-        //    if (IsDecoderInitialized)
-        //        throw new InvalidOperationException("Already initialized receiver");
-
-        //    m_needFlip = true;
-        //    var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
-        //    m_sourceTexture = CreateRenderTexture(width, height, format);
-        //    m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
-
-        //    m_renderer = new UnityVideoRenderer(WebRTC.Context.CreateVideoRenderer(), this);
-
-        //    return m_destTexture;
-        //}
-
         public UnityEngine.Texture InitializeReceiver(int width, int height)
         {
             if (IsDecoderInitialized)
@@ -76,9 +61,8 @@ namespace Unity.WebRTC
 
             m_needFlip = true;
             var format = WebRTC.GetSupportedTextureFormat(SystemInfo.graphicsDeviceType);
-            m_sourceTexture = new Texture2D(width, height, format, false);
-            var format2 = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
-            m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format2);
+            m_sourceTexture = new Texture2D(width, height, format, TextureCreationFlags.None);
+            m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
 
             m_renderer = new UnityVideoRenderer(WebRTC.Context.CreateVideoRenderer(), this);
 
@@ -124,7 +108,7 @@ namespace Unity.WebRTC
         /// <param name="width"></param>
         /// <param name="height"></param>
         public VideoStreamTrack(string label, UnityEngine.RenderTexture source)
-            : this(label, source, CreateRenderTexture(source.width, source.height, source.format), source.width,
+            : this(label, source, CreateRenderTexture(source.width, source.height, source.graphicsFormat), source.width,
                 source.height)
         {
         }
@@ -133,7 +117,7 @@ namespace Unity.WebRTC
             : this(label,
                 source,
                 CreateRenderTexture(source.width, source.height,
-                    WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
+                    WebRTC.GetSupportedTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
                 source.width,
                 source.height)
         {

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -60,7 +60,7 @@ namespace Unity.WebRTC
                 throw new InvalidOperationException("Already initialized receiver");
 
             m_needFlip = true;
-            var format = WebRTC.GetSupportedTextureFormat(SystemInfo.graphicsDeviceType);
+            var format = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
             m_sourceTexture = new Texture2D(width, height, format, TextureCreationFlags.None);
             m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
 
@@ -117,7 +117,7 @@ namespace Unity.WebRTC
             : this(label,
                 source,
                 CreateRenderTexture(source.width, source.height,
-                    WebRTC.GetSupportedTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
+                    WebRTC.GetSupportedGraphicsFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
                 source.width,
                 source.height)
         {

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -369,21 +369,21 @@ namespace Unity.WebRTC
             return RenderTextureFormat.Default;
         }
 
-        public static TextureFormat GetSupportedTextureFormat(GraphicsDeviceType type)
+        public static GraphicsFormat GetSupportedTextureFormat(GraphicsDeviceType type)
         {
             switch (type)
             {
                 case UnityEngine.Rendering.GraphicsDeviceType.Direct3D11:
                 case UnityEngine.Rendering.GraphicsDeviceType.Direct3D12:
-                    return TextureFormat.BGRA32;
+                    return GraphicsFormat.B8G8R8A8_SRGB;
                 case UnityEngine.Rendering.GraphicsDeviceType.Vulkan:
-                    return TextureFormat.RGBA32;
+                    return GraphicsFormat.R8G8B8A8_SRGB;
                 case UnityEngine.Rendering.GraphicsDeviceType.OpenGLCore:
                 case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES2:
                 case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3:
-                    return TextureFormat.ARGB32;
+                    return GraphicsFormat.R8G8B8A8_SRGB;
                 case UnityEngine.Rendering.GraphicsDeviceType.Metal:
-                    return TextureFormat.BGRA32;
+                    return GraphicsFormat.B8G8R8A8_SRGB;
             }
             throw new ArgumentException("Graphics device type not supported");
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
@@ -368,6 +367,25 @@ namespace Unity.WebRTC
                     return RenderTextureFormat.BGRA32;
             }
             return RenderTextureFormat.Default;
+        }
+
+        public static TextureFormat GetSupportedTextureFormat(GraphicsDeviceType type)
+        {
+            switch (type)
+            {
+                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D11:
+                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D12:
+                    return TextureFormat.BGRA32;
+                case UnityEngine.Rendering.GraphicsDeviceType.Vulkan:
+                    return TextureFormat.RGBA32;
+                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLCore:
+                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES2:
+                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3:
+                    return TextureFormat.ARGB32;
+                case UnityEngine.Rendering.GraphicsDeviceType.Metal:
+                    return TextureFormat.BGRA32;
+            }
+            throw new ArgumentException("Graphics device type not supported");
         }
 
         internal static IEnumerable<T> Deserialize<T>(IntPtr buf, int length, Func<IntPtr, T> constructor) where T : class

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -369,7 +369,7 @@ namespace Unity.WebRTC
             return RenderTextureFormat.Default;
         }
 
-        public static GraphicsFormat GetSupportedTextureFormat(GraphicsDeviceType type)
+        public static GraphicsFormat GetSupportedGraphicsFormat(GraphicsDeviceType type)
         {
             switch (type)
             {

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -45,6 +45,9 @@ public class BandwidthSample : MonoBehaviour
         { "125",  125 },
     };
 
+    private const int width = 1280;
+    private const int height = 720;
+
     private RTCOfferOptions _offerOptions = new RTCOfferOptions
     {
         iceRestart = false, offerToReceiveAudio = true, offerToReceiveVideo = true
@@ -94,7 +97,7 @@ public class BandwidthSample : MonoBehaviour
 
             if (e.Track is VideoStreamTrack track)
             {
-                receiveImage.texture = track.InitializeReceiver(1280, 720);
+                receiveImage.texture = track.InitializeReceiver(width, height);
                 receiveImage.color = Color.white;
             }
         };
@@ -227,7 +230,7 @@ public class BandwidthSample : MonoBehaviour
 
         if (videoStream == null)
         {
-            videoStream = cam.CaptureStream(1280, 720, 1000000);
+            videoStream = cam.CaptureStream(width, height, 1000000);
         }
         sourceImage.texture = cam.targetTexture;
         sourceImage.color = Color.white;

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
@@ -59,7 +59,7 @@ namespace Unity.WebRTC.RuntimeTest
             var sendStream = new MediaStream();
             var receiveStream = new MediaStream();
             VideoStreamTrack receiveVideoTrack = null;
-            RenderTexture receiveImage = null;
+            Texture receiveImage = null;
             receiveStream.OnAddTrack = e =>
             {
                 if (e.Track is VideoStreamTrack track)

--- a/WebRTC~/ProjectSettings/ProjectSettings.asset
+++ b/WebRTC~/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 18
+  serializedVersion: 20
   productGUID: 9f7b1246933b6e24f9f5ea8882213bb8
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -47,12 +47,11 @@ PlayerSettings:
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
-  m_ActiveColorSpace: 0
+  m_ActiveColorSpace: 1
   m_MTRendering: 1
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
-  displayResolutionDialog: 0
   iosUseCustomAppBackgroundBehavior: 0
   iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
@@ -85,7 +84,6 @@ PlayerSettings:
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
-  graphicsJobs: 0
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0
   xboxEnableKinect: 0
@@ -93,7 +91,6 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  graphicsJobMode: 0
   fullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
@@ -106,6 +103,7 @@ PlayerSettings:
   xboxOneMonoLoggingLevel: 0
   xboxOneLoggingLevel: 1
   xboxOneDisableEsram: 0
+  xboxOneEnableTypeOptimization: 0
   xboxOnePresentImmediateThreshold: 0
   switchQueueCommandMemory: 0
   switchQueueControlMemory: 16384
@@ -113,7 +111,13 @@ PlayerSettings:
   switchNVNShaderPoolsGranularity: 33554432
   switchNVNDefaultPoolsGranularity: 16777216
   switchNVNOtherPoolsGranularity: 16777216
+  switchNVNMaxPublicTextureIDCount: 0
+  switchNVNMaxPublicSamplerIDCount: 0
+  stadiaPresentMode: 0
+  stadiaTargetFramerate: 0
+  vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
+  vulkanEnableLateAcquireNextImage: 0
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -155,9 +159,9 @@ PlayerSettings:
       v2Signing: 0
     enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
-  protectGraphicsMemory: 0
   enableFrameTimingStats: 0
   useHDRDisplay: 0
+  D3DHDRBitDepth: 0
   m_ColorGamuts: 00000000
   targetPixelDensity: 30
   resolutionScalingMode: 0
@@ -166,7 +170,7 @@ PlayerSettings:
   applicationIdentifier: {}
   buildNumber: {}
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 16
+  AndroidMinSdkVersion: 19
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -181,32 +185,16 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 9.0
+  iOSTargetOSVersionString: 10.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 9.0
+  tvOSTargetOSVersionString: 10.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
   uIStatusBarHidden: 1
   uIExitOnSuspend: 0
   uIStatusBarStyle: 0
-  iPhoneSplashScreen: {fileID: 0}
-  iPhoneHighResSplashScreen: {fileID: 0}
-  iPhoneTallHighResSplashScreen: {fileID: 0}
-  iPhone47inSplashScreen: {fileID: 0}
-  iPhone55inPortraitSplashScreen: {fileID: 0}
-  iPhone55inLandscapeSplashScreen: {fileID: 0}
-  iPhone58inPortraitSplashScreen: {fileID: 0}
-  iPhone58inLandscapeSplashScreen: {fileID: 0}
-  iPadPortraitSplashScreen: {fileID: 0}
-  iPadHighResPortraitSplashScreen: {fileID: 0}
-  iPadLandscapeSplashScreen: {fileID: 0}
-  iPadHighResLandscapeSplashScreen: {fileID: 0}
-  iPhone65inPortraitSplashScreen: {fileID: 0}
-  iPhone65inLandscapeSplashScreen: {fileID: 0}
-  iPhone61inPortraitSplashScreen: {fileID: 0}
-  iPhone61inLandscapeSplashScreen: {fileID: 0}
   appleTVSplashScreen: {fileID: 0}
   appleTVSplashScreen2x: {fileID: 0}
   tvOSSmallIconLayers: []
@@ -243,6 +231,7 @@ PlayerSettings:
   metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 0
+  iosCopyPluginsCodeInsteadOfSymlink: 0
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
@@ -274,7 +263,6 @@ PlayerSettings:
   androidGamepadSupportLevel: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  resolutionDialogBanner: {fileID: 0}
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons: []
   m_BuildTargetBatching:
@@ -293,6 +281,40 @@ PlayerSettings:
   - m_BuildTarget: WebGL
     m_StaticBatching: 0
     m_DynamicBatching: 0
+  m_BuildTargetGraphicsJobs:
+  - m_BuildTarget: MacStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: Switch
+    m_GraphicsJobs: 0
+  - m_BuildTarget: MetroSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: AppleTVSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: BJMSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: LinuxStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: PS4Player
+    m_GraphicsJobs: 0
+  - m_BuildTarget: iOSSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: WindowsStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: XboxOnePlayer
+    m_GraphicsJobs: 0
+  - m_BuildTarget: LuminSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: CloudRendering
+    m_GraphicsJobs: 0
+  - m_BuildTarget: AndroidPlayer
+    m_GraphicsJobs: 0
+  - m_BuildTarget: WebGLSupport
+    m_GraphicsJobs: 0
+  m_BuildTargetGraphicsJobMode:
+  - m_BuildTarget: PS4Player
+    m_GraphicsJobMode: 0
+  - m_BuildTarget: XboxOnePlayer
+    m_GraphicsJobMode: 0
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
     m_APIs: 150000000b000000
@@ -315,7 +337,6 @@ PlayerSettings:
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
   openGLRequireES32: 0
-  vuforiaEnabled: 0
   m_TemplateCustomTags: {}
   mobileMTRendering:
     Android: 1
@@ -431,6 +452,7 @@ PlayerSettings:
   switchRatingsInt_9: 0
   switchRatingsInt_10: 0
   switchRatingsInt_11: 0
+  switchRatingsInt_12: 0
   switchLocalCommunicationIds_0: 
   switchLocalCommunicationIds_1: 
   switchLocalCommunicationIds_2: 
@@ -487,6 +509,7 @@ PlayerSettings:
   ps4ShareFilePath: 
   ps4ShareOverlayImagePath: 
   ps4PrivacyGuardImagePath: 
+  ps4ExtraSceSysFile: 
   ps4NPtitleDatPath: 
   ps4RemotePlayKeyAssignment: -1
   ps4RemotePlayKeyMappingDir: 
@@ -512,6 +535,7 @@ PlayerSettings:
   ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
   ps4UseAudio3dBackend: 0
+  ps4UseLowGarlicFragmentationMode: 1
   ps4SocialScreenEnabled: 0
   ps4ScriptOptimizationLevel: 0
   ps4Audio3dVirtualSpeakerCount: 14
@@ -528,8 +552,11 @@ PlayerSettings:
   ps4disableAutoHideSplash: 0
   ps4videoRecordingFeaturesUsed: 0
   ps4contentSearchFeaturesUsed: 0
+  ps4CompatibilityPS5: 0
+  ps4GPU800MHz: 1
   ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
+  ps4attribVROutputEnabled: 0
   monoEnv: 
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
@@ -614,8 +641,8 @@ PlayerSettings:
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
   XboxOneXTitleMemory: 8
-  xboxOneScriptCompiler: 1
   XboxOneOverrideIdentityName: 
+  XboxOneOverrideIdentityPublisher: 
   vrEditorSettings:
     daydream:
       daydreamIconForeground: {fileID: 0}
@@ -633,13 +660,6 @@ PlayerSettings:
   luminVersion:
     m_VersionCode: 1
     m_VersionName: 
-  facebookSdkVersion: 7.9.4
-  facebookAppId: 
-  facebookCookies: 1
-  facebookLogging: 1
-  facebookStatus: 1
-  facebookXfbml: 0
-  facebookFrictionlessRequests: 1
   apiCompatibilityLevel: 6
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
- Fix the performance issue of `ConvertRGBToI420` method
- Edit ProjectSettings.asset of the project under WebRTC~ directory to change `Color Space` parameter to `Gamma` to `Linear`
- Change a texture format of the RenderTexture which using for the receiver with Vulkan API