### PR TITLE
feat: Add icecandidate properties

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -243,19 +243,6 @@ namespace webrtc
         connection->CreateAnswer(this, _options);
     }
 
-    void PeerConnectionObject::AddIceCandidate(const RTCIceCandidate& candidate)
-    {
-        if(connection.get() == nullptr) {
-            LogPrint("peer connection is not initialized %d", this);
-            return;
-        }
-
-        webrtc::SdpParseError error;
-        const std::unique_ptr<webrtc::IceCandidateInterface> _candidate(
-            webrtc::CreateIceCandidate(candidate.sdpMid, candidate.sdpMLineIndex, candidate.candidate, &error));
-        connection->AddIceCandidate(_candidate.get());
-    }
-
     void PeerConnectionObject::ReceiveStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report)
     {
         context.AddStatsReport(report);

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -38,7 +38,6 @@ namespace webrtc
         std::string GetConfiguration() const;
         void CreateOffer(const RTCOfferOptions& options);
         void CreateAnswer(const RTCAnswerOptions& options);
-        void AddIceCandidate(const RTCIceCandidate& candidate);
         void ReceiveStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report);
 
         void RegisterCallbackCreateSD(DelegateCreateSDSuccess onSuccess, DelegateCreateSDFailure onFailure)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -857,7 +857,7 @@ extern "C"
         }
     };
 
-    UNITY_INTERFACE_EXPORT RTCErrorType IceCandidateCreate(const RTCIceCandidateInit* options, IceCandidateInterface** candidate)
+    UNITY_INTERFACE_EXPORT RTCErrorType CreateIceCandidate(const RTCIceCandidateInit* options, IceCandidateInterface** candidate)
     {
         SdpParseError error;
         IceCandidateInterface* _candidate = CreateIceCandidate(options->sdpMid, options->sdpMLineIndex, options->candidate, &error);
@@ -865,6 +865,11 @@ extern "C"
             return RTCErrorType::INVALID_PARAMETER;
         *candidate = _candidate;
         return RTCErrorType::NONE;
+    }
+
+    UNITY_INTERFACE_EXPORT void DeleteIceCandidate(IceCandidateInterface* candidate)
+    {
+        delete candidate;
     }
 
     UNITY_INTERFACE_EXPORT void IceCandidateGetCandidate(const IceCandidateInterface* candidate, Candidate* dst)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -810,9 +810,76 @@ extern "C"
         context->GetObserver(obj->connection)->RegisterDelegateOnFailure(onFailure);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionAddIceCandidate(PeerConnectionObject* obj, const RTCIceCandidate* candidate)
+    UNITY_INTERFACE_EXPORT bool PeerConnectionAddIceCandidate(PeerConnectionObject* obj, const IceCandidateInterface* candidate)
     {
-        return obj->AddIceCandidate(*candidate);
+        return obj->connection->AddIceCandidate(candidate);
+    }
+
+    struct RTCIceCandidateInit
+    {
+        char* candidate;
+        char* sdpMid;
+        int32_t sdpMLineIndex;
+    };
+
+    struct Candidate
+    {
+        char* candidate;
+        int32_t component;
+        char* foundation;
+        char* ip;
+        uint16_t port;
+        uint32_t priority;
+        char* address;
+        char* protocol;
+        char* relatedAddress;
+        uint16_t relatedPort;
+        char* tcpType;
+        char* type;
+        char* usernameFragment;
+
+        Candidate& operator =(const cricket::Candidate& obj)
+        {
+            candidate = ConvertString(obj.ToString());
+            component = obj.component();
+            foundation = ConvertString(obj.foundation());
+            ip = ConvertString(obj.address().ipaddr().ToString());
+            port = obj.address().port();
+            priority = obj.priority();
+            address = ConvertString(obj.address().ToString());
+            protocol = ConvertString(obj.protocol());
+            relatedAddress = ConvertString(obj.related_address().ToString());
+            relatedPort = obj.related_address().port();
+            tcpType = ConvertString(obj.tcptype());
+            type = ConvertString(obj.type());
+            usernameFragment = ConvertString(obj.username());
+            return *this;
+        }
+    };
+
+    UNITY_INTERFACE_EXPORT RTCErrorType IceCandidateCreate(const RTCIceCandidateInit* options, IceCandidateInterface** candidate)
+    {
+        SdpParseError error;
+        IceCandidateInterface* _candidate = CreateIceCandidate(options->sdpMid, options->sdpMLineIndex, options->candidate, &error);
+        if (_candidate == nullptr)
+            return RTCErrorType::INVALID_PARAMETER;
+        *candidate = _candidate;
+        return RTCErrorType::NONE;
+    }
+
+    UNITY_INTERFACE_EXPORT void IceCandidateGetCandidate(const IceCandidateInterface* candidate, Candidate* dst)
+    {
+        *dst = candidate->candidate();
+    }
+
+    UNITY_INTERFACE_EXPORT int32_t IceCandidateGetSdpLineIndex(const IceCandidateInterface* candidate)
+    {
+        return candidate->sdp_mline_index();
+    }
+
+    UNITY_INTERFACE_EXPORT const char* IceCandidateGetSdpMid(const IceCandidateInterface* candidate)
+    {
+        return ConvertString(candidate->sdp_mid());
     }
 
     UNITY_INTERFACE_EXPORT RTCPeerConnectionState PeerConnectionState(PeerConnectionObject* obj)

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -99,6 +99,12 @@
 #include "IUnityGraphicsVulkan.h"
 #endif
 
+#if _WIN32 && _DEBUG
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
+#define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#endif
+
 namespace unity
 {
 namespace webrtc

--- a/Runtime/Scripts/RTCIceCandidate.cs
+++ b/Runtime/Scripts/RTCIceCandidate.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Unity.WebRTC
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RTCIceCandidateInit
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string candidate;
+        /// <summary>
+        /// 
+        /// </summary>
+        public string sdpMid;
+        /// <summary>
+        /// 
+        /// </summary>
+        public int? sdpMLineIndex;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum RTCIceComponent : int
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Rtp = 1,
+        /// <summary>
+        /// 
+        /// </summary>
+        Rtcp = 2,
+
+        Default = 1
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum RTCIceProtocol : int
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Udp = 1,
+        /// <summary>
+        /// 
+        /// </summary>
+        Tcp = 2
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum RTCIceCandidateType
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Host,
+        /// <summary>
+        /// 
+        /// </summary>
+        Srflx,
+        /// <summary>
+        /// 
+        /// </summary>
+        Prflx,
+        /// <summary>
+        /// 
+        /// </summary>
+        Relay
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum RTCIceTcpCandidateType
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Active,
+        /// <summary>
+        /// 
+        /// </summary>
+        Passive,
+        /// <summary>
+        /// 
+        /// </summary>
+        So
+    }
+
+    internal static class CandidateExtention
+    {
+        public static RTCIceProtocol ParseRTCIceProtocol(this string src)
+        {
+            switch (src)
+            {
+                case "udp":
+                    return RTCIceProtocol.Udp;
+                case "tcp":
+                    return RTCIceProtocol.Tcp;
+                default:
+                    throw new ArgumentException($"Invalid parameter: {src}");
+            }
+        }
+
+        public static RTCIceCandidateType ParseRTCIceCandidateType(this string src)
+        {
+            switch (src)
+            {
+                case "local":
+                    return RTCIceCandidateType.Host;
+                case "stun":
+                    return RTCIceCandidateType.Srflx;
+                case "prflx":
+                    return RTCIceCandidateType.Prflx;
+                case "relay":
+                    return RTCIceCandidateType.Relay;
+                default:
+                    throw new ArgumentException($"Invalid parameter: {src}");
+            }
+        }
+
+        
+        public static RTCIceTcpCandidateType? ParseRTCIceTcpCandidateType(this string src)
+        {
+            if (string.IsNullOrEmpty(src))
+                return null;
+            switch (src)
+            {
+                case "active":
+                    return RTCIceTcpCandidateType.Active;
+                case "passive":
+                    return RTCIceTcpCandidateType.Passive;
+                case "so":
+                    return RTCIceTcpCandidateType.So;
+                default:
+                    throw new ArgumentException($"Invalid parameter: {src}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RTCIceCandidate
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Candidate => _candidate.candidate;
+        /// <summary>
+        /// 
+        /// </summary>
+        public string SdpMid => NativeMethods.IceCandidateGetSdpMid(self);
+        /// <summary>
+        /// 
+        /// </summary>
+        public int? SdpMLineIndex => NativeMethods.IceCandidateGetSdpLineIndex(self);
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Foundation => _candidate.foundation;
+        /// <summary>
+        /// 
+        /// </summary>
+        public RTCIceComponent? Component => _candidate.component;
+        /// <summary>
+        /// 
+        /// </summary>
+        public uint Priority => _candidate.priority;
+        /// <summary>
+        /// 
+        /// </summary>
+        public string Address => _candidate.address;
+        /// <summary>
+        /// 
+        /// </summary>
+        public RTCIceProtocol? Protocol => _candidate.protocol.ParseRTCIceProtocol();
+        /// <summary>
+        /// 
+        /// </summary>
+        public ushort? Port => _candidate.port;
+        /// <summary>
+        /// 
+        /// </summary>
+        public RTCIceCandidateType? Type => _candidate.type.ParseRTCIceCandidateType();
+        /// <summary>
+        /// 
+        /// </summary>
+        public RTCIceTcpCandidateType? TcpType => _candidate.tcpType.ParseRTCIceTcpCandidateType();
+        /// <summary>
+        /// 
+        /// </summary>
+        public string RelatedAddress => _candidate.relatedAddress;
+        /// <summary>
+        /// 
+        /// </summary>
+        public ushort? RelatedPort => _candidate.relatedPort;
+        /// <summary>
+        /// 
+        /// </summary>
+        public string UserNameFragment => _candidate.usernameFragment;
+
+
+        internal IntPtr self;
+        private CandidateInternal _candidate;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="candidateInfo"></param>
+        public RTCIceCandidate(RTCIceCandidateInit candidateInfo = null)
+        {
+            candidateInfo = candidateInfo ?? new RTCIceCandidateInit();
+            RTCIceCandidateInitInternal option = (RTCIceCandidateInitInternal)candidateInfo;
+            RTCErrorType error = NativeMethods.IceCandidateCreate(ref option, out self);
+            if (error != RTCErrorType.None)
+                throw new ArgumentException();
+
+            NativeMethods.IceCandidateGetCandidate(self, out _candidate);
+        }
+    }
+
+    internal struct RTCIceCandidateInitInternal
+    {
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string candidate;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string sdpMid;
+        public int sdpMLineIndex;
+
+        public static explicit operator RTCIceCandidateInitInternal(RTCIceCandidateInit origin)
+        {
+            RTCIceCandidateInitInternal dst = new RTCIceCandidateInitInternal
+            {
+                candidate = origin.candidate ?? "",
+                sdpMid = origin.sdpMid ?? "0",
+                sdpMLineIndex = origin.sdpMLineIndex.GetValueOrDefault(0)
+            };
+            return dst;
+        }
+    }
+
+    internal struct CandidateInternal
+    {
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string candidate;
+        public RTCIceComponent component;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string foundation;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string ip;
+        public ushort port;
+        public uint priority;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string address;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string protocol;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string relatedAddress;
+        public ushort relatedPort;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string tcpType;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string type;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string usernameFragment;
+    }
+}

--- a/Runtime/Scripts/RTCIceCandidate.cs
+++ b/Runtime/Scripts/RTCIceCandidate.cs
@@ -150,7 +150,7 @@ namespace Unity.WebRTC
     /// <summary>
     /// 
     /// </summary>
-    public class RTCIceCandidate
+    public class RTCIceCandidate : IDisposable
     {
         /// <summary>
         /// 
@@ -212,6 +212,32 @@ namespace Unity.WebRTC
 
         internal IntPtr self;
         private CandidateInternal _candidate;
+        private bool disposed;
+
+        ~RTCIceCandidate()
+        {
+            this.Dispose();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            if (self != IntPtr.Zero)
+            {
+                NativeMethods.DeleteIceCandidate(self);
+                self = IntPtr.Zero;
+            }
+
+            this.disposed = true;
+            GC.SuppressFinalize(this);
+        }
 
         /// <summary>
         /// 
@@ -221,7 +247,7 @@ namespace Unity.WebRTC
         {
             candidateInfo = candidateInfo ?? new RTCIceCandidateInit();
             RTCIceCandidateInitInternal option = (RTCIceCandidateInitInternal)candidateInfo;
-            RTCErrorType error = NativeMethods.IceCandidateCreate(ref option, out self);
+            RTCErrorType error = NativeMethods.CreateIceCandidate(ref option, out self);
             if (error != RTCErrorType.None)
                 throw new ArgumentException();
 

--- a/Runtime/Scripts/RTCIceCandidate.cs.meta
+++ b/Runtime/Scripts/RTCIceCandidate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ffd1fcd75b792d46b29a015cca9c232
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -273,8 +273,13 @@ namespace Unity.WebRTC
             {
                 if (WebRTC.Table[ptr] is RTCPeerConnection connection)
                 {
-                    var candidate =
-                        new RTCIceCandidate { candidate = sdp, sdpMid = sdpMid, sdpMLineIndex = sdpMlineIndex };
+                    var options = new RTCIceCandidateInit
+                    {
+                        candidate = sdp,
+                        sdpMid = sdpMid,
+                        sdpMLineIndex = sdpMlineIndex
+                    };
+                    var candidate = new RTCIceCandidate(options);
                     connection.OnIceCandidate?.Invoke(candidate);
                 }
             });
@@ -497,9 +502,9 @@ namespace Unity.WebRTC
         ///
         /// </summary>
         /// <param name="candidate"></param>
-        public void AddIceCandidate(ref RTCIceCandidate candidate)
+        public bool AddIceCandidate(RTCIceCandidate candidate)
         {
-            NativeMethods.PeerConnectionAddIceCandidate(self, ref candidate);
+            return NativeMethods.PeerConnectionAddIceCandidate(self, candidate.self);
         }
 
         /// <summary>

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -15,15 +15,6 @@ namespace Unity.WebRTC
         Hardware = 1
     }
 
-    public struct RTCIceCandidate
-    {
-        [MarshalAs(UnmanagedType.LPStr)]
-        public string candidate;
-        [MarshalAs(UnmanagedType.LPStr)]
-        public string sdpMid;
-        public int sdpMLineIndex;
-    }
-
     public enum RTCErrorDetailType
     {
         DataChannelFailure,
@@ -586,7 +577,16 @@ namespace Unity.WebRTC
         public static extern void PeerConnectionRemoveTrack(IntPtr pc, IntPtr sender);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool PeerConnectionAddIceCandidate(IntPtr ptr, ref RTCIceCandidate candidate);
+        public static extern bool PeerConnectionAddIceCandidate(IntPtr ptr, IntPtr candidate);
+        [DllImport(WebRTC.Lib)]
+        public static extern RTCErrorType IceCandidateCreate(ref RTCIceCandidateInitInternal options, out IntPtr candidate);
+        [DllImport(WebRTC.Lib)]
+        public static extern void IceCandidateGetCandidate(IntPtr candidate, out CandidateInternal dst);
+        [DllImport(WebRTC.Lib)]
+        public static extern int IceCandidateGetSdpLineIndex(IntPtr candidate);
+        [DllImport(WebRTC.Lib)]
+        [return: MarshalAs(UnmanagedType.LPStr)]
+        public static extern string IceCandidateGetSdpMid(IntPtr candidate);
         [DllImport(WebRTC.Lib)]
         public static extern RTCPeerConnectionState PeerConnectionState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -579,7 +579,9 @@ namespace Unity.WebRTC
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool PeerConnectionAddIceCandidate(IntPtr ptr, IntPtr candidate);
         [DllImport(WebRTC.Lib)]
-        public static extern RTCErrorType IceCandidateCreate(ref RTCIceCandidateInitInternal options, out IntPtr candidate);
+        public static extern RTCErrorType CreateIceCandidate(ref RTCIceCandidateInitInternal options, out IntPtr candidate);
+        [DllImport(WebRTC.Lib)]
+        public static extern RTCErrorType DeleteIceCandidate(IntPtr candidate);
         [DllImport(WebRTC.Lib)]
         public static extern void IceCandidateGetCandidate(IntPtr candidate, out CandidateInternal dst);
         [DllImport(WebRTC.Lib)]

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -292,8 +292,8 @@ public class BandwidthSample : MonoBehaviour
 
     private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     private string GetName(RTCPeerConnection pc)

--- a/Samples~/ChangeCodecs/ChangeCodecsSample.cs
+++ b/Samples~/ChangeCodecs/ChangeCodecsSample.cs
@@ -268,8 +268,8 @@ public class ChangeCodecsSample : MonoBehaviour
 
     private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     private string GetName(RTCPeerConnection pc)

--- a/Samples~/DataChannel/DataChannelSample.cs
+++ b/Samples~/DataChannel/DataChannelSample.cs
@@ -167,8 +167,8 @@ public class DataChannelSample : MonoBehaviour
     /// <param name="streamEvent"></param>
     void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     public void SendMsg()

--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -198,8 +198,8 @@ public class MediaStreamSample : MonoBehaviour
 
     private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     private void OnTrack(RTCPeerConnection pc, RTCTrackEvent e)

--- a/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
+++ b/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
@@ -245,8 +245,8 @@ public class MultiVideoReceiveSample : MonoBehaviour
 
     private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     private string GetName(RTCPeerConnection pc)

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -99,15 +99,15 @@ public class MultiplePeerConnectionsSample : MonoBehaviour
         pc1Local = new RTCPeerConnection(ref configuration);
         pc1Remote = new RTCPeerConnection(ref configuration);
         pc1Remote.OnTrack = e => receiveVideoStream1.AddTrack(e.Track);
-        pc1Local.OnIceCandidate = candidate => pc1Remote.AddIceCandidate(ref candidate);
-        pc1Remote.OnIceCandidate = candidate => pc1Local.AddIceCandidate(ref candidate);
+        pc1Local.OnIceCandidate = candidate => pc1Remote.AddIceCandidate(candidate);
+        pc1Remote.OnIceCandidate = candidate => pc1Local.AddIceCandidate(candidate);
         Debug.Log("pc1: created local and remote peer connection object");
 
         pc2Local = new RTCPeerConnection(ref configuration);
         pc2Remote = new RTCPeerConnection(ref configuration);
         pc2Remote.OnTrack = e => receiveVideoStream2.AddTrack(e.Track);
-        pc2Local.OnIceCandidate = candidate => pc2Remote.AddIceCandidate(ref candidate);
-        pc2Remote.OnIceCandidate = candidate => pc2Local.AddIceCandidate(ref candidate);
+        pc2Local.OnIceCandidate = candidate => pc2Remote.AddIceCandidate(candidate);
+        pc2Remote.OnIceCandidate = candidate => pc2Local.AddIceCandidate(candidate);
         Debug.Log("pc2: created local and remote peer connection object");
 
         foreach (var track in sourceVideoStream.GetTracks())

--- a/Samples~/MungeSDP/MungeSDPSample.cs
+++ b/Samples~/MungeSDP/MungeSDPSample.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using Unity.WebRTC;
 using UnityEngine;
 using UnityEngine.UI;
@@ -99,8 +99,8 @@ public class MungeSDPSample : MonoBehaviour
         pcLocal = new RTCPeerConnection(ref configuration);
         pcRemote = new RTCPeerConnection(ref configuration);
         pcRemote.OnTrack = e => receiveVideoStream.AddTrack(e.Track);
-        pcLocal.OnIceCandidate = candidate => pcRemote.AddIceCandidate(ref candidate);
-        pcRemote.OnIceCandidate = candidate => pcLocal.AddIceCandidate(ref candidate);
+        pcLocal.OnIceCandidate = candidate => pcRemote.AddIceCandidate(candidate);
+        pcRemote.OnIceCandidate = candidate => pcLocal.AddIceCandidate(candidate);
         Debug.Log("pc1: created local and remote peer connection object");
 
         foreach (var track in sourceVideoStream.GetTracks())

--- a/Samples~/PeerConnection/PeerConnectionSample.cs
+++ b/Samples~/PeerConnection/PeerConnectionSample.cs
@@ -143,8 +143,8 @@ public class PeerConnectionSample : MonoBehaviour
     }
     void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
     string GetName(RTCPeerConnection pc)
     {

--- a/Samples~/Stats/StatsSample.cs
+++ b/Samples~/Stats/StatsSample.cs
@@ -190,8 +190,8 @@ public class StatsSample : MonoBehaviour
     /// <param name="streamEvent"></param>
     void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     string GetName(RTCPeerConnection pc)

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -220,8 +220,8 @@ public class VideoReceiveSample : MonoBehaviour
 
     private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
     {
-        GetOtherPc(pc).AddIceCandidate(ref candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.candidate}");
+        GetOtherPc(pc).AddIceCandidate(candidate);
+        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
     }
 
     private string GetName(RTCPeerConnection pc)

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -118,8 +118,8 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             RTCDataChannel channel2 = null;
 
-            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
-            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
             peer2.OnDataChannel = channel => { channel2 = channel; };
 
             var channel1 = peer1.CreateDataChannel("data");

--- a/Tests/Runtime/IceCandidateTest.cs
+++ b/Tests/Runtime/IceCandidateTest.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+
+namespace Unity.WebRTC.RuntimeTest
+{
+    class IceCandidateTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            var value = NativeMethods.GetHardwareEncoderSupport();
+            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            WebRTC.Dispose();
+        }
+
+        [Test]
+        [Category("IceCandidate")]
+        public void Construct()
+        {
+            var option = new RTCIceCandidateInit
+            {
+                sdpMid = "0",
+                sdpMLineIndex = 0,
+                candidate =
+                    "candidate:102362043 1 udp 2122262783 240b:10:2fe0:4900:3cbd:7306:63c4:a8e1 50241 typ host generation 0 ufrag DEIG network-id 5"
+            };
+            var candidate = new RTCIceCandidate(option);
+            Assert.IsNotEmpty(candidate.Candidate);
+            Assert.AreEqual(RTCIceComponent.Default, candidate.Component);
+            Assert.IsNotEmpty(candidate.Foundation);
+            Assert.NotNull(candidate.Port);
+            Assert.NotNull(candidate.Priority);
+            Assert.IsNotEmpty(candidate.Address);
+            Assert.NotNull(candidate.Protocol);
+            Assert.IsNotEmpty(candidate.RelatedAddress);
+            Assert.NotNull(candidate.RelatedPort);
+            Assert.IsNotEmpty(candidate.SdpMid);
+            Assert.NotNull(candidate.SdpMLineIndex);
+            Assert.NotNull(candidate.Type);
+            Assert.Null(candidate.TcpType);
+            Assert.IsNotEmpty(candidate.UserNameFragment);
+        }
+    }
+}

--- a/Tests/Runtime/IceCandidateTest.cs.meta
+++ b/Tests/Runtime/IceCandidateTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39690421dbf0bd041a208ebbf782c299
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -61,6 +61,11 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void NothingToDo()
+        {
+        }
+
+        [Test]
         public void CreateAndDestroyContext()
         {
             var context = NativeMethods.ContextCreate(0, encoderType);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -503,8 +503,8 @@ namespace Unity.WebRTC.RuntimeTest
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
 
-            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(ref candidate); };
-            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(ref candidate); };
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
 
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -83,14 +83,14 @@ namespace Unity.WebRTC.RuntimeTest
             peers[0].OnIceCandidate = candidate =>
             {
                 Assert.NotNull(candidate);
-                Assert.NotNull(candidate.candidate);
-                peers[1].AddIceCandidate(ref candidate);
+                Assert.NotNull(candidate.Candidate);
+                peers[1].AddIceCandidate(candidate);
             };
             peers[1].OnIceCandidate = candidate =>
             {
                 Assert.NotNull(candidate);
-                Assert.NotNull(candidate.candidate);
-                peers[0].AddIceCandidate(ref candidate);
+                Assert.NotNull(candidate.Candidate);
+                peers[0].AddIceCandidate(candidate);
             };
             peers[1].OnTrack = e =>
             {

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -103,8 +103,8 @@ namespace Unity.WebRTC.RuntimeTest
 
         private static IEnumerator SignalingPeers(RTCPeerConnection offerPc, RTCPeerConnection answerPc)
         {
-            offerPc.OnIceCandidate = candidate => answerPc.AddIceCandidate(ref candidate);
-            answerPc.OnIceCandidate = candidate => offerPc.AddIceCandidate(ref candidate);
+            offerPc.OnIceCandidate = candidate => answerPc.AddIceCandidate(candidate);
+            answerPc.OnIceCandidate = candidate => offerPc.AddIceCandidate(candidate);
 
             var offerOption = new RTCOfferOptions {offerToReceiveVideo = true};
             var answerOption = new RTCAnswerOptions {iceRestart = false};


### PR DESCRIPTION
Related issue : #274 

- Changed type of `RTCIceCandidate` from `struct` to `class`
- Added properties to `RTCIceCandidate` class based on [WebIDL](https://www.w3.org/TR/webrtc/#rtcicecandidate-interface)

```csharp
    public class RTCIceCandidate : IDisposable
    {
        public string Candidate;
        public string SdpMid;
        public int? SdpMLineIndex;
        public string Foundation;
        public RTCIceComponent? Component;
        public uint Priority;
        public string Address;
        public RTCIceProtocol? Protocol;
        public ushort? Port;
        public RTCIceCandidateType? Type;
        public RTCIceTcpCandidateType? TcpType;
        public string RelatedAddress;
        public ushort? RelatedPort;
        public string UserNameFragment;
    }
```