### PR TITLE
test: Add LeakSanitizer on linux

### DIFF
--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -2,6 +2,8 @@
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
+export ASAN_OPTIONS=protect_shadow_gap=0:detect_leaks=1
+export LSAN_OPTIONS=suppressions=$(pwd)/Plugin~/tools/lsan/lsan_suppressions.txt
 
 # Download LibWebRTC 
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.h
@@ -70,11 +70,12 @@ namespace webrtc
         bool m_isNvEncoderSupported = false;
 
         virtual void* AllocateInputResourceV(ITexture2D* tex) = 0;
+        virtual void ReleaseInputResourceV(void* pResource) = 0;
 
-    private:
         void InitEncoderResources();
         void ReleaseEncoderResources();
 
+    private:
         void ReleaseFrameInputBuffer(Frame& frame);
         void ProcessEncodedFrame(Frame& frame, int64_t timestamp_us);
         NV_ENC_REGISTERED_PTR RegisterResource(NV_ENC_INPUT_RESOURCE_TYPE type, void *pBuffer);
@@ -85,6 +86,7 @@ namespace webrtc
         NVENCSTATUS errorCode;
         Frame bufferedFrames[bufferedFrameNum];
         ITexture2D* m_renderTextures[bufferedFrameNum];
+        std::vector<void*> m_buffers;
         uint64 frameCount = 0;
         void* pEncoderInterface = nullptr;
         bool isIdrFrame = false;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.cpp
@@ -6,7 +6,6 @@
 
 #include "GraphicsDevice/IGraphicsDevice.h"
 #include "GraphicsDevice/ITexture2D.h"
-#include "GraphicsDevice/Vulkan/VulkanGraphicsDevice.h"
 
 namespace unity
 {
@@ -27,6 +26,11 @@ namespace webrtc
         device,
         textureFormat)
     {
+    }
+
+    NvEncoderCuda::~NvEncoderCuda()
+    {
+        ReleaseEncoderResources();
     }
 
     void NvEncoderCuda::InitV()
@@ -55,6 +59,5 @@ namespace webrtc
     {
         return tex->GetEncodeTexturePtrV();
     }
-
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderCuda.h
@@ -11,9 +11,10 @@ namespace webrtc
     public:
         NvEncoderCuda(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
         void InitV() override;
-        virtual ~NvEncoderCuda() = default;
+        ~NvEncoderCuda() override;
     protected:
-        virtual void* AllocateInputResourceV(ITexture2D* tex) override;
+        void* AllocateInputResourceV(ITexture2D* tex) override;
+        void ReleaseInputResourceV(void* pResource) override {}
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.cpp
@@ -16,6 +16,7 @@ namespace webrtc
 
     NvEncoderD3D11::~NvEncoderD3D11()
     {
+        ReleaseEncoderResources();
     }
 
     void* NvEncoderD3D11::AllocateInputResourceV(ITexture2D* tex) {

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D11.h
@@ -10,10 +10,11 @@ namespace webrtc
     {
     public:
         NvEncoderD3D11(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFromat);
-        virtual ~NvEncoderD3D11();
+        ~NvEncoderD3D11() override;
     protected:
 
-        virtual void* AllocateInputResourceV(ITexture2D* tex) override;
+        void* AllocateInputResourceV(ITexture2D* tex) override;
+        void ReleaseInputResourceV(void* pResource) override {}
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.cpp
@@ -16,6 +16,7 @@ namespace webrtc
 
     NvEncoderD3D12::~NvEncoderD3D12()
     {
+        ReleaseEncoderResources();
     }
 
     void* NvEncoderD3D12::AllocateInputResourceV(ITexture2D* tex) {

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderD3D12.h
@@ -9,10 +9,12 @@ namespace webrtc
     class NvEncoderD3D12 : public NvEncoder {
     public:
         NvEncoderD3D12(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
-        virtual ~NvEncoderD3D12();
+        ~NvEncoderD3D12() override;
     protected:
 
-        virtual void* AllocateInputResourceV(ITexture2D* tex) override;
+        void* AllocateInputResourceV(ITexture2D* tex) override;
+        void ReleaseInputResourceV(void* pResource) override {}
+
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.cpp
@@ -16,6 +16,7 @@ namespace webrtc
 
     NvEncoderGL::~NvEncoderGL()
     {
+        ReleaseEncoderResources();
     }
 
     void* NvEncoderGL::AllocateInputResourceV(ITexture2D* tex) {
@@ -23,6 +24,13 @@ namespace webrtc
         pResource->texture = (GLuint)(size_t)(tex->GetEncodeTexturePtrV());
         pResource->target = GL_TEXTURE_2D;
         return pResource;
+    }
+
+    void NvEncoderGL::ReleaseInputResourceV(void* pResource)
+    {
+        NV_ENC_INPUT_RESOURCE_OPENGL_TEX* tex =
+            static_cast<NV_ENC_INPUT_RESOURCE_OPENGL_TEX*>(pResource);
+        delete tex;
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderGL.h
@@ -9,9 +9,10 @@ namespace webrtc
     class NvEncoderGL : public NvEncoder {
     public:
         NvEncoderGL(uint32_t nWidth, uint32_t nHeight, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat);
-        virtual ~NvEncoderGL();
+        ~NvEncoderGL() override;
     protected:
         virtual void* AllocateInputResourceV(ITexture2D* tex) override;
+        virtual void ReleaseInputResourceV(void* pResource) override;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -414,6 +414,26 @@ namespace webrtc
         m_mapSetSessionDescriptionObserver.erase(connection);
     }
 
+    PeerConnectionObject* Context::CreatePeerConnection(
+            const webrtc::PeerConnectionInterface::RTCConfiguration& config)
+    {
+        rtc::scoped_refptr<PeerConnectionObject> obj =
+                new rtc::RefCountedObject<PeerConnectionObject>(*this);
+        PeerConnectionDependencies dependencies(obj);
+        obj->connection = m_peerConnectionFactory->CreatePeerConnection(
+                config, std::move(dependencies));
+        if (obj->connection == nullptr)
+            return nullptr;
+        const PeerConnectionObject* ptr = obj.get();
+        m_mapClients[ptr] = std::move(obj);
+        return m_mapClients[ptr].get();
+    }
+
+    void Context::DeletePeerConnection(PeerConnectionObject *obj)
+    {
+        m_mapClients.erase(obj);
+    }
+
     SetSessionDescriptionObserver* Context::GetObserver(webrtc::PeerConnectionInterface* connection)
     {
         return m_mapSetSessionDescriptionObserver[connection];

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -79,10 +79,10 @@ namespace webrtc
 
         // PeerConnection
         PeerConnectionObject* CreatePeerConnection(const webrtc::PeerConnectionInterface::RTCConfiguration& config);
+        void DeletePeerConnection(PeerConnectionObject* obj);
         void AddObserver(const webrtc::PeerConnectionInterface* connection, const rtc::scoped_refptr<SetSessionDescriptionObserver>& observer);
         void RemoveObserver(const webrtc::PeerConnectionInterface* connection);
         SetSessionDescriptionObserver* GetObserver(webrtc::PeerConnectionInterface* connection);
-        void DeletePeerConnection(PeerConnectionObject* obj) { m_mapClients.erase(obj); }
 
         // StatsReport
         void AddStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -32,8 +32,8 @@ D3D12GraphicsDevice::D3D12GraphicsDevice(ID3D12Device* nativeDevice, ID3D12Comma
 
 
 //---------------------------------------------------------------------------------------------------------------------
-D3D12GraphicsDevice::~D3D12GraphicsDevice() {
-
+D3D12GraphicsDevice::~D3D12GraphicsDevice()
+{
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -80,8 +80,6 @@ bool D3D12GraphicsDevice::InitV() {
 //---------------------------------------------------------------------------------------------------------------------
 void D3D12GraphicsDevice::ShutdownV() {
     m_cudaContext.Shutdown();
-    m_commandList->Release();
-    m_commandAllocator->Release();
     SAFE_RELEASE(m_d3d11Device);
     SAFE_RELEASE(m_d3d11Context);
     SAFE_RELEASE(m_copyResourceFence);

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -29,23 +29,7 @@ namespace webrtc
         {
             connection->Close();
         }
-        connection.release();
-    }
-
-    PeerConnectionObject* Context::CreatePeerConnection(
-        const webrtc::PeerConnectionInterface::RTCConfiguration& config)
-    {
-        rtc::scoped_refptr<PeerConnectionObject> obj =
-            new rtc::RefCountedObject<PeerConnectionObject>(*this);
-        PeerConnectionDependencies dependencies(obj);
-        obj->connection = m_peerConnectionFactory->CreatePeerConnection(
-            config, std::move(dependencies));
-
-        if (obj->connection == nullptr)
-            return nullptr;
-        const PeerConnectionObject* ptr = obj.get();
-        m_mapClients[ptr] = std::move(obj);
-        return m_mapClients[ptr].get();
+        connection = nullptr;
     }
 
     void PeerConnectionObject::OnSuccess(webrtc::SessionDescriptionInterface* desc)

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -152,7 +152,24 @@ elseif(macOS)
 elseif(Linux)
   find_package(OpenGL REQUIRED)
   find_package(GLUT REQUIRED)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lto -fno-rtti -stdlib=libc++")
+
+  target_compile_options(WebRTCLibTest
+    PUBLIC
+      -fno-lto
+      -fno-rtti
+      -stdlib=libc++
+      $<$<CONFIG:Debug>:-fsanitize=address$<COMMA>undefined>
+  )
+
+  target_link_options(WebRTCLibTest
+    PUBLIC
+      $<$<CONFIG:Debug>:-fsanitize=address$<COMMA>undefined>
+  )
+
+  target_compile_definitions(WebRTCLibTest
+    PRIVATE
+      $<$<CONFIG:Debug>:LEAK_SANITIZER>
+  )
 
   target_link_libraries(WebRTCLibTest
     PRIVATE

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -14,10 +14,10 @@ namespace webrtc
 class ContextTest : public GraphicsDeviceTestBase
 {
 protected:
-    std::unique_ptr<IEncoder> encoder_;
     const int width = 256;
     const int height = 256;
     std::unique_ptr<Context> context;
+    std::unique_ptr<IEncoder> encoder_;
 
     void SetUp() override {
         GraphicsDeviceTestBase::SetUp();

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -277,6 +277,7 @@ void DestroyDeviceVulkan(void* pGfxDevice)
 {
     UnityVulkanInstance* pVkInstance = static_cast<UnityVulkanInstance*>(pGfxDevice);
     vkDestroyDevice(pVkInstance->device, nullptr);
+    delete pVkInstance;
     pVkInstance = nullptr;
 }
 
@@ -414,10 +415,25 @@ GraphicsDeviceTestBase::GraphicsDeviceTestBase()
     m_device->InitV();
 }
 
+void GraphicsDeviceTestBase::SetUp()
+{
+#if defined(LEAK_SANITIZER)
+    __lsan_disable();
+    __lsan_enable();
+#endif
+}
+
+void GraphicsDeviceTestBase::TearDown()
+{
+#if defined(LEAK_SANITIZER)
+    ASSERT_EQ(__lsan_do_recoverable_leak_check(),0);
+#endif
+}
 
 GraphicsDeviceTestBase::~GraphicsDeviceTestBase()
 {
     m_device->ShutdownV();
+    delete m_device;
     m_device = nullptr;
     DestroyGfxDevice(m_pNativeGfxDevice, m_unityGfxRenderer);
 }

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -17,6 +17,8 @@ class GraphicsDeviceTestBase
 public:
     GraphicsDeviceTestBase();
     virtual ~GraphicsDeviceTestBase();
+    void SetUp() override;
+    void TearDown() override;
 protected:
     void* m_pNativeGfxDevice;
     IGraphicsDevice* m_device;

--- a/Plugin~/WebRTCPluginTest/Sanitizer.cpp
+++ b/Plugin~/WebRTCPluginTest/Sanitizer.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+#include <sanitizer/asan_interface.h>
+
+extern "C"
+{
+
+void __ubsan_on_report()
+{
+    FAIL() << "Encountered an undefined behavior sanitizer error";
+}
+void __asan_on_error()
+{
+    FAIL() << "Encountered an address sanitizer error";
+}
+void __tsan_on_report()
+{
+    FAIL() << "Encountered a thread sanitizer error";
+}
+}  // extern "C"

--- a/Plugin~/WebRTCPluginTest/pch.h
+++ b/Plugin~/WebRTCPluginTest/pch.h
@@ -8,3 +8,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "../WebRTCPlugin/pch.h"
+
+#if defined(LEAK_SANITIZER)
+#include <sanitizer/lsan_interface.h>
+#endif

--- a/Plugin~/tools/lsan/lsan_suppressions.txt
+++ b/Plugin~/tools/lsan/lsan_suppressions.txt
@@ -1,0 +1,5 @@
+# ================ Leaks in third-party code ================
+
+# Leaks in Nvidia's library
+leak:libcuda.so
+leak:libnvidia-glcore.so


### PR DESCRIPTION
This pull request adds [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) to detect memory issues in native tests.

### Support platforms
Currently, AddressSanitizer works on only Linux. 
Visual Studio 2019 supports it experimentally, but it is not production-ready ([link](https://devblogs.microsoft.com/cppblog/asan-for-windows-x64-and-debug-build-support/)). 
Xcode(AppleClang) supports AddressSanitizer already, but LeakSanitizer is not supported yet.

If you want to debug the native code with a sanitizer on Clion, [this page](https://www.jetbrains.com/help/clion/google-sanitizers.html) is comfortable.

### Suppressions file for false positive

You need to set the parameters below to the environment variables before testing with AddressSanitizer.
NVIDIA libraries give a false positive so we need to list them on `suppressions.txt`. 
```
export ASAN_OPTIONS=protect_shadow_gap=0:detect_leaks=1
export LSAN_OPTIONS=suppressions=$(pwd)/Plugin~/tools/lsan/lsan_suppressions.txt
```