### PR TITLE
feat: videotoolbox decoder and handle transceiver direction

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -2,41 +2,37 @@
 #include "UnityVideoDecoderFactory.h"
 #include "absl/strings/match.h"
 
+#if defined(__APPLE__)
+#import "sdk/objc/components/video_codec/RTCDefaultVideoDecoderFactory.h"
+#import "sdk/objc/native/api/video_decoder_factory.h"
+#endif
+
 namespace unity
 {
 namespace webrtc
 {
-    UnityVideoDecoderFactory::UnityVideoDecoderFactory() : internal_decoder_factory_(new webrtc::InternalDecoderFactory())
+    webrtc::VideoDecoderFactory* CreateDecoderFactory()
+    {
+#if defined(__APPLE__)
+        return webrtc::ObjCToNativeVideoDecoderFactory(
+            [[RTCDefaultVideoDecoderFactory alloc] init]).release();
+#endif
+        return new webrtc::InternalDecoderFactory();
+    }
+
+    UnityVideoDecoderFactory::UnityVideoDecoderFactory()
+    : internal_decoder_factory_(CreateDecoderFactory())
     {
     }
 
     std::vector<webrtc::SdpVideoFormat> UnityVideoDecoderFactory::GetSupportedFormats() const
     {
-        std::vector<webrtc::SdpVideoFormat> formats;
-
-        formats.push_back(webrtc::SdpVideoFormat(cricket::kVp8CodecName));
-        
-        for (const webrtc::SdpVideoFormat& format : webrtc::SupportedVP9Codecs())
-        {
-            formats.push_back(format);
-        }
-
-        return formats;
+        return internal_decoder_factory_->GetSupportedFormats();
     }
 
     std::unique_ptr<webrtc::VideoDecoder> UnityVideoDecoderFactory::CreateVideoDecoder(const webrtc::SdpVideoFormat & format)
     {
-        if (absl::EqualsIgnoreCase(format.name, cricket::kVp8CodecName))
-        {
-            return webrtc::VP8Decoder::Create();
-        }
-
-        if (absl::EqualsIgnoreCase(format.name, cricket::kVp9CodecName))
-        {
-            return webrtc::VP9Decoder::Create();
-        }
-
-        return nullptr;
+        return internal_decoder_factory_->CreateVideoDecoder(format);
     }
 
 }  // namespace webrtc

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -698,6 +698,11 @@ extern "C"
         transceiver->Stop();
     }
 
+    UNITY_INTERFACE_EXPORT void TransceiverSetDirection(RtpTransceiverInterface* transceiver, RtpTransceiverDirection direction)
+    {
+        transceiver->SetDirection(direction);
+    }
+
     UNITY_INTERFACE_EXPORT RtpReceiverInterface* TransceiverGetReceiver(RtpTransceiverInterface* transceiver)
     {
         return transceiver->receiver().get();

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -698,6 +698,11 @@ extern "C"
         transceiver->Stop();
     }
 
+    UNITY_INTERFACE_EXPORT RtpTransceiverDirection TransceiverGetDirection(RtpTransceiverInterface* transceiver)
+    {
+        return transceiver->direction();
+    }
+
     UNITY_INTERFACE_EXPORT void TransceiverSetDirection(RtpTransceiverInterface* transceiver, RtpTransceiverDirection direction)
     {
         transceiver->SetDirection(direction);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -785,6 +785,11 @@ extern "C"
         return error.type();
     }
 
+    UNITY_INTERFACE_EXPORT bool SenderReplaceTrack(RtpSenderInterface* sender, MediaStreamTrackInterface* track)
+    {
+        return sender->SetTrack(track);
+    }
+
     UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* SenderGetTrack(RtpSenderInterface* sender)
     {
         return sender->track().get();

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -45,5 +45,10 @@ namespace Unity.WebRTC
 
             return error;
         }
+
+        public bool ReplaceTrack(MediaStreamTrack track)
+        {
+            return NativeMethods.SenderReplaceTrack(self, track.self);
+        }
     }
 }

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -66,10 +66,8 @@ namespace Unity.WebRTC
         /// <param name="direction"></param>
         public void SetDirection(RTCRtpTransceiverDirection direction)
         {
-            // TODO::
-            throw new NotImplementedException();
+            NativeMethods.TransceiverSetDirection(self, direction);
         }
-
 
         public void SetCodecPreferences(RTCRtpCodecCapability[] capabilities)
         {

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -44,7 +44,7 @@ namespace Unity.WebRTC
         /// or null if the transceiver is stopped or has never participated in an exchange of offers and answers.
         /// To change the transceiver's directionality, set the value of the <see cref="Direction"/> property.
         /// </summary>
-        public RTCRtpTransceiverDirection CurrentDirection
+        public RTCRtpTransceiverDirection? CurrentDirection
         {
             get
             {
@@ -53,7 +53,8 @@ namespace Unity.WebRTC
                 {
                     return direction;
                 }
-                throw new InvalidOperationException("Transceiver is not running");
+
+                return null;
             }
         }
 

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -4,10 +4,11 @@ namespace Unity.WebRTC
 {
     public enum RTCRtpTransceiverDirection
     {
-        SendRecv,
-        SendOnly,
-        RecvOnly,
-        Inactive
+        SendRecv = 0,
+        SendOnly = 1,
+        RecvOnly = 2,
+        Inactive = 3,
+        Stopped  = 4
     }
 
     /// <summary>
@@ -29,7 +30,19 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        ///
+        /// This is used to set the transceiver's desired direction
+        /// and will be used in calls to CreateOffer and CreateAnswer.
+        /// </summary>
+        public RTCRtpTransceiverDirection Direction
+        {
+            get { return NativeMethods.TransceiverGetDirection(self); }
+            set { NativeMethods.TransceiverSetDirection(self, value); }
+        }
+
+        /// <summary>
+        /// This property indicates the transceiver's current directionality,
+        /// or null if the transceiver is stopped or has never participated in an exchange of offers and answers.
+        /// To change the transceiver's directionality, set the value of the <see cref="Direction"/> property.
         /// </summary>
         public RTCRtpTransceiverDirection CurrentDirection
         {
@@ -58,15 +71,6 @@ namespace Unity.WebRTC
         public RTCRtpSender Sender
         {
             get { return new RTCRtpSender(NativeMethods.TransceiverGetSender(self), peer); }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="direction"></param>
-        public void SetDirection(RTCRtpTransceiverDirection direction)
-        {
-            NativeMethods.TransceiverSetDirection(self, direction);
         }
 
         public void SetCodecPreferences(RTCRtpCodecCapability[] capabilities)

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -627,6 +627,8 @@ namespace Unity.WebRTC
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool TransceiverStop(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
+        public static extern bool TransceiverSetDirection(IntPtr transceiver, RTCRtpTransceiverDirection direction);
+        [DllImport(WebRTC.Lib)]
         public static extern IntPtr TransceiverGetReceiver(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr TransceiverGetSender(IntPtr transceiver);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -627,7 +627,9 @@ namespace Unity.WebRTC
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool TransceiverStop(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
-        public static extern bool TransceiverSetDirection(IntPtr transceiver, RTCRtpTransceiverDirection direction);
+        public static extern RTCRtpTransceiverDirection TransceiverGetDirection(IntPtr transceiver);
+        [DllImport(WebRTC.Lib)]
+        public static extern void TransceiverSetDirection(IntPtr transceiver, RTCRtpTransceiverDirection direction);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr TransceiverGetReceiver(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -641,6 +641,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType SenderSetParameters(IntPtr sender, IntPtr parameters);
         [DllImport(WebRTC.Lib)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static extern bool SenderReplaceTrack(IntPtr sender, IntPtr track);
+        [DllImport(WebRTC.Lib)]
         public static extern IntPtr ReceiverGetTrack(IntPtr receiver);
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -116,7 +116,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(0, peer.GetTransceivers().Count());
             var transceiver = peer.AddTransceiver(track);
             Assert.NotNull(transceiver);
-            Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
+            Assert.IsNull(transceiver.CurrentDirection);
             RTCRtpSender sender = transceiver.Sender;
             Assert.NotNull(sender);
             Assert.AreEqual(track, sender.Track);
@@ -149,7 +149,7 @@ namespace Unity.WebRTC.RuntimeTest
             var peer = new RTCPeerConnection();
             var transceiver = peer.AddTransceiver(TrackKind.Audio);
             Assert.NotNull(transceiver);
-            Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
+            Assert.IsNull(transceiver.CurrentDirection);
             RTCRtpReceiver receiver = transceiver.Receiver;
             Assert.NotNull(receiver);
             MediaStreamTrack track = receiver.Track;
@@ -168,7 +168,7 @@ namespace Unity.WebRTC.RuntimeTest
             var peer = new RTCPeerConnection();
             var transceiver = peer.AddTransceiver(TrackKind.Video);
             Assert.NotNull(transceiver);
-            Assert.That(() => Assert.NotNull(transceiver.CurrentDirection), Throws.InvalidOperationException);
+            Assert.IsNull(transceiver.CurrentDirection);
             RTCRtpReceiver receiver = transceiver.Receiver;
             Assert.NotNull(receiver);
             MediaStreamTrack track = receiver.Track;
@@ -208,6 +208,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             var transceiver1 = peer1.AddTransceiver(audioTrack);
             transceiver1.Direction = RTCRtpTransceiverDirection.SendOnly;
+            Assert.IsNull(transceiver1.CurrentDirection);
 
             RTCOfferOptions options1 = new RTCOfferOptions {offerToReceiveAudio = true};
             RTCAnswerOptions options2 = default;


### PR DESCRIPTION
- enable videotoolbox decoder on mac
- add transceiver direction handling api
- add transceiver direction test
- add replace track method on sender