### PR TITLE
chore: build libwebrtc for iOS

### DIFF
--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -25,7 +25,7 @@ fi
 patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
 # add objc library to use videotoolbox
-patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_mac.patch"
+patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 
 mkdir -p "$ARTIFACTS_DIR/lib"
 

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -35,12 +35,13 @@ do
   do
     # generate ninja files
     gn gen "$OUTPUT_DIR" --root="src" \
-      --args="is_debug=${is_debug} target_os=\"ios\" target_cpu=\"${target_cpu}\" ios_enable_code_signing=false rtc_use_h264=false rtc_include_tests=false rtc_build_examples=false"
+      --args="is_debug=${is_debug} target_os=\"ios\" target_cpu=\"${target_cpu}\" ios_enable_code_signing=false enable_ios_bitcode=true rtc_use_h264=false rtc_include_tests=false rtc_build_examples=false"
 
     # build static library
     ninja -C "$OUTPUT_DIR" webrtc
 
     # copy static library
+    mkdir "$ARTIFACTS_DIR/lib/${target_cpu}/"
     cp "$OUTPUT_DIR/obj/libwebrtc.a" "$ARTIFACTS_DIR/lib/${target_cpu}/"
   done
     filename="libwebrtc.a"

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -24,10 +24,8 @@ fi
 # add jsoncpp
 patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
-mkdir -p "$ARTIFACTS_DIR/lib"
-
-# add jsoncpp
-patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
+# add objc library to use videotoolbox
+patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_mac.patch"
 
 mkdir -p "$ARTIFACTS_DIR/lib"
 

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -43,26 +43,38 @@ do
     # note: `use_xcode_clang=true` is for using bitcode.
     #
     gn gen "$OUTPUT_DIR" --root="src" \
-      --args="is_debug=${is_debug} target_os=\"ios\" target_cpu=\"${target_cpu}\" ios_enable_code_signing=false enable_ios_bitcode=true rtc_use_h264=false rtc_include_tests=false rtc_build_examples=false"
+      --args="is_debug=${is_debug}    \
+      target_os=\"ios\"               \
+      target_cpu=\"${target_cpu}\"    \
+      rtc_use_h264=false              \
+      treat_warnings_as_errors=false  \
+      use_xcode_clang=true            \
+      enable_ios_bitcode=true         \
+      ios_enable_code_signing=false   \
+      rtc_include_tests=false         \
+      rtc_build_examples=false"
 
     # build static library
     ninja -C "$OUTPUT_DIR" webrtc
 
     # copy static library
-    mkdir "$ARTIFACTS_DIR/lib/${target_cpu}/"
+    mkdir "$ARTIFACTS_DIR/lib/${target_cpu}"
     cp "$OUTPUT_DIR/obj/libwebrtc.a" "$ARTIFACTS_DIR/lib/${target_cpu}/"
   done
-    filename="libwebrtc.a"
-    if [ $is_debug = "true" ]; then
-      filename="libwebrtcd.a"
-    fi
-    lipo -create -output \
-    "$ARTIFACTS_DIR/lib/${filename}"
-    "$ARTIFACTS_DIR/lib/arm64/libwebrtc.a"
-    "$ARTIFACTS_DIR/lib/x64/libwebrtc.a"
 
-    rm -r "$ARTIFACTS_DIR/lib/arm64"
-    rm -r "$ARTIFACTS_DIR/lib/x64"
+  filename="libwebrtc.a"
+  if [ $is_debug = "true" ]; then
+    filename="libwebrtcd.a"
+  fi
+
+  # make universal binary
+  lipo -create -output                   \
+  "$ARTIFACTS_DIR/lib/${filename}"       \
+  "$ARTIFACTS_DIR/lib/arm64/libwebrtc.a" \
+  "$ARTIFACTS_DIR/lib/x64/libwebrtc.a"
+  
+  rm -r "$ARTIFACTS_DIR/lib/arm64"
+  rm -r "$ARTIFACTS_DIR/lib/x64"
 done
 
 # fix error when generate license

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -34,6 +34,14 @@ do
   for target_cpu in "arm64" "x64"
   do
     # generate ninja files
+    # 
+    # note: `treat_warnings_as_errors=false` is for avoiding LLVM warning.
+    #       https://reviews.llvm.org/D72212
+    #       See below for details.
+    #       https://bugs.chromium.org/p/webrtc/issues/detail?id=11729
+    #
+    # note: `use_xcode_clang=true` is for using bitcode.
+    #
     gn gen "$OUTPUT_DIR" --root="src" \
       --args="is_debug=${is_debug} target_os=\"ios\" target_cpu=\"${target_cpu}\" ios_enable_code_signing=false enable_ios_bitcode=true rtc_use_h264=false rtc_include_tests=false rtc_build_examples=false"
 

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -37,7 +37,7 @@ do
   do
     # generate ninja files
     gn gen "$OUTPUT_DIR" --root="src" \
-      --args="is_debug=${is_debug} target_os=\"ios\" target_cpu=\"${target_cpu}\" rtc_use_h264=false rtc_include_tests=false rtc_build_examples=false"
+      --args="is_debug=${is_debug} target_os=\"ios\" target_cpu=\"${target_cpu}\" ios_enable_code_signing=false rtc_use_h264=false rtc_include_tests=false rtc_build_examples=false"
 
     # build static library
     ninja -C "$OUTPUT_DIR" webrtc

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -25,7 +25,7 @@ fi
 patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
 # add objc library to use videotoolbox
-patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_mac.patch"
+patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 
 mkdir -p "$ARTIFACTS_DIR/lib"
 

--- a/BuildScripts~/patches/add_objc_deps.patch
+++ b/BuildScripts~/patches/add_objc_deps.patch
@@ -4,7 +4,7 @@
      if (is_ios) {
        public_deps += [ ":framework_objc" ]
      }
-+    if(is_mac) {
++    if(is_ios || is_mac) {
 +      public_deps += [ 
 +        ":base_objc",
 +        ":default_codec_factory_objc",


### PR DESCRIPTION
This PR provides a script to build `libwebrtc` for iOS.

- To create a universal framework, use `lipo` command
- `arm64` and `x86_64` are supported for iOS device and simulator
- Enable bitcode

### Directory structure
```
webrtc
├── LICENSE.md
├── include
└── lib
    ├── libwebrtc.a
    └── libwebrtcd.a
```