### PR TITLE
fix: Fixed crash bug when access instance after disposed of it

### DIFF
--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -134,7 +134,7 @@ namespace Unity.WebRTC
 
         public void DeleteMediaStream(MediaStream stream)
         {
-            NativeMethods.ContextDeleteMediaStream(self, stream.self);
+            NativeMethods.ContextDeleteMediaStream(self, stream.GetSelfOrThrow());
         }
 
         public void MediaStreamRegisterOnAddTrack(IntPtr stream, DelegateNativeMediaStreamOnAddTrack callback)

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace Unity.WebRTC
 {
     public class MediaStreamTrack : IDisposable
     {
-        internal IntPtr self;
+        protected IntPtr self;
         protected bool disposed;
         private bool enabled;
         private TrackState readyState;
@@ -18,41 +16,36 @@ namespace Unity.WebRTC
         {
             get
             {
-                return NativeMethods.MediaStreamTrackGetEnabled(self);
+                return NativeMethods.MediaStreamTrackGetEnabled(GetSelfOrThrow());
             }
             set
             {
-                NativeMethods.MediaStreamTrackSetEnabled(self, value);
+                NativeMethods.MediaStreamTrackSetEnabled(GetSelfOrThrow(), value);
             }
         }
 
         /// <summary>
         ///
         /// </summary>
-        public TrackState ReadyState
-        {
-            get
-            {
-                return NativeMethods.MediaStreamTrackGetReadyState(self);
-            }
-        }
+        public TrackState ReadyState =>
+            NativeMethods.MediaStreamTrackGetReadyState(GetSelfOrThrow());
 
         /// <summary>
         ///
         /// </summary>
-        public TrackKind Kind { get; }
+        public TrackKind Kind =>
+            NativeMethods.MediaStreamTrackGetKind(GetSelfOrThrow());
 
         /// <summary>
         ///
         /// </summary>
-        public string Id { get; }
+        public string Id =>
+            NativeMethods.MediaStreamTrackGetID(GetSelfOrThrow()).AsAnsiStringWithFreeMem();
 
         internal MediaStreamTrack(IntPtr ptr)
         {
             self = ptr;
             WebRTC.Table.Add(self, this);
-            Kind = NativeMethods.MediaStreamTrackGetKind(self);
-            Id = NativeMethods.MediaStreamTrackGetID(self).AsAnsiStringWithFreeMem();
         }
 
         ~MediaStreamTrack()
@@ -81,7 +74,7 @@ namespace Unity.WebRTC
         //Disassociate track from its source(video or audio), not for destroying the track
         public void Stop()
         {
-            WebRTC.Context.StopMediaStreamTrack(self);
+            WebRTC.Context.StopMediaStreamTrack(GetSelfOrThrow());
         }
 
         internal static MediaStreamTrack Create(IntPtr ptr)
@@ -92,6 +85,15 @@ namespace Unity.WebRTC
             }
 
             return new AudioStreamTrack(ptr);
+        }
+
+        internal IntPtr GetSelfOrThrow()
+        {
+            if (self == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("This instance has been disposed.");
+            }
+            return self;
         }
     }
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -25,8 +25,6 @@ namespace Unity.WebRTC
         private IntPtr self;
 
         internal Action<IntPtr> OnStatsDelivered = null;
-
-        private int m_id;
         private DelegateOnIceConnectionChange onIceConnectionChange;
         private DelegateOnIceGatheringStateChange onIceGatheringStateChange;
         private DelegateOnIceCandidate onIceCandidate;
@@ -493,7 +491,7 @@ namespace Unity.WebRTC
             }
 
             var streamId = stream == null ? Guid.NewGuid().ToString() : stream.Id;
-            return new RTCRtpSender(NativeMethods.PeerConnectionAddTrack(GetSelfOrThrow(), track.self, streamId), this);
+            return new RTCRtpSender(NativeMethods.PeerConnectionAddTrack(GetSelfOrThrow(), track.GetSelfOrThrow(), streamId), this);
         }
 
         /// <summary>
@@ -513,7 +511,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track)
         {
-            return new RTCRtpTransceiver(NativeMethods.PeerConnectionAddTransceiver(GetSelfOrThrow(), track.self), this);
+            return new RTCRtpTransceiver(NativeMethods.PeerConnectionAddTransceiver(GetSelfOrThrow(), track.GetSelfOrThrow()), this);
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -88,7 +88,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public bool ReplaceTrack(MediaStreamTrack track)
         {
-            return NativeMethods.SenderReplaceTrack(self, track.self);
+            return NativeMethods.SenderReplaceTrack(self, track.GetSelfOrThrow());
         }
     }
 }

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -51,7 +51,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                return WebRTC.Context.GetInitializationResult(self) == CodecInitializationResult.Success;
+                return WebRTC.Context.GetInitializationResult(GetSelfOrThrow()) == CodecInitializationResult.Success;
             }
         }
 
@@ -242,7 +242,7 @@ namespace Unity.WebRTC
         {
             self = ptr;
             this.track = track;
-            NativeMethods.VideoTrackAddOrUpdateSink(track.self, self);
+            NativeMethods.VideoTrackAddOrUpdateSink(track.GetSelfOrThrow(), self);
             WebRTC.Table.Add(self, this);
         }
 
@@ -260,9 +260,10 @@ namespace Unity.WebRTC
 
             if (self != IntPtr.Zero)
             {
-                if (track.self != IntPtr.Zero)
+                IntPtr trackPtr = track.GetSelfOrThrow();
+                if (trackPtr != IntPtr.Zero)
                 {
-                    NativeMethods.VideoTrackRemoveSink(track.self, self);
+                    NativeMethods.VideoTrackRemoveSink(trackPtr, self);
                 }
 
                 WebRTC.Context.DeleteVideoRenderer(self);

--- a/Runtime/Scripts/WebRTC.AsyncOperation.cs
+++ b/Runtime/Scripts/WebRTC.AsyncOperation.cs
@@ -36,7 +36,7 @@ namespace Unity.WebRTC
 
         internal RTCStatsReportAsyncOperation(RTCPeerConnection connection)
         {
-            NativeMethods.PeerConnectionGetStats(connection.self);
+            NativeMethods.PeerConnectionGetStats(connection.GetSelfOrThrow());
 
             connection.OnStatsDelivered = ptr =>
             {
@@ -48,7 +48,7 @@ namespace Unity.WebRTC
 
         internal RTCStatsReportAsyncOperation(RTCPeerConnection connection, RTCRtpSender sender)
         {
-            NativeMethods.PeerConnectionSenderGetStats(connection.self, sender.self);
+            NativeMethods.PeerConnectionSenderGetStats(connection.GetSelfOrThrow(), sender.self);
 
             connection.OnStatsDelivered = ptr =>
             {
@@ -59,7 +59,7 @@ namespace Unity.WebRTC
         }
         internal RTCStatsReportAsyncOperation(RTCPeerConnection connection, RTCRtpReceiver receiver)
         {
-            NativeMethods.PeerConnectionReceiverGetStats(connection.self, receiver.self);
+            NativeMethods.PeerConnectionReceiverGetStats(connection.GetSelfOrThrow(), receiver.self);
 
             connection.OnStatsDelivered = ptr =>
             {

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -1,8 +1,10 @@
+using System;
 using UnityEngine;
 using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Linq;
 using System.Collections;
+using Object = UnityEngine.Object;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -22,11 +24,20 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDeleteMediaStream()
+        public void Construct()
         {
             var stream = new MediaStream();
             Assert.That(stream, Is.Not.Null);
             stream.Dispose();
+        }
+
+        [Test]
+        [Category("MediaStream")]
+        public void AccessAfterDisposed()
+        {
+            var stream = new MediaStream();
+            stream.Dispose();
+            Assert.That(() => { var id = stream.Id; }, Throws.TypeOf<InvalidOperationException>());
         }
 
         [Test]

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -24,6 +24,35 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void Construct()
+        {
+            var width = 256;
+            var height = 256;
+            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var rt = new RenderTexture(width, height, 0, format);
+            rt.Create();
+            var track = new VideoStreamTrack("video", rt);
+            Assert.That(track, Is.Not.Null);
+            track.Dispose();
+            Object.DestroyImmediate(rt);
+        }
+
+        [Test]
+        public void AccessAfterDisposed()
+        {
+            var width = 256;
+            var height = 256;
+            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var rt = new RenderTexture(width, height, 0, format);
+            rt.Create();
+            var track = new VideoStreamTrack("video", rt);
+            Assert.That(track, Is.Not.Null);
+            track.Dispose();
+            Assert.That(() => { var id = track.Id; }, Throws.TypeOf<InvalidOperationException>());
+            Object.DestroyImmediate(rt);
+        }
+
+        [Test]
         public void ConstructorThrowsException()
         {
             var width = 256;
@@ -31,10 +60,8 @@ namespace Unity.WebRTC.RuntimeTest
             var format = RenderTextureFormat.R8;
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
-            Assert.Throws<ArgumentException>(() =>
-            {
-                var track = new VideoStreamTrack("video", rt);
-            });
+
+            Assert.That(() => { new VideoStreamTrack("video", rt); }, Throws.TypeOf<ArgumentException>());
             Object.DestroyImmediate(rt);
         }
 

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -67,7 +67,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var peer = new RTCPeerConnection();
             peer.Dispose();
-            Assert.Throws<InvalidOperationException>(() => {  var state = peer.ConnectionState; });
+            Assert.That(() => {  var state = peer.ConnectionState; }, Throws.TypeOf<InvalidOperationException>());
         }
 
         [Test]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -63,6 +63,15 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("PeerConnection")]
+        public void AccessAfterDisposed()
+        {
+            var peer = new RTCPeerConnection();
+            peer.Dispose();
+            Assert.Throws<InvalidOperationException>(() => {  var state = peer.ConnectionState; });
+        }
+
+        [Test]
+        [Category("PeerConnection")]
         public void GetConfiguration()
         {
             var config = GetDefaultConfiguration();


### PR DESCRIPTION
In the past, the disposable object like `RTCPeerConnection` crashes when access properties after disposed of it.

Example
```csharp
var connection = new RTCPeerConnection();
connection.Dispose();
Debug.Log(connection.ConnectionState); // crash!!!
```

This behavior is uncomfortable for developers and it becomes difficult to resolve the bug.
This change fixes it in order to throw an exception when access properties after instances are disposed of.