### PR TITLE
fix: Fix crash bug when using vulkan API when the application ended

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -84,7 +84,7 @@ namespace webrtc
         NV_ENC_CONFIG nvEncConfig = {};
         NVENCSTATUS errorCode;
         Frame bufferedFrames[bufferedFrameNum];
-        ITexture2D* renderTextures[bufferedFrameNum];
+        ITexture2D* m_renderTextures[bufferedFrameNum];
         uint64 frameCount = 0;
         void* pEncoderInterface = nullptr;
         bool isIdrFrame = false;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
@@ -13,8 +13,19 @@ namespace unity
 namespace webrtc
 {
 
-    NvEncoderCuda::NvEncoderCuda(const uint32_t nWidth, const uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
-        NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nWidth, nHeight, device, textureFormat)
+    NvEncoderCuda::NvEncoderCuda(
+        const uint32_t nWidth,
+        const uint32_t nHeight,
+        IGraphicsDevice* device,
+        UnityRenderingExtTextureFormat textureFormat)
+    : NvEncoder(
+        NV_ENC_DEVICE_TYPE_CUDA,
+        NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY,
+        NV_ENC_BUFFER_FORMAT_ARGB,
+        nWidth,
+        nHeight,
+        device,
+        textureFormat)
     {
     }
 
@@ -40,7 +51,8 @@ namespace webrtc
     }
 
 
-    void* NvEncoderCuda::AllocateInputResourceV(ITexture2D* tex) {
+    void* NvEncoderCuda::AllocateInputResourceV(ITexture2D* tex)
+    {
         return tex->GetEncodeTexturePtrV();
     }
 

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "SoftwareEncoder.h"
 #include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/ITexture2D.h"
 
 #if defined(_WIN32)
 #else
@@ -16,8 +17,15 @@ namespace webrtc
     m_device(device),
     m_width(width),
     m_height(height),
+    m_encodeTex(nullptr),
     m_textureFormat(textureFormat)
     {
+    }
+
+    SoftwareEncoder::~SoftwareEncoder()
+    {
+        delete m_encodeTex;
+        m_encodeTex = nullptr;
     }
 
     void SoftwareEncoder::InitV()

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.h
@@ -15,6 +15,7 @@ namespace webrtc
     {
     public:
         SoftwareEncoder(int _width, int _height, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
+        virtual ~SoftwareEncoder();
         void InitV() override;
         void SetRates(uint32_t bitRate, int64_t frameRate) override {}
         void UpdateSettings() override {}

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -55,9 +55,8 @@ bool VulkanGraphicsDevice::InitV() {
 //---------------------------------------------------------------------------------------------------------------------
 
 void VulkanGraphicsDevice::ShutdownV() {
-    VULKAN_SAFE_DESTROY_COMMAND_POOL(m_device, m_commandPool, m_allocator);
-    vkDestroyDevice(m_device, NULL);
     m_cudaContext.Shutdown();
+    VULKAN_SAFE_DESTROY_COMMAND_POOL(m_device, m_commandPool, m_allocator);
 
     if (s_hModule)
     {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -115,7 +115,6 @@ ITexture2D* VulkanGraphicsDevice::CreateDefaultTextureV(const uint32_t w, const 
 ITexture2D* VulkanGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
     VulkanTexture2D* vulkanTexture = new VulkanTexture2D(w, h);
     if (!vulkanTexture->InitCpuRead(m_physicalDevice, m_device)) {
-        vulkanTexture->Shutdown();
         delete (vulkanTexture);
         return nullptr;
     }
@@ -126,11 +125,9 @@ ITexture2D* VulkanGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, 
         VK_IMAGE_LAYOUT_UNDEFINED, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_PIPELINE_STAGE_TRANSFER_BIT))
     {
-        vulkanTexture->Shutdown();
         delete (vulkanTexture);
         return nullptr;
     }
-
     return vulkanTexture;
 }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
@@ -10,10 +10,13 @@ namespace webrtc
 
 //---------------------------------------------------------------------------------------------------------------------
 
-VulkanTexture2D::VulkanTexture2D(const uint32_t w, const uint32_t h) : ITexture2D(w,h),
-    m_textureImage(VK_NULL_HANDLE), m_textureImageMemory(VK_NULL_HANDLE),
-    m_textureImageMemorySize(0), m_device(VK_NULL_HANDLE),
-    m_textureFormat(VK_FORMAT_B8G8R8A8_UNORM)
+VulkanTexture2D::VulkanTexture2D(const uint32_t w, const uint32_t h)
+    : ITexture2D(w,h)
+    , m_textureImage(VK_NULL_HANDLE)
+    , m_textureImageMemory(VK_NULL_HANDLE)
+    , m_textureImageMemorySize(0)
+    , m_device(VK_NULL_HANDLE)
+    , m_textureFormat(VK_FORMAT_B8G8R8A8_UNORM)
 {
 }
 
@@ -21,7 +24,6 @@ VulkanTexture2D::VulkanTexture2D(const uint32_t w, const uint32_t h) : ITexture2
 
 VulkanTexture2D::~VulkanTexture2D() {
     Shutdown();
-
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -18,6 +18,7 @@ public:
     GraphicsDeviceTestBase();
     virtual ~GraphicsDeviceTestBase();
 protected:
+    void* m_pNativeGfxDevice;
     IGraphicsDevice* m_device;
     UnityEncoderType m_encoderType;
     UnityGfxRenderer m_unityGfxRenderer;


### PR DESCRIPTION
This PR fixes the crash bug that occurs during terminate the application using vulkan API.
It might be the cause of crash is the `vkDestroyDevice` function called from the plugin side. This logical device is allocated from Unity side.