### PR TITLE
fix: The comparing result of RTCRtpSender is wrong

### DIFF
--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -56,7 +56,7 @@ namespace Unity.WebRTC
                     if (value == null)
                         continue;
                     var disposable = value as IDisposable;
-                    disposable.Dispose();
+                    disposable?.Dispose();
                 }
                 table.Clear();
 

--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -11,7 +11,13 @@ namespace Unity.WebRTC
         internal RTCRtpReceiver(IntPtr ptr, RTCPeerConnection peer)
         {
             self = ptr;
+            WebRTC.Table.Add(self, this);
             this.peer = peer;
+        }
+
+        ~RTCRtpReceiver()
+        {
+            WebRTC.Table.Remove(self);
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -3,10 +3,14 @@ using System.Runtime.InteropServices;
 
 namespace Unity.WebRTC
 {
-    public class RTCRtpReceiver
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RTCRtpReceiver : IDisposable
     {
         internal IntPtr self;
         private RTCPeerConnection peer;
+        private bool disposed;
 
         internal RTCRtpReceiver(IntPtr ptr, RTCPeerConnection peer)
         {
@@ -17,7 +21,22 @@ namespace Unity.WebRTC
 
         ~RTCRtpReceiver()
         {
-            WebRTC.Table.Remove(self);
+            this.Dispose();
+        }
+
+        public virtual void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+            if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
+            {
+                WebRTC.Table.Remove(self);
+                self = IntPtr.Zero;
+            }
+            this.disposed = true;
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -14,7 +14,13 @@ namespace Unity.WebRTC
         internal RTCRtpSender(IntPtr ptr, RTCPeerConnection peer)
         {
             self = ptr;
+            WebRTC.Table.Add(self, this);
             this.peer = peer;
+        }
+
+        ~RTCRtpSender()
+        {
+            WebRTC.Table.Remove(self);
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -6,10 +6,12 @@ namespace Unity.WebRTC
     /// <summary>
     /// 
     /// </summary>
-    public class RTCRtpSender
+    public class RTCRtpSender : IDisposable
     {
         internal IntPtr self;
         private RTCPeerConnection peer;
+        private bool disposed;
+
 
         internal RTCRtpSender(IntPtr ptr, RTCPeerConnection peer)
         {
@@ -20,7 +22,22 @@ namespace Unity.WebRTC
 
         ~RTCRtpSender()
         {
-            WebRTC.Table.Remove(self);
+            this.Dispose();
+        }
+
+        public virtual void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+            if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
+            {
+                WebRTC.Table.Remove(self);
+                self = IntPtr.Zero;
+            }
+            this.disposed = true;
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -48,7 +48,11 @@ namespace Unity.WebRTC
         /// </summary>
         public RTCRtpReceiver Receiver
         {
-            get { return new RTCRtpReceiver(NativeMethods.TransceiverGetReceiver(self), peer); }
+            get
+            {
+                IntPtr receiverPtr = NativeMethods.TransceiverGetReceiver(self);
+                return WebRTC.FindOrCreate(receiverPtr, ptr => new RTCRtpReceiver(ptr, peer));
+            }
         }
 
         /// <summary>
@@ -56,7 +60,11 @@ namespace Unity.WebRTC
         /// </summary>
         public RTCRtpSender Sender
         {
-            get { return new RTCRtpSender(NativeMethods.TransceiverGetSender(self), peer); }
+            get
+            {
+                IntPtr senderPtr = NativeMethods.TransceiverGetSender(self);
+                return WebRTC.FindOrCreate(senderPtr, ptr => new RTCRtpSender(ptr, peer));
+            }
         }
 
         public RTCErrorType SetCodecPreferences(RTCRtpCodecCapability[] codecs)

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -218,6 +218,22 @@ namespace Unity.WebRTC.RuntimeTest
             peer.Dispose();
         }
 
+        [Test]
+        [Category("PeerConnection")]
+        public void GetTransceivers()
+        {
+            var peer = new RTCPeerConnection();
+            var track = new AudioStreamTrack("audio");
+
+            var sender = peer.AddTrack(track);
+            Assert.That(peer.GetTransceivers().ToList(), Has.Count.EqualTo(1));
+            Assert.That(peer.GetTransceivers().Select(t => t.Sender).ToList(), Has.Member(sender));
+
+            track.Dispose();
+            peer.Close();
+            peer.Dispose();
+        }
+
         [UnityTest]
         [Timeout(1000)]
         [Category("PeerConnection")]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -230,7 +230,6 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(peer.GetTransceivers().Select(t => t.Sender).ToList(), Has.Member(sender));
 
             track.Dispose();
-            peer.Close();
             peer.Dispose();
         }
 


### PR DESCRIPTION
The comparing result of `RTCRtpSender` is weird like this.
```csharp
var peer = new RTCPeerConnection();
var track = new AudioStreamTrack("audio");
var sender = peer.AddTrack(track);
var transceiver = peer.GetTransceivers().First();
Debug.Log(sender == transceiver.Sender);           // false
```

Two instances of `RTCRtpSender` are the same but the result is false.
The reason is creating a new instance when calling the `RTCRtpTransceiver.Sender` property.