### PR TITLE
fix: fix crash bug on Vulkan API

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -427,10 +427,10 @@ namespace webrtc
             }
         }
 
-        for (uint32 i = 0; i < bufferedFrameNum; i++)
+        for (auto& renderTexture : m_renderTextures)
         {
-            delete m_renderTextures[i];
-            m_renderTextures[i] = nullptr;
+            delete renderTexture;
+            renderTexture = nullptr;
         }
     }
     uint32_t NvEncoder::GetNumChromaPlanes(const NV_ENC_BUFFER_FORMAT bufferFormat)

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -102,6 +102,8 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
     }
     case kUnityGfxDeviceEventShutdown:
     {
+        s_mapEncoder.clear();
+
         if (s_gfxDevice != nullptr)
         {
             s_gfxDevice->ShutdownV();
@@ -110,7 +112,6 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
 
         //UnityPluginUnload not called normally
         s_Graphics->UnregisterDeviceEventCallback(OnGraphicsDeviceEvent);
-        s_mapEncoder.clear();
         break;
     }
     case kUnityGfxDeviceEventBeforeReset:


### PR DESCRIPTION
Changed the order of operations for disposing instances. 
Encoder instances depend on the graphics device instance, so this crash occurs. 