### PR TITLE
fix: VideoStreamTrack constructor throws an exception if the arguments are invalid

### DIFF
--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -17,11 +17,11 @@ namespace Unity.WebRTC
         UnityVideoRenderer m_renderer;
 
         private static RenderTexture CreateRenderTexture(int width, int height,
-            GraphicsFormat format)
+            RenderTextureFormat format)
         {
             // todo::(kazuki) Increase the supported formats.
-            GraphicsFormat supportedFormat
-                = WebRTC.GetSupportedGraphicsFormat(UnityEngine.SystemInfo.graphicsDeviceType);
+            RenderTextureFormat supportedFormat
+                = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             if (format != supportedFormat)
             {
                 throw new ArgumentException(
@@ -71,7 +71,8 @@ namespace Unity.WebRTC
             m_needFlip = true;
             var format = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
             m_sourceTexture = new Texture2D(width, height, format, TextureCreationFlags.None);
-            m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, format);
+            var renderTextureFormat = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, renderTextureFormat);
 
             m_renderer = new UnityVideoRenderer(WebRTC.Context.CreateVideoRenderer(), this);
 
@@ -117,7 +118,7 @@ namespace Unity.WebRTC
         /// <param name="width"></param>
         /// <param name="height"></param>
         public VideoStreamTrack(string label, UnityEngine.RenderTexture source)
-            : this(label, source, CreateRenderTexture(source.width, source.height, source.graphicsFormat), source.width,
+            : this(label, source, CreateRenderTexture(source.width, source.height, source.format), source.width,
                 source.height)
         {
         }
@@ -126,7 +127,7 @@ namespace Unity.WebRTC
             : this(label,
                 source,
                 CreateRenderTexture(source.width, source.height,
-                    WebRTC.GetSupportedGraphicsFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
+                    WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
                 source.width,
                 source.height)
         {

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -19,6 +19,15 @@ namespace Unity.WebRTC
         private static RenderTexture CreateRenderTexture(int width, int height,
             GraphicsFormat format)
         {
+            // todo::(kazuki) Increase the supported formats.
+            GraphicsFormat supportedFormat
+                = WebRTC.GetSupportedGraphicsFormat(UnityEngine.SystemInfo.graphicsDeviceType);
+            if (format != supportedFormat)
+            {
+                throw new ArgumentException(
+                    $"This graphics format is not supported for streaming: {format} supportedFormat: {supportedFormat}");
+            }
+
             var tex = new RenderTexture(width, height, 0, format);
             tex.Create();
             return tex;

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -28,7 +28,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var width = 256;
             var height = 256;
-            var format = RenderTextureFormat.Default;
+            var format = RenderTextureFormat.R8;
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
             Assert.Throws<ArgumentException>(() =>
@@ -37,7 +37,6 @@ namespace Unity.WebRTC.RuntimeTest
             });
             Object.DestroyImmediate(rt);
         }
-
 
         // todo(kazuki): Crash on windows standalone player
         [UnityTest]

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -1,8 +1,10 @@
+using System;
 using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Linq;
 using System.Collections;
+using Object = UnityEngine.Object;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -20,6 +22,22 @@ namespace Unity.WebRTC.RuntimeTest
         {
             WebRTC.Dispose();
         }
+
+        [Test]
+        public void ConstructorThrowsException()
+        {
+            var width = 256;
+            var height = 256;
+            var format = RenderTextureFormat.Default;
+            var rt = new RenderTexture(width, height, 0, format);
+            rt.Create();
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var track = new VideoStreamTrack("video", rt);
+            });
+            Object.DestroyImmediate(rt);
+        }
+
 
         // todo(kazuki): Crash on windows standalone player
         [UnityTest]


### PR DESCRIPTION
Related issue https://github.com/Unity-Technologies/UnityRenderStreaming/issues/360 .

Up until now the constructor of `VideoStreamTrack` class accepts parameters unconditionally but now it checks the `GraphicsFormat` which is supported by the library.
If the format is invalid, the constructor throws `ArgumentException`.