### PR TITLE
fix: change value type "uint" to "ulong"

### DIFF
--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -82,15 +82,13 @@ namespace Unity.WebRTC
 
         public IEnumerable<MediaStreamTrack> GetVideoTracks()
         {
-            uint length = 0;
-            var buf = NativeMethods.MediaStreamGetVideoTracks(self, ref length);
+            var buf = NativeMethods.MediaStreamGetVideoTracks(self, out ulong length);
             return WebRTC.Deserialize(buf, (int)length, ptr => new MediaStreamTrack(ptr));
         }
 
         public IEnumerable<MediaStreamTrack> GetAudioTracks()
         {
-            uint length = 0;
-            var buf = NativeMethods.MediaStreamGetAudioTracks(self, ref length);
+            var buf = NativeMethods.MediaStreamGetAudioTracks(self, out ulong length);
             return WebRTC.Deserialize(buf, (int)length, ptr => new MediaStreamTrack(ptr));
         }
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -139,8 +139,7 @@ namespace Unity.WebRTC
         /// <seealso cref="GetTransceivers()"/>
         public IEnumerable<RTCRtpReceiver> GetReceivers()
         {
-            uint length = 0;
-            var buf = NativeMethods.PeerConnectionGetReceivers(self, ref length);
+            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(self, out ulong length);
             return WebRTC.Deserialize(buf, (int)length, ptr => new RTCRtpReceiver(ptr, this));
         }
 
@@ -157,8 +156,7 @@ namespace Unity.WebRTC
         /// <seealso cref="GetTransceivers()"/>
         public IEnumerable<RTCRtpSender> GetSenders()
         {
-            uint length = 0;
-            var buf = NativeMethods.PeerConnectionGetSenders(self, ref length);
+            var buf = NativeMethods.PeerConnectionGetSenders(self, out ulong length);
             return WebRTC.Deserialize(buf, (int)length, ptr => new RTCRtpSender(ptr, this));
         }
 
@@ -175,8 +173,7 @@ namespace Unity.WebRTC
         /// <seealso cref="GetReceivers()"/>
         public IEnumerable<RTCRtpTransceiver> GetTransceivers()
         {
-            uint length = 0;
-            var buf = NativeMethods.PeerConnectionGetTransceivers(self, ref length);
+            var buf = NativeMethods.PeerConnectionGetTransceivers(self, out ulong length);
             return WebRTC.Deserialize(buf, (int)length, ptr => new RTCRtpTransceiver(ptr, this));
         }
 

--- a/Runtime/Scripts/RTCStats.cs
+++ b/Runtime/Scripts/RTCStats.cs
@@ -108,7 +108,7 @@ namespace Unity.WebRTC
                 return null;
             }
 
-            uint length = 0;
+            ulong length = 0;
             switch (type)
             {
                 case StatsMemberType.Bool:
@@ -126,19 +126,19 @@ namespace Unity.WebRTC
                 case StatsMemberType.String:
                     return NativeMethods.StatsMemberGetString(self).AsAnsiStringWithFreeMem();
                 case StatsMemberType.SequenceBool:
-                    return NativeMethods.StatsMemberGetBoolArray(self, ref length).AsArray<bool>((int)length);
+                    return NativeMethods.StatsMemberGetBoolArray(self, out length).AsArray<bool>((int)length);
                 case StatsMemberType.SequenceInt32:
-                    return NativeMethods.StatsMemberGetIntArray(self, ref length).AsArray<int>((int)length);
+                    return NativeMethods.StatsMemberGetIntArray(self, out length).AsArray<int>((int)length);
                 case StatsMemberType.SequenceUint32:
-                    return NativeMethods.StatsMemberGetUnsignedIntArray(self, ref length).AsArray<uint>((int)length);
+                    return NativeMethods.StatsMemberGetUnsignedIntArray(self, out length).AsArray<uint>((int)length);
                 case StatsMemberType.SequenceInt64:
-                    return NativeMethods.StatsMemberGetLongArray(self, ref length).AsArray<long>((int)length);
+                    return NativeMethods.StatsMemberGetLongArray(self, out length).AsArray<long>((int)length);
                 case StatsMemberType.SequenceUint64:
-                    return NativeMethods.StatsMemberGetUnsignedLongArray(self, ref length).AsArray<ulong>((int)length);
+                    return NativeMethods.StatsMemberGetUnsignedLongArray(self, out length).AsArray<ulong>((int)length);
                 case StatsMemberType.SequenceDouble:
-                    return NativeMethods.StatsMemberGetDoubleArray(self, ref length).AsArray<double>((int)length);
+                    return NativeMethods.StatsMemberGetDoubleArray(self, out length).AsArray<double>((int)length);
                 case StatsMemberType.SequenceString:
-                    return NativeMethods.StatsMemberGetStringArray(self, ref length).AsArray<string>((int)length);
+                    return NativeMethods.StatsMemberGetStringArray(self, out length).AsArray<string>((int)length);
                 default:
                     throw new ArgumentException();
             }
@@ -251,8 +251,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetBoolArray(m_members[key].self, ref length).AsArray<bool>((int)length);
+            return NativeMethods.StatsMemberGetBoolArray(m_members[key].self, out ulong length).AsArray<bool>((int)length);
         }
         internal int[] GetIntArray(string key)
         {
@@ -260,8 +259,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetIntArray(m_members[key].self, ref length).AsArray<int>((int)length);
+            return NativeMethods.StatsMemberGetIntArray(m_members[key].self, out ulong length).AsArray<int>((int)length);
         }
 
         internal uint[] GetUnsignedIntArray(string key)
@@ -270,8 +268,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetUnsignedIntArray(m_members[key].self, ref length).AsArray<uint>((int)length);
+            return NativeMethods.StatsMemberGetUnsignedIntArray(m_members[key].self, out ulong length).AsArray<uint>((int)length);
         }
         internal long[] GetLongArray(string key)
         {
@@ -279,8 +276,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetLongArray(m_members[key].self, ref length).AsArray<long>((int)length);
+            return NativeMethods.StatsMemberGetLongArray(m_members[key].self, out ulong length).AsArray<long>((int)length);
         }
         internal ulong[] GetUnsignedLongArray(string key)
         {
@@ -288,8 +284,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetUnsignedLongArray(m_members[key].self, ref length).AsArray<ulong>((int)length);
+            return NativeMethods.StatsMemberGetUnsignedLongArray(m_members[key].self, out ulong length).AsArray<ulong>((int)length);
         }
         internal double[] GetDoubleArray(string key)
         {
@@ -297,8 +292,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetDoubleArray(m_members[key].self, ref length).AsArray<double>((int)length);
+            return NativeMethods.StatsMemberGetDoubleArray(m_members[key].self, out ulong length).AsArray<double>((int)length);
         }
         internal string[] GetStringArray(string key)
         {
@@ -306,8 +300,7 @@ namespace Unity.WebRTC
             {
                 return default;
             }
-            uint length = 0;
-            return NativeMethods.StatsMemberGetStringArray(m_members[key].self, ref length).AsArray<string>((int)length);
+            return NativeMethods.StatsMemberGetStringArray(m_members[key].self, out ulong length).AsArray<string>((int)length);
         }
 
         internal RTCStats(IntPtr ptr)
@@ -323,12 +316,11 @@ namespace Unity.WebRTC
 
         RTCStatsMember[] GetMembers()
         {
-            uint length = 0;
-            IntPtr ptr = NativeMethods.StatsGetMembers(self, ref length);
+            IntPtr ptr = NativeMethods.StatsGetMembers(self, out ulong length);
             IntPtr[] array = ptr.AsArray<IntPtr>((int)length);
 
             RTCStatsMember[] members = new RTCStatsMember[length];
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < (int)length; i++)
             {
                 members[i] = new RTCStatsMember(array[i]);
             }
@@ -740,15 +732,14 @@ namespace Unity.WebRTC
             self = ptr;
             WebRTC.Table.Add(self, this);
 
-            uint length = 0;
             IntPtr ptrStatsTypeArray = IntPtr.Zero;
-            IntPtr ptrStatsArray = NativeMethods.StatsReportGetStatsList(self, ref length, ref ptrStatsTypeArray);
+            IntPtr ptrStatsArray = NativeMethods.StatsReportGetStatsList(self, out ulong length, ref ptrStatsTypeArray);
 
             IntPtr[] array = ptrStatsArray.AsArray<IntPtr>((int)length);
             byte[] types = ptrStatsTypeArray.AsArray<byte>((int)length);
 
             m_dictStats = new Dictionary<string, RTCStats>();
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < (int)length; i++)
             {
                 RTCStatsType type = (RTCStatsType)types[i];
                 RTCStats stats = StatsFactory.Create(type, array[i]);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -612,11 +612,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern RTCPeerConnectionState PeerConnectionState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionGetReceivers(IntPtr ptr, ref uint length);
+        public static extern IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionGetSenders(IntPtr ptr, ref uint length);
+        public static extern IntPtr PeerConnectionGetSenders(IntPtr ptr, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionGetTransceivers(IntPtr ptr, ref uint length);
+        public static extern IntPtr PeerConnectionGetTransceivers(IntPtr ptr, out ulong length);
         [DllImport(WebRTC.Lib)]
         public static extern RTCIceConnectionState PeerConnectionIceConditionState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
@@ -683,9 +683,9 @@ namespace Unity.WebRTC
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool MediaStreamRemoveTrack(IntPtr stream, IntPtr track);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr MediaStreamGetVideoTracks(IntPtr stream, ref uint length);
+        public static extern IntPtr MediaStreamGetVideoTracks(IntPtr stream, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr MediaStreamGetAudioTracks(IntPtr stream, ref uint length);
+        public static extern IntPtr MediaStreamGetAudioTracks(IntPtr stream, out ulong length);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr MediaStreamGetID(IntPtr stream);
         [DllImport(WebRTC.Lib)]
@@ -722,7 +722,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ProcessAudio(float[] data, int size);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsReportGetStatsList(IntPtr report, ref uint length, ref IntPtr types);
+        public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsGetJson(IntPtr stats);
         [DllImport(WebRTC.Lib)]
@@ -732,7 +732,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern long StatsGetTimestamp(IntPtr stats);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsGetMembers(IntPtr stats, ref uint length);
+        public static extern IntPtr StatsGetMembers(IntPtr stats, out ulong length);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsMemberGetName(IntPtr member);
         [DllImport(WebRTC.Lib)]
@@ -756,19 +756,19 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsMemberGetString(IntPtr member);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetBoolArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetBoolArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetIntArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetIntArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetUnsignedIntArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetUnsignedIntArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetLongArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetLongArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetUnsignedLongArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetUnsignedLongArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetDoubleArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetDoubleArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsMemberGetStringArray(IntPtr member, ref uint length);
+        public static extern IntPtr StatsMemberGetStringArray(IntPtr member, out ulong length);
     }
 
     internal static class VideoEncoderMethods

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -38,10 +38,11 @@ namespace Unity.WebRTC.RuntimeTest
             stream.Dispose();
         }
 
+        // todo(kazuki): Crash on windows standalone player
         [UnityTest]
         [Timeout(5000)]
         [Category("MediaStream")]
-        [Ignore("TODO::Crash on windows standalone")]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer })]
         public IEnumerator VideoStreamAddTrackAndRemoveTrack()
         {
             var width = 256;
@@ -71,7 +72,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void AddAndRemoveAudioStreamTrack()
         {
             var stream = new MediaStream();
@@ -89,7 +89,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator CameraCaptureStream()
         {
             var camObj = new GameObject("Camera");
@@ -111,7 +110,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void AddAndRemoveAudioStream()
         {
             var audioStream = Audio.CaptureStream();
@@ -127,7 +125,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator AddAndRemoveAudioMediaTrack()
         {
             RTCConfiguration config = default;
@@ -149,7 +146,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator CaptureStream()
         {
             var camObj = new GameObject("Camera");
@@ -175,7 +171,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator SenderGetStats()
         {
             var camObj = new GameObject("Camera");
@@ -221,7 +216,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator ReceiverGetStats()
         {
             var camObj = new GameObject("Camera");
@@ -265,7 +259,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator SetParametersReturnNoError()
         {
             var camObj = new GameObject("Camera");
@@ -309,7 +302,7 @@ namespace Unity.WebRTC.RuntimeTest
         // todo::(kazuki) Test execution timed out on linux standalone
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.OSXPlayer })]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public IEnumerator OnAddTrackDelegatesWithEvent()
         {
             var camObj = new GameObject("Camera");

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -21,10 +21,11 @@ namespace Unity.WebRTC.RuntimeTest
             WebRTC.Dispose();
         }
 
+        // todo(kazuki): Crash on windows standalone player
         [UnityTest]
         [Timeout(5000)]
         [Category("MediaStreamTrack")]
-        [Ignore("TODO::Crash on windows standalone")]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer })]
         public IEnumerator VideoStreamTrackEnabled()
         {
             var width = 256;
@@ -61,7 +62,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(5000)]
         [Category("MediaStreamTrack")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.OSXPlayer })]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public IEnumerator CaptureStreamTrack()
         {
             var camObj = new GameObject("Camera");
@@ -77,7 +78,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("MediaStreamTrack")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void AddAndRemoveAudioStreamTrack()
         {
             var stream = new MediaStream();
@@ -111,7 +111,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(5000)]
         [Category("MediaStreamTrack")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.OSXPlayer })]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public IEnumerator VideoStreamTrackInstantiateMultiple()
         {
             var width = 256;

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -112,8 +112,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
-            uint length = 0;
-            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(connection, ref length);
+            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(connection, out ulong length);
             Assert.AreEqual(0, length);
             NativeMethods.ContextDeletePeerConnection(context, connection);
             NativeMethods.ContextDestroy(0);
@@ -225,7 +224,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         // todo(kazuki): Crash occurs when calling NativeMethods.MediaStreamRemoveTrack method on iOS device
         [Test]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer })]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void AddAndRemoveVideoTrackToMediaStream()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
@@ -236,8 +235,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = NativeMethods.ContextCreateVideoTrack(context, "video");
             NativeMethods.MediaStreamAddTrack(stream, track);
 
-            uint length = 0;
-            IntPtr buf = NativeMethods.MediaStreamGetVideoTracks(stream, ref length);
+            IntPtr buf = NativeMethods.MediaStreamGetVideoTracks(stream, out ulong length);
             Assert.AreNotEqual(buf, IntPtr.Zero);
             Assert.Greater(length, 0);
 
@@ -258,7 +256,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         // todo(kazuki): Crash occurs when calling NativeMethods.MediaStreamRemoveTrack method on iOS device
         [Test]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer })]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void AddAndRemoveAudioTrackToMediaStream()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);
@@ -266,13 +264,11 @@ namespace Unity.WebRTC.RuntimeTest
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
             NativeMethods.MediaStreamAddTrack(stream, track);
 
-            uint trackSize = 0;
-            var trackNativePtr = NativeMethods.MediaStreamGetAudioTracks(stream, ref trackSize);
+            var trackNativePtr = NativeMethods.MediaStreamGetAudioTracks(stream, out ulong trackSize);
             Assert.AreNotEqual(trackNativePtr, IntPtr.Zero);
             Assert.Greater(trackSize, 0);
 
-            uint length = 0;
-            IntPtr buf = NativeMethods.MediaStreamGetAudioTracks(stream, ref length);
+            IntPtr buf = NativeMethods.MediaStreamGetAudioTracks(stream, out ulong length);
             Assert.AreNotEqual(buf, IntPtr.Zero);
             Assert.Greater(length, 0);
 

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -41,7 +41,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("PeerConnection")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void Construct()
         {
             var peer = new RTCPeerConnection();
@@ -109,7 +108,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("PeerConnection")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void AddTransceiver()
         {
             var peer = new RTCPeerConnection();
@@ -146,7 +144,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("PeerConnection")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void AddTransceiverTrackKindAudio()
         {
             var peer = new RTCPeerConnection();
@@ -166,7 +163,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("PeerConnection")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public void AddTransceiverTrackKindVideo()
         {
             var peer = new RTCPeerConnection();
@@ -203,7 +199,6 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(1000)]
         [Category("PeerConnection")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator CurrentDirection()
         {
             var config = GetConfiguration();
@@ -448,7 +443,6 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(1000)]
         [Category("PeerConnection")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator SetRemoteDescriptionFailed()
         {
             var config = GetConfiguration();
@@ -484,7 +478,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator IceConnectionStateChange()
         {
             RTCConfiguration config = default;
@@ -533,7 +526,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator GetStatsReturnsReport()
         {
             var camObj = new GameObject("Camera");

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -49,7 +49,8 @@ namespace Unity.WebRTC.RuntimeTest
         [Timeout(5000)]
         [ConditionalIgnore(ConditionalIgnore.Direct3D12,
             "VideoStreamTrack.UpdateReceiveTexture is not supported on Direct3D12")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
+        [UnityPlatform(exclude = new[] {
+            RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.OSXEditor})]
         public IEnumerator VideoReceive()
         {
             var config = new RTCConfiguration


### PR DESCRIPTION
This fix is for the crash that occurred when testing the standalone build with IL2CPP on macOS.
This issue is not reproduced with mono backend instead of IL2CPP.

It should treat `size_t` type in c++ code on 64bit architecture as `ulong` type in managed code, but had treated as `uint`.