### PR TITLE
fix: fixed crash when occurs on standalone build with Vulkan API  

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -261,7 +261,7 @@ namespace webrtc
 
     void NvEncoder::SetRates(uint32_t bitRate, int64_t frameRate)
     {
-        m_frameRate = frameRate;
+        m_frameRate = static_cast<uint32_t>(frameRate);
         m_targetBitrate = bitRate;
         isIdrFrame = true;
     }

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -12,7 +12,6 @@
 #include "UnityVideoEncoderFactory.h"
 #include "UnityVideoDecoderFactory.h"
 #include "UnityVideoTrackSource.h"
-#include "GraphicsDevice/GraphicsUtility.h"
 
 using namespace ::webrtc;
 

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -12,6 +12,7 @@
 #include "UnityVideoEncoderFactory.h"
 #include "UnityVideoDecoderFactory.h"
 #include "UnityVideoTrackSource.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 
 using namespace ::webrtc;
 
@@ -252,9 +253,16 @@ namespace webrtc
         return m_mapVideoEncoderParameter[track].get();
     }
 
-    void Context::SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height, UnityRenderingExtTextureFormat textureFormat)
+    void Context::SetEncoderParameter(
+        const MediaStreamTrackInterface* track,
+        int width,
+        int height,
+        UnityRenderingExtTextureFormat textureFormat,
+        void* textureHandle)
     {
-        m_mapVideoEncoderParameter[track] = std::make_unique<VideoEncoderParameter>(width, height, textureFormat);
+        m_mapVideoEncoderParameter[track] =
+            std::make_unique<VideoEncoderParameter>(
+                width, height, textureFormat, textureHandle);
     }
 
     void Context::SetKeyFrame(uint32_t id)
@@ -309,10 +317,10 @@ namespace webrtc
     }
 
     webrtc::VideoTrackInterface* Context::CreateVideoTrack(
-        const std::string& label, void* frame, UnityGfxRenderer gfxRenderer)
+        const std::string& label)
     {
         const rtc::scoped_refptr<UnityVideoTrackSource> source =
-            new rtc::RefCountedObject<UnityVideoTrackSource>(frame, gfxRenderer, false, nullptr);
+            new rtc::RefCountedObject<UnityVideoTrackSource>(false, nullptr);
 
         const rtc::scoped_refptr<VideoTrackInterface> track =
             m_peerConnectionFactory->CreateVideoTrack(label, source);

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -41,8 +41,13 @@ namespace webrtc
         int width;
         int height;
         UnityRenderingExtTextureFormat textureFormat;
-        VideoEncoderParameter(int width, int height, UnityRenderingExtTextureFormat textureFormat)
-            : width(width), height(height), textureFormat(textureFormat)
+        void* textureHandle;
+        VideoEncoderParameter(
+            int width, int height, UnityRenderingExtTextureFormat textureFormat, void* textureHandle)
+            : width(width)
+            , height(height)
+            , textureFormat(textureFormat)
+            , textureHandle(textureHandle)
         {
         }
     };
@@ -66,7 +71,7 @@ namespace webrtc
 
         // MediaStreamTrack
         webrtc::VideoTrackInterface* CreateVideoTrack(
-            const std::string& label, void* frame, UnityGfxRenderer gfxRenderer);
+            const std::string& label);
         webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label);
         void DeleteMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
@@ -99,7 +104,8 @@ namespace webrtc
         bool FinalizeEncoder(IEncoder* encoder);
         // You must call these methods on Rendering thread.
         const VideoEncoderParameter* GetEncoderParameter(const webrtc::MediaStreamTrackInterface* track);
-        void SetEncoderParameter(const webrtc::MediaStreamTrackInterface* track, int width, int height, UnityRenderingExtTextureFormat format);
+        void SetEncoderParameter(const MediaStreamTrackInterface* track, int width, int height,
+            UnityRenderingExtTextureFormat format, void* textureHandle);
 
         // mutex;
         std::mutex mutex;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
@@ -1,7 +1,9 @@
 #include "pch.h"
 #include "GraphicsUtility.h"
 
+#if defined(SUPPORT_VULKAN)
 #include "Vulkan/VulkanGraphicsDevice.h"
+#endif
 
 namespace unity
 {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "GraphicsUtility.h"
 
+#include "Vulkan/VulkanGraphicsDevice.h"
+
 namespace unity
 {
 namespace webrtc
@@ -46,6 +48,22 @@ rtc::scoped_refptr<webrtc::I420Buffer> GraphicsUtility::ConvertRGBToI420Buffer(c
 
     return i420_buffer;
 
+}
+
+void* GraphicsUtility::TextureHandleToNativeGraphicsPtr(
+    void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer)
+{
+#if defined(SUPPORT_VULKAN)
+    if (renderer == kUnityGfxRendererVulkan)
+    {
+        VulkanGraphicsDevice* vulkanDevice =
+            static_cast<VulkanGraphicsDevice*>(device);
+        std::unique_ptr<UnityVulkanImage> unityVulkanImage =
+            vulkanDevice->AccessTexture(textureHandle);
+        return unityVulkanImage.release();
+    }
+#endif
+    return textureHandle;
 }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
@@ -13,6 +13,9 @@ public:
         const uint32_t rowToRowInBytes, const uint8_t* srcData);
     static IGraphicsDevice* GetGraphicsDevice();
     static UnityGfxRenderer GetGfxRenderer();
+    static void* TextureHandleToNativeGraphicsPtr(
+        void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer);
+
 };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/UnityVulkanInitCallback.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/UnityVulkanInitCallback.cpp
@@ -45,7 +45,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateDevice(
     // copy extension name list
     std::vector<const char*> enabledExtensions;
     enabledExtensions.reserve(pCreateInfo->enabledExtensionCount);
-    for(int i = 0; i < pCreateInfo->enabledExtensionCount; i++)
+    for(uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++)
     {
         enabledExtensions.push_back(newCreateInfo.ppEnabledExtensionNames[i]);
     }
@@ -60,7 +60,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateDevice(
 
     // replace extension name list
     newCreateInfo.ppEnabledExtensionNames = newExtensions.data();
-    newCreateInfo.enabledExtensionCount = newExtensions.size();
+    newCreateInfo.enabledExtensionCount = static_cast<uint32_t>(newExtensions.size());
     VkResult result = vkCreateDevice(physicalDevice, &newCreateInfo, pAllocator, pDevice);
     if(result != VK_SUCCESS)
     {
@@ -81,7 +81,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateInstance(
     // copy extension name list
     std::vector<const char*> enabledExtensions;
     enabledExtensions.reserve(pCreateInfo->enabledExtensionCount);
-    for (int i = 0; i < pCreateInfo->enabledExtensionCount; i++)
+    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++)
     {
         enabledExtensions.push_back(newCreateInfo.ppEnabledExtensionNames[i]);
     }
@@ -96,7 +96,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateInstance(
 
     // replace extension name list
     newCreateInfo.ppEnabledExtensionNames = newExtensions.data();
-    newCreateInfo.enabledExtensionCount = newExtensions.size();
+    newCreateInfo.enabledExtensionCount = static_cast<uint32_t>(newExtensions.size());
 
     VkResult result = s_vkCreateInstance(&newCreateInfo, pAllocator, pInstance);
     if (result != VK_SUCCESS)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -228,7 +228,7 @@ rtc::scoped_refptr<webrtc::I420Buffer> VulkanGraphicsDevice::ConvertRGBToI420(
     VkSubresourceLayout subresourceLayout;
     vkGetImageSubresourceLayout(m_device, vulkanTexture->GetImage(), &subresource,
         &subresourceLayout);
-    size_t rowPitch = subresourceLayout.rowPitch;
+    const uint32_t rowPitch = static_cast<uint32_t>(subresourceLayout.rowPitch);
 
     void* data;
     std::vector<uint8_t> dst;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -188,6 +188,11 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         {
             const VideoEncoderParameter* param = s_context->GetEncoderParameter(track);
             const UnityEncoderType encoderType = s_context->GetEncoderType();
+            UnityVideoTrackSource* source = s_context->GetVideoSource(track);
+            UnityGfxRenderer gfxRenderer = GraphicsUtility::GetGfxRenderer();
+            void* ptr = GraphicsUtility::TextureHandleToNativeGraphicsPtr(
+                param->textureHandle, s_gfxDevice, gfxRenderer);
+            source->Init(ptr);
             s_mapEncoder[track] = EncoderFactory::GetInstance().Init(
                 param->width, param->height, s_gfxDevice, encoderType, param->textureFormat);
             if (!s_context->InitializeEncoder(s_mapEncoder[track].get(), track))

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -4,7 +4,6 @@
 #include <mutex>
 
 #include "Codec/IEncoder.h"
-#include "GraphicsDevice/Vulkan/VulkanGraphicsDevice.h"
 
 namespace unity
 {

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -4,6 +4,7 @@
 #include <mutex>
 
 #include "Codec/IEncoder.h"
+#include "GraphicsDevice/Vulkan/VulkanGraphicsDevice.h"
 
 namespace unity
 {
@@ -11,25 +12,14 @@ namespace webrtc
 {
 
 UnityVideoTrackSource::UnityVideoTrackSource(
-    void* frame,
-    UnityGfxRenderer gfxRenderer,
     bool is_screencast,
     absl::optional<bool> needs_denoising) :
     AdaptedVideoTrackSource(/*required_alignment=*/1),
     is_screencast_(is_screencast),
     needs_denoising_(needs_denoising),
-    encoder_(nullptr),
-    frame_(frame)
+    encoder_(nullptr)
 {
 //  DETACH_FROM_THREAD(thread_checker_);
-
-#if defined(SUPPORT_VULKAN)
-    if(gfxRenderer == kUnityGfxRendererVulkan)
-    {
-        unityVulkanImage_ = *static_cast<UnityVulkanImage*>(frame_);
-        frame_ = &unityVulkanImage_;
-    }
-#endif
 }
 
 UnityVideoTrackSource::~UnityVideoTrackSource()
@@ -37,7 +27,12 @@ UnityVideoTrackSource::~UnityVideoTrackSource()
     {
         std::unique_lock<std::mutex> lock(m_mutex);
     }
-};
+}
+
+void UnityVideoTrackSource::Init(void* frame)
+{
+    frame_ = frame;
+}
 
 UnityVideoTrackSource::SourceState UnityVideoTrackSource::state() const
 {

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -31,8 +31,7 @@ class   UnityVideoTrackSource :
         };
 
     UnityVideoTrackSource(
-        bool is_screencast,
-        absl::optional<bool> needs_denoising);
+        bool is_screencast, absl::optional<bool> needs_denoising);
     ~UnityVideoTrackSource() override;
 
     SourceState state() const override;
@@ -90,13 +89,7 @@ class   UnityVideoTrackSource :
     std::mutex m_mutex;
     IEncoder* encoder_;
     void* frame_;
-    UnityGfxRenderer gfxRenderer_;
-    IGraphicsDevice* pGfxDevice_;
-
-    #if defined(SUPPORT_VULKAN)
-    UnityVulkanImage unityVulkanImage_;
-#endif
-  webrtc::Clock* clock_;
+    webrtc::Clock* clock_;
 };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -8,12 +8,13 @@ namespace unity {
 namespace webrtc {
 
 class IEncoder;
+class IGraphicsDevice;
 
 // This class implements webrtc's VideoTrackSourceInterface. To pass frames down
 // the webrtc video pipeline, each received a media::VideoFrame is converted to
 // a webrtc::VideoFrame, taking any adaptation requested by downstream classes
 // into account.
-class UnityVideoTrackSource :
+class   UnityVideoTrackSource :
     public rtc::AdaptedVideoTrackSource,
     public sigslot::has_slots<>
 {
@@ -30,8 +31,6 @@ class UnityVideoTrackSource :
         };
 
     UnityVideoTrackSource(
-        void* frame,
-        UnityGfxRenderer gfxRenderer,
         bool is_screencast,
         absl::optional<bool> needs_denoising);
     ~UnityVideoTrackSource() override;
@@ -42,7 +41,10 @@ class UnityVideoTrackSource :
     bool is_screencast() const override;
     absl::optional<bool> needs_denoising() const override;
 
-    // todo(kazuki)::
+    // note:: call from render thread
+    void Init(void* frame);
+
+    // note:: call from render thread
     void OnFrameCaptured(int64_t timestampe_us);
 
     // todo(kazuki)::
@@ -88,8 +90,10 @@ class UnityVideoTrackSource :
     std::mutex m_mutex;
     IEncoder* encoder_;
     void* frame_;
+    UnityGfxRenderer gfxRenderer_;
+    IGraphicsDevice* pGfxDevice_;
 
-#if defined(SUPPORT_VULKAN)
+    #if defined(SUPPORT_VULKAN)
     UnityVulkanImage unityVulkanImage_;
 #endif
   webrtc::Clock* clock_;

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -8,13 +8,12 @@ namespace unity {
 namespace webrtc {
 
 class IEncoder;
-class IGraphicsDevice;
 
 // This class implements webrtc's VideoTrackSourceInterface. To pass frames down
 // the webrtc video pipeline, each received a media::VideoFrame is converted to
 // a webrtc::VideoFrame, taking any adaptation requested by downstream classes
 // into account.
-class   UnityVideoTrackSource :
+class UnityVideoTrackSource :
     public rtc::AdaptedVideoTrackSource,
     public sigslot::has_slots<>
 {

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -112,9 +112,11 @@ extern "C"
         return context->GetInitializationResult(track);
     }
 
-    UNITY_INTERFACE_EXPORT void ContextSetVideoEncoderParameter(Context* context, MediaStreamTrackInterface* track, int width, int height, UnityRenderingExtTextureFormat textureFormat)
+    UNITY_INTERFACE_EXPORT void ContextSetVideoEncoderParameter(
+        Context* context, MediaStreamTrackInterface* track, int width, int height,
+        UnityRenderingExtTextureFormat textureFormat, void* textureHandle)
     {
-        context->SetEncoderParameter(track, width, height, textureFormat);
+        context->SetEncoderParameter(track, width, height, textureFormat, textureHandle);
     }
 
     UNITY_INTERFACE_EXPORT MediaStreamInterface* ContextCreateMediaStream(Context* context, const char* streamId)
@@ -127,21 +129,9 @@ extern "C"
         context->DeleteMediaStream(stream);
     }
 
-    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* ContextCreateVideoTrack(Context* context, const char* label, void* rt)
+    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* ContextCreateVideoTrack(Context* context, const char* label)
     {
-        UnityGfxRenderer gfxRenderer = GraphicsUtility::GetGfxRenderer();
-#if defined(SUPPORT_VULKAN)
-        if(gfxRenderer == kUnityGfxRendererVulkan)
-        {
-            void* frame = nullptr;
-            VulkanGraphicsDevice* device =
-                static_cast<VulkanGraphicsDevice*>(GraphicsUtility::GetGraphicsDevice());
-            const std::unique_ptr<UnityVulkanImage> unityVulkanImage =
-                device->AccessTexture(rt);
-            return context->CreateVideoTrack(label, unityVulkanImage.get(), gfxRenderer);
-        }
-#endif
-        return context->CreateVideoTrack(label, rt, gfxRenderer);
+        return context->CreateVideoTrack(label);
     }
 
     UNITY_INTERFACE_EXPORT void ContextDeleteMediaStreamTrack(Context* context, ::webrtc::MediaStreamTrackInterface* track)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -744,7 +744,7 @@ extern "C"
             dst->encodings[i].hasValueMinBitrate = src.encodings[i].min_bitrate_bps.has_value();
             dst->encodings[i].minBitrate = src.encodings[i].min_bitrate_bps.value_or(0);
             dst->encodings[i].hasValueMaxFramerate = src.encodings[i].max_framerate.has_value();
-            dst->encodings[i].maxFramerate = src.encodings[i].max_framerate.value_or(0);
+            dst->encodings[i].maxFramerate = static_cast<uint32_t>(src.encodings[i].max_framerate.value_or(0));
             dst->encodings[i].hasValueScaleResolutionDownBy = src.encodings[i].scale_resolution_down_by.has_value();
             dst->encodings[i].scaleResolutionDownBy = src.encodings[i].scale_resolution_down_by.value_or(0);
             dst->encodings[i].rid = ConvertString(src.encodings[i].rid);

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -35,7 +35,7 @@ protected:
 TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_NE(nullptr, tex);
-    const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
+    const auto track = context->CreateVideoTrack("video");
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
 }
 
@@ -48,7 +48,7 @@ TEST_P(ContextTest, CreateAndDeleteMediaStream) {
 TEST_P(ContextTest, CreateAndDeleteVideoTrack) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_NE(nullptr, tex.get());
-    const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
+    const auto track = context->CreateVideoTrack("video");
     EXPECT_NE(nullptr, track);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
     context->DeleteMediaStreamTrack(track);
@@ -72,7 +72,7 @@ TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
 TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     const auto stream = context->CreateMediaStream("videostream");
-    const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
+    const auto track = context->CreateVideoTrack("video");
     const auto videoTrack = reinterpret_cast<webrtc::VideoTrackInterface*>(track);
     stream->AddTrack(videoTrack);
     stream->RemoveTrack(videoTrack);
@@ -114,7 +114,7 @@ TEST_P(ContextTest, EqualRendererGetById) {
 
 TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
-    const auto track = context->CreateVideoTrack("video", tex.get(), m_unityGfxRenderer);
+    const auto track = context->CreateVideoTrack("video");
     const auto renderer = context->CreateVideoRenderer();
     track->AddOrUpdateSink(renderer, rtc::VideoSinkWants());
     track->RemoveSink(renderer);

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -193,9 +193,9 @@ void* CreateDeviceVulkan()
     std::vector<const char*> layers = { "VK_LAYER_LUNARG_standard_validation" };
     VkInstanceCreateInfo instanceInfo{};
     instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-    instanceInfo.enabledExtensionCount = instanceExtensions.size();
+    instanceInfo.enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size());
     instanceInfo.ppEnabledExtensionNames = instanceExtensions.data();
-    instanceInfo.enabledLayerCount = layers.size();
+    instanceInfo.enabledLayerCount = static_cast<uint32_t>(layers.size());
     instanceInfo.ppEnabledLayerNames = layers.data();
     instanceInfo.pApplicationInfo = &appInfo;
     VkInstance instance = nullptr;
@@ -256,7 +256,7 @@ void* CreateDeviceVulkan()
     VkDeviceCreateInfo deviceCreateInfo = {};
     deviceCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
     deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions.data();
-    deviceCreateInfo.enabledExtensionCount = deviceExtensions.size();
+    deviceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
     deviceCreateInfo.pQueueCreateInfos = &deviceQueueCreateInfo;
     deviceCreateInfo.queueCreateInfoCount = 1;
     VkDevice device;
@@ -360,6 +360,7 @@ void* CreateGfxDevice(UnityGfxRenderer renderer)
         return CreateDeviceMetal();
 #endif
     }
+    return nullptr;
 }
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -27,8 +27,6 @@ public:
         m_texture(m_device->CreateDefaultTextureV(width, height, m_textureFormat))
     {
         m_trackSource = new rtc::RefCountedObject<UnityVideoTrackSource>(
-            m_texture->GetNativeTexturePtrV(),
-            m_unityGfxRenderer,
             /*is_screencast=*/ false,
             /*needs_denoising=*/ absl::nullopt);
         m_renderer = std::make_unique<UnityVideoRenderer>(1);

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -32,11 +32,10 @@ public:
         m_texture(m_device->CreateDefaultTextureV(width, height, m_textureFormat))
     {
         m_trackSource = new rtc::RefCountedObject<UnityVideoTrackSource>(
-            m_texture->GetNativeTexturePtrV(),
-            m_unityGfxRenderer,
             /*is_screencast=*/ false,
             /*needs_denoising=*/ absl::nullopt);
         m_trackSource->AddOrUpdateSink(&mock_sink_, rtc::VideoSinkWants());
+        m_trackSource->Init(m_texture->GetNativeTexturePtrV());
         m_trackSource->SetEncoder(encoder_.get());
 
         EXPECT_NE(nullptr, m_device);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -162,9 +162,9 @@ namespace Unity.WebRTC
             return NativeMethods.ContextCreateAudioTrack(self, label);
         }
 
-        public IntPtr CreateVideoTrack(string label, IntPtr texturePtr)
+        public IntPtr CreateVideoTrack(string label)
         {
-            return NativeMethods.ContextCreateVideoTrack(self, label, texturePtr);
+            return NativeMethods.ContextCreateVideoTrack(self, label);
         }
 
         public void StopMediaStreamTrack(IntPtr track)
@@ -192,9 +192,9 @@ namespace Unity.WebRTC
             NativeMethods.ContextDeleteStatsReport(self, report);
         }
 
-        public void SetVideoEncoderParameter(IntPtr track, int width, int height, GraphicsFormat format)
+        public void SetVideoEncoderParameter(IntPtr track, int width, int height, GraphicsFormat format, IntPtr texturePtr)
         {
-            NativeMethods.ContextSetVideoEncoderParameter(self, track, width, height, format);
+            NativeMethods.ContextSetVideoEncoderParameter(self, track, width, height, format, texturePtr);
         }
 
         public CodecInitializationResult GetInitializationResult(IntPtr track)

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -132,14 +132,14 @@ namespace Unity.WebRTC
         /// See Also: Texture.GetNativeTexturePtr
         /// </summary>
         /// <param name="label"></param>
-        /// <param name="ptr"></param>
+        /// <param name="texturePtr"></param>
         /// <param name="width"></param>
         /// <param name="height"></param>
         /// <param name="format"></param>
-        public VideoStreamTrack(string label, IntPtr ptr, int width, int height, GraphicsFormat format)
-            : base(WebRTC.Context.CreateVideoTrack(label, ptr))
+        public VideoStreamTrack(string label, IntPtr texturePtr, int width, int height, GraphicsFormat format)
+            : base(WebRTC.Context.CreateVideoTrack(label))
         {
-            WebRTC.Context.SetVideoEncoderParameter(self, width, height, format);
+            WebRTC.Context.SetVideoEncoderParameter(self, width, height, format, texturePtr);
             WebRTC.Context.InitializeEncoder(self);
             tracks.Add(this);
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -532,7 +532,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteDataChannel(IntPtr ptr, IntPtr ptrChannel);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label, IntPtr texturePtr);
+        public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreateAudioTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
         [DllImport(WebRTC.Lib)]
@@ -542,7 +542,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteStatsReport(IntPtr context, IntPtr report);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height, GraphicsFormat format);
+        public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height, GraphicsFormat format, IntPtr texturePtr);
         [DllImport(WebRTC.Lib)]
         public static extern CodecInitializationResult GetInitializationResult(IntPtr context, IntPtr track);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -83,7 +83,7 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = context.CreateVideoTrack("video", rt.GetNativeTexturePtr());
+            var track = context.CreateVideoTrack("video");
             context.DeleteMediaStreamTrack(track);
             context.Dispose();
             UnityEngine.Object.DestroyImmediate(rt);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -371,7 +371,8 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(CodecInitializationResult.NotInitialized, NativeMethods.GetInitializationResult(context, track));
 
             // todo:: You must call `InitializeEncoder` method after `NativeMethods.ContextCaptureVideoStream`
-            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, renderTexture.graphicsFormat);
+            NativeMethods.ContextSetVideoEncoderParameter(
+                context, track, width, height, renderTexture.graphicsFormat, renderTexture.GetNativeTexturePtr());
             VideoEncoderMethods.InitializeEncoder(callback, track);
             yield return new WaitForSeconds(1.0f);
 

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -148,7 +148,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             NativeMethods.ContextDeleteMediaStreamTrack(context, track);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
@@ -165,7 +165,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
             var track2 = NativeMethods.SenderGetTrack(sender);
             Assert.AreEqual(track, track2);
@@ -188,7 +188,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             NativeMethods.SenderGetParameters(sender, out var ptr);
@@ -213,7 +213,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             NativeMethods.MediaStreamAddTrack(stream, track);
 
             uint length = 0;
@@ -301,7 +301,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             var renderer = NativeMethods.CreateVideoRenderer(context);
             NativeMethods.VideoTrackAddOrUpdateSink(track, renderer);
             NativeMethods.VideoTrackRemoveSink(track, renderer);
@@ -364,7 +364,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             var callback = NativeMethods.GetRenderEventFunc(context);
@@ -418,7 +418,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
             var receiveTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video", renderTexture.GetNativeTexturePtr());
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             var renderer = NativeMethods.CreateVideoRenderer(context);
             var rendererId = NativeMethods.GetVideoRendererId(renderer);
             NativeMethods.VideoTrackAddOrUpdateSink(track, renderer);
@@ -426,7 +426,7 @@ namespace Unity.WebRTC.RuntimeTest
             var renderEvent = NativeMethods.GetRenderEventFunc(context);
             var updateTextureEvent = NativeMethods.GetUpdateTextureFunc(context);
 
-            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, renderTexture.graphicsFormat);
+            NativeMethods.ContextSetVideoEncoderParameter(context, track, width, height, renderTexture.graphicsFormat, renderTexture.GetNativeTexturePtr());
             VideoEncoderMethods.InitializeEncoder(renderEvent, track);
             yield return new WaitForSeconds(1.0f);
 


### PR DESCRIPTION
The cause of the crash is the way of calling Unity Native API.
`AccessTexture` method of `IUnityVulkan` class returns `nullptr` when called on the main thread, not the render thread.

I changed the place of the method call to `UnityRenderEvent` class which is called on just the render thread.