### PR TITLE
test: Use FetchContent to install googletest 

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -30,7 +30,7 @@ platforms:
     image: slough-ops/macos-10.14-xcode
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_mac.sh
-    test_command: BuildScripts~/test _plugin_mac.sh
+    test_command: BuildScripts~/test_plugin_mac.sh
     plugin_path: Runtime/Plugins/x86_64/webrtc.bundle/**
   - name: ios
     type: Unity::metal::macmini

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -167,7 +167,7 @@ test_webrtc_plugin_{{ platform.name }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   commands:
-    - {{ platform.build_command }}
+    - {{ platform.test_command }}
 {% endfor %}
 
 test_webrtc_plugin_all_platform:

--- a/BuildScripts~/test_plugin_ios.sh
+++ b/BuildScripts~/test_plugin_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-mac.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 # Install cmake
@@ -49,8 +49,8 @@ cmake .                                        \
 #  -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.3'
 
 # Copy and run the test on the Metal device
-scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r "$SOLUTION_DIR/WebRTCPluginTest/Release" bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc
-ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '~/com.unity.webrtc/WebRTCPluginTest'
+#scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r "$SOLUTION_DIR/WebRTCPluginTest/Release" bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc
+#ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '~/com.unity.webrtc/WebRTCPluginTest'
 
 # Running test locally. Left as a reference
 # "$SOLUTION_DIR/WebRTCPluginTest/Release/WebRTCPluginTest"

--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -10,26 +10,18 @@ unzip -d $SOLUTION_DIR/webrtc webrtc.zip
 # Install libc++, libc++abi googletest clang glut
 # TODO:: Remove this install process from here and recreate an image to build the plugin.
 sudo apt update
-sudo apt install -y libc++-dev libc++abi-dev googletest clang freeglut3-dev
-
-# Install googletest
-cd /usr/src/googletest
-sudo cmake -Dcxx_no_rtti=ON \
-           -DCMAKE_C_COMPILER="clang" \
-           -DCMAKE_CXX_COMPILER="clang++" \
-           -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
-           CMakeLists.txt
-sudo make
-sudo cp googlemock/*.a "/usr/lib"
-sudo cp googlemock/gtest/*.a "/usr/lib"
+sudo apt install -y libc++-dev libc++abi-dev clang freeglut3-dev
 
 # Build UnityRenderStreaming Plugin 
 cd "$SOLUTION_DIR"
 cmake -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
       -DCMAKE_BUILD_TYPE="Debug" \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+      -Dcxx_no_rtti=ON \
+      -B "build" \
       .
-make
+cmake --build build --config Debug
 
 # Run UnitTest
-"$SOLUTION_DIR/WebRTCPluginTest/WebRTCPluginTest"
+"$SOLUTION_DIR/build/WebRTCPluginTest/WebRTCLibTest"

--- a/BuildScripts~/test_plugin_mac.sh
+++ b/BuildScripts~/test_plugin_mac.sh
@@ -8,17 +8,7 @@ brew install cmake
 
 # Download LibWebRTC 
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
-unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
-
-# Install googletest
-git clone https://github.com/google/googletest.git
-cd googletest
-git checkout 2fe3bd994b3189899d93f1d5a881e725e046fdc2
-mkdir debug
-cd debug
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-make
-sudo make install
+unzip -d $SOLUTION_DIR/webrtc webrtc.zip
 
 # Build UnityRenderStreaming Plugin 
 cd "$SOLUTION_DIR"
@@ -28,7 +18,7 @@ xcodebuild -scheme WebRTCLibTest -configuration Debug build
 
 # Copy and run the test on the Metal device
 scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r "$SOLUTION_DIR/WebRTCPluginTest/Release" bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc
-ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '~/com.unity.webrtc/WebRTCPluginTest'
+ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '~/com.unity.webrtc/WebRTCLibTest'
 
 # Running test locally. Left as a reference
-# "$SOLUTION_DIR/WebRTCPluginTest/Release/WebRTCPluginTest"
+# "$SOLUTION_DIR/WebRTCPluginTest/Release/WebRTCLibTest"

--- a/BuildScripts~/test_plugin_mac.sh
+++ b/BuildScripts~/test_plugin_mac.sh
@@ -17,7 +17,7 @@ xcodebuild -scheme WebRTCPlugin -configuration Debug build
 xcodebuild -scheme WebRTCLibTest -configuration Debug build
 
 # Copy and run the test on the Metal device
-scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r "$SOLUTION_DIR/WebRTCPluginTest/Release" bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc
+scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r "$SOLUTION_DIR/WebRTCPluginTest/Debug" bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc
 ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '~/com.unity.webrtc/WebRTCLibTest'
 
 # Running test locally. Left as a reference

--- a/BuildScripts~/test_plugin_win.cmd
+++ b/BuildScripts~/test_plugin_win.cmd
@@ -10,26 +10,6 @@ curl -L %LIBWEBRTC_DOWNLOAD_URL% > webrtc.zip
 7z x -aoa webrtc.zip -o%SOLUTION_DIR%\webrtc
 
 echo -------------------
-echo Install googletest
-
-cd %SOLUTION_DIR%
-git clone https://github.com/google/googletest.git
-cd googletest
-git checkout 2fe3bd994b3189899d93f1d5a881e725e046fdc2
-cmake . -G "Visual Studio 15 2017" -A x64 -B "build64" -DCMAKE_CXX_FLAGS_DEBUG="/MTd /Zi -D_ITERATOR_DEBUG_LEVEL=0"
-cmake --build build64 --config Release
-cmake --build build64 --config Debug
-mkdir include\gtest
-xcopy /e googletest\include\gtest include\gtest
-mkdir include\gmock
-xcopy /e googlemock\include\gmock include\gmock
-mkdir lib
-xcopy /e build64\googlemock\Release lib
-xcopy /e build64\googlemock\Debug lib
-xcopy /e build64\googlemock\gtest\Release lib
-xcopy /e build64\googlemock\gtest\Debug lib
-
-echo -------------------
 echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%

--- a/BuildScripts~/test_plugin_win.cmd
+++ b/BuildScripts~/test_plugin_win.cmd
@@ -33,12 +33,12 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
-cmake . -G "Visual Studio 15 2017" -A x64 -B "build64"
-cmake --build build64 --config Debug
+cmake . -G "Visual Studio 15 2017" -A x64 -B "build"
+cmake --build build --config Debug
 
 echo -------------------
-echo Test com.unity.webrtc Plugin 
+echo Test com.unity.webrtc Plugin
 
-%SOLUTION_DIR%\build64\WebRTCPluginTest\Release\WebRTCPluginTest.exe
+%SOLUTION_DIR%\build\WebRTCPluginTest\Debug\WebRTCLibTest.exe
 if not %errorlevel% == 0 exit 1
 echo -------------------

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -24,14 +24,38 @@ if(Windows OR Linux)
 endif()
 
 # specify gtest root directory
-if(Windows)
-  set(GTEST_ROOT "${CMAKE_SOURCE_DIR}/googletest")
-  set(GMOCK_ROOT "${CMAKE_SOURCE_DIR}/googletest")
+#if(Windows)
+#  set(GTEST_ROOT "${CMAKE_SOURCE_DIR}/googletest")
+#  set(GMOCK_ROOT "${CMAKE_SOURCE_DIR}/googletest")
+#endif()
+
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.10.0
+)
+
+FetchContent_GetProperties(googletest)
+if(NOT googletest_POPULATED)
+  FetchContent_Populate(googletest)
+  add_subdirectory(
+    ${googletest_SOURCE_DIR} 
+    ${googletest_BINARY_DIR}
+  )
 endif()
 
+include(GoogleTest)
+
 if(NOT iOS)
-  find_package(GTest)
-  find_package(GMock)
+  target_include_directories(WebRTCLibTest
+    PRIVATE
+      $<TARGET_PROPERTY:gtest,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+      $<TARGET_PROPERTY:gtest_main,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+      $<TARGET_PROPERTY:gmock,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+      $<TARGET_PROPERTY:gmock_main,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+  )
 else()
   set(GOOGLETEST_ROOT_DIR ${CMAKE_SOURCE_DIR}/googletest)
   set(GTEST_INCLUDE_DIRS
@@ -51,8 +75,6 @@ else()
   )
 endif()
 
-include(GoogleTest)
-
 if(Windows)
   # Use precompiled header
   set(CMAKE_CXX_FLAGS 
@@ -63,10 +85,10 @@ if(Windows)
       ${WEBRTC_LIBRARY}
       ${Vulkan_LIBRARY}
       ${CUDA_CUDA_LIBRARY}
-      ${GTEST_MAIN_LIBRARIES}
-      ${GTEST_LIBRARIES}
-      ${GMOCK_LIBRARIES}
       ${NVCODEC_LIBRARIES}
+      gtest
+      gmock
+      gtest_main
       d3d11
       d3d12
       dxgi
@@ -106,9 +128,9 @@ elseif(macOS)
       ${WEBRTC_LIBRARY}
       ${OPENGL_LIBRARIES}
       ${FRAMEWORK_LIBS}
-      ${GTEST_MAIN_LIBRARIES}
-      ${GTEST_LIBRARIES}
-      ${GMOCK_LIBRARIES}
+      gtest
+      gmock
+      gtest_main
       WebRTCLib
   )
   target_include_directories(WebRTCLibTest
@@ -127,11 +149,11 @@ elseif(Linux)
       ${OPENGL_opengl_LIBRARY}
       ${GLUT_LIBRARY}
       ${CMAKE_DL_LIBS}
-      ${GTEST_MAIN_LIBRARIES}
-      ${GTEST_LIBRARIES}
-      ${GMOCK_LIBRARIES}
       ${CMAKE_THREAD_LIBS_INIT}
       ${Vulkan_LIBRARY}
+      gtest
+      gmock
+      gtest_main
       WebRTCLib
   )
   target_include_directories(WebRTCLibTest
@@ -156,9 +178,9 @@ elseif(iOS)
       ${WEBRTC_LIBRARY}
       ${OPENGL_LIBRARIES}
       ${FRAMEWORK_LIBS}
-      ${GTEST_MAIN_LIBRARIES}
-      ${GTEST_LIBRARIES}
-      ${GMOCK_LIBRARIES}
+      gtest
+      gmock
+      gtest_main
       WebRTCLib
   )
   target_include_directories(WebRTCLibTest
@@ -177,5 +199,4 @@ target_include_directories(WebRTCLibTest
     ${CMAKE_SOURCE_DIR}/unity/include
     ${WEBRTC_INCLUDE_DIR}
     ${OPENGL_INCLUDE_DIR}
-    ${GTEST_INCLUDE_DIRS}
 )

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -23,12 +23,6 @@ if(Windows OR Linux)
   add_subdirectory(NvCodec)
 endif()
 
-# specify gtest root directory
-#if(Windows)
-#  set(GTEST_ROOT "${CMAKE_SOURCE_DIR}/googletest")
-#  set(GMOCK_ROOT "${CMAKE_SOURCE_DIR}/googletest")
-#endif()
-
 include(FetchContent)
 
 FetchContent_Declare(
@@ -40,6 +34,7 @@ FetchContent_Declare(
 FetchContent_GetProperties(googletest)
 if(NOT googletest_POPULATED)
   FetchContent_Populate(googletest)
+
   add_subdirectory(
     ${googletest_SOURCE_DIR} 
     ${googletest_BINARY_DIR}
@@ -55,6 +50,22 @@ if(NOT iOS)
       $<TARGET_PROPERTY:gtest_main,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
       $<TARGET_PROPERTY:gmock,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
       $<TARGET_PROPERTY:gmock_main,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+  )
+  set_target_properties(gtest
+    PROPERTIES
+      MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+  set_target_properties(gtest_main
+    PROPERTIES
+      MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+  set_target_properties(gmock
+    PROPERTIES
+      MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+  set_target_properties(gmock_main
+    PROPERTIES
+      MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
   )
 else()
   set(GOOGLETEST_ROOT_DIR ${CMAKE_SOURCE_DIR}/googletest)

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -89,7 +89,7 @@ TEST_P(ContextTest, CreateAndDeletePeerConnection) {
 TEST_P(ContextTest, CreateAndDeleteDataChannel) {
     const webrtc::PeerConnectionInterface::RTCConfiguration config;
     const auto connection = context->CreatePeerConnection(config);
-    RTCDataChannelInit init;
+    DataChannelInit init;
     init.protocol = "";
     const auto channel = context->CreateDataChannel(connection, "test", init);
     context->DeleteDataChannel(channel);


### PR DESCRIPTION
[FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module enables to install a third-party content in CMake. It makes it easier to set up modules like `googletest`.