### PR TITLE
fix: Fixed the bug of the ice candidate property

### DIFF
--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -887,6 +887,14 @@ extern "C"
         return candidate->sdp_mline_index();
     }
 
+    UNITY_INTERFACE_EXPORT const char* IceCandidateGetSdp(const IceCandidateInterface* candidate)
+    {
+        std::string str;
+        if (!candidate->ToString(&str))
+            return nullptr;
+        return ConvertString(str);
+    }
+
     UNITY_INTERFACE_EXPORT const char* IceCandidateGetSdpMid(const IceCandidateInterface* candidate)
     {
         return ConvertString(candidate->sdp_mid());

--- a/Runtime/Scripts/RTCIceCandidate.cs
+++ b/Runtime/Scripts/RTCIceCandidate.cs
@@ -154,7 +154,7 @@ namespace Unity.WebRTC
         /// <summary>
         /// 
         /// </summary>
-        public string Candidate => _candidate.candidate;
+        public string Candidate => NativeMethods.IceCandidateGetSdp(self);
         /// <summary>
         /// 
         /// </summary>
@@ -245,10 +245,17 @@ namespace Unity.WebRTC
         public RTCIceCandidate(RTCIceCandidateInit candidateInfo = null)
         {
             candidateInfo = candidateInfo ?? new RTCIceCandidateInit();
+            if(candidateInfo.sdpMLineIndex == null && candidateInfo.sdpMid == null)
+                throw new ArgumentException("sdpMid and sdpMLineIndex are both null");
+
             RTCIceCandidateInitInternal option = (RTCIceCandidateInitInternal)candidateInfo;
             RTCErrorType error = NativeMethods.CreateIceCandidate(ref option, out self);
             if (error != RTCErrorType.None)
-                throw new ArgumentException();
+                throw new ArgumentException(
+                        $"create candidate is failed. error type:{error}, " +
+                        $"sdpMid:{candidateInfo.candidate}\n" +
+                        $"sdpMid:{candidateInfo.sdpMid}\n" +
+                        $"sdpMLineIndex:{candidateInfo.sdpMLineIndex}\n");
 
             NativeMethods.IceCandidateGetCandidate(self, out _candidate);
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -678,6 +678,9 @@ namespace Unity.WebRTC
         public static extern int IceCandidateGetSdpLineIndex(IntPtr candidate);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.LPStr)]
+        public static extern string IceCandidateGetSdp(IntPtr candidate);
+        [DllImport(WebRTC.Lib)]
+        [return: MarshalAs(UnmanagedType.LPStr)]
         public static extern string IceCandidateGetSdpMid(IntPtr candidate);
         [DllImport(WebRTC.Lib)]
         public static extern RTCPeerConnectionState PeerConnectionState(IntPtr ptr);

--- a/Tests/Runtime/IceCandidateTest.cs
+++ b/Tests/Runtime/IceCandidateTest.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace Unity.WebRTC.RuntimeTest
@@ -21,6 +22,13 @@ namespace Unity.WebRTC.RuntimeTest
         [Category("IceCandidate")]
         public void Construct()
         {
+            Assert.Throws<ArgumentException>(() => new RTCIceCandidate());
+        }
+
+        [Test]
+        [Category("IceCandidate")]
+        public void ConstructWithOption()
+        {
             var option = new RTCIceCandidateInit
             {
                 sdpMid = "0",
@@ -30,6 +38,9 @@ namespace Unity.WebRTC.RuntimeTest
             };
             var candidate = new RTCIceCandidate(option);
             Assert.IsNotEmpty(candidate.Candidate);
+            Assert.AreEqual(candidate.Candidate, option.candidate);
+            Assert.AreEqual(candidate.SdpMLineIndex, option.sdpMLineIndex);
+            Assert.AreEqual(candidate.SdpMid, option.sdpMid);
             Assert.AreEqual(RTCIceComponent.Rtp, candidate.Component);
             Assert.IsNotEmpty(candidate.Foundation);
             Assert.NotNull(candidate.Port);


### PR DESCRIPTION
This pull request fixes the issue reported on the forum.
https://forum.unity.com/threads/unity-render-streaming-introduction-faq.742481/page-11#post-6697456

`RTCIceCandidate.Candidate` property has been returned an invalid string until this fix.