### PR TITLE
chore: Update CHANGELOG to release a bug fix version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,35 @@ All notable changes to the webrtc package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2021-02-12
+
+### Changed
+
+- Changed `Audio.CaptureStream` method to allow setting of audio track label.
+
+### Fixed
+
+- Fixed memory leaks in native code.
+- Fixed a crash bug when access an instance after disposed of it.
+- Fixed `MediaStream.GetVideoStreamTrack` method and `MediaStream.GetVideoStreamTrack` method to return a correct value.
+- Fixed `RTCRtpTransceiver.Receiver` property and `RTCRtpTransceiver.Sender` property to return a correct value.
+
 ## [2.3.1] - 2021-01-07
 
 ### Fixed
 
-- Fixed `RTCIceCandidate.candidate` property in order to return a correct SDP formatted string
+- Fixed `RTCIceCandidate.candidate` property in order to return a correct SDP formatted string.
 
 ## [2.3.0] - 2020-12-28
 
 ### Added 
 
-- iOS platform support
-- H.264 HW decoder (VideoToolbox) support on macOS
+- Supported iOS platform
+- Supported H.264 HW decoder (VideoToolbox) on macOS
 - Added `GetCapabilities` method to the `RTCRtpSender` class and the `RTCRtpReceiver` class
-- Added `SetCodecPreferences` method to the `RTCRtpTransceiver` class.
+- Added `SetCodecPreferences` method to the `RTCRtpTransceiver` class
 - Added two samples (`ChangeCodecs`, `TrickleIce`)
-- Added properties to the `RTCIceCandidate` class 
+- Added properties to the `RTCIceCandidate` class
 - Added properties tp the `RTCDataChannelInit` class
 
 ### Changed
@@ -47,7 +60,7 @@ public RTCDataChannel CreateDataChannel(string label RTCDataChannelInit options 
 
 ### Added
 
-- Added a `Bandwidth` sample 
+- Added a `Bandwidth` sample
 
 ### Fixed
 

--- a/Documentation~/install.md
+++ b/Documentation~/install.md
@@ -32,7 +32,7 @@ Check Package Manager window, Click `+` button and select `Add package from git 
 Input the string below to the input field.
 
 ```
-com.unity.webrtc@2.3.1-preview
+com.unity.webrtc@2.3.2-preview
 ```
 
 The list of version string is [here](https://github.com/Unity-Technologies/com.unity.webrtc/tags). In most cases, the latest version is recommended to use.

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
 endif()
 
 project(webrtc
-  VERSION 2.3.1
+  VERSION 2.3.2
   LANGUAGES C CXX ASM
 )
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ If you are interested in the streaming solution with WebRTC, you can check [Unit
 
 ## Documentation
 
-- [English](https://docs.unity3d.com/Packages/com.unity.webrtc@2.3/manual/index.html)
-- [Japanese](https://docs.unity3d.com/Packages/com.unity.webrtc@2.3/manual/jp/index.html)
+- [English](https://docs.unity3d.com/Packages/com.unity.webrtc@latest/index.html)
+- [Japanese](https://docs.unity3d.com/ja/Packages/com.unity.webrtc@latest/index.html
+)
 
 ### Guide
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ If you are interested in the streaming solution with WebRTC, you can check [Unit
 
 ## Documentation
 
-- [English](https://docs.unity3d.com/Packages/com.unity.webrtc@2.1/manual/index.html)
-- [Japanese](https://docs.unity3d.com/Packages/com.unity.webrtc@2.1/manual/jp/index.html)
+- [English](https://docs.unity3d.com/Packages/com.unity.webrtc@2.3/manual/index.html)
+- [Japanese](https://docs.unity3d.com/Packages/com.unity.webrtc@2.3/manual/jp/index.html)
 
 ### Guide
 
@@ -85,7 +85,7 @@ This package uses GPU hardware acceleration for video encoding, so it only runs 
 | `2.1`   | [M84](https://groups.google.com/g/discuss-webrtc/c/MRAV4jgHYV0/m/A5X253_ZAQAJ) | - Profiler tool <br>- Bitrate control                                                          | Aug 2020 |
 | `2.2`   | [M85](https://groups.google.com/g/discuss-webrtc/c/Qq3nsR2w2HU/m/7WGLPscPBwAJ) | - Video decoder (VP8, VP9 only) <br>- Vulkan HW encoder support <br>- MacOS HW encoder support | Oct 2020 |
 | `2.3`   | [M85](https://groups.google.com/g/discuss-webrtc/c/Qq3nsR2w2HU/m/7WGLPscPBwAJ) | - iOS platform suppport                                                                        | Dec 2020 |
-| `2.4`   | [M88](https://groups.google.com/g/discuss-webrtc/c/A0FjOcTW2c0/m/UAv-veyPCAAJ) | - Android platform suppport                                                                        | Feb 2021 |
+| `2.4`   | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | - Android platform suppport<br> - Audio renderer support                                                                        | Mar 2021 |
 
 ## Licenses
 

--- a/WebRTC~/Packages/manifest.json
+++ b/WebRTC~/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
-    "com.unity.ext.nunit": "1.0.5",
+    "com.unity.ext.nunit": "1.0.6",
     "com.unity.ide.rider": "2.0.7",
-    "com.unity.ide.visualstudio": "2.0.2",
+    "com.unity.ide.visualstudio": "2.0.5",
     "com.unity.ide.vscode": "1.2.3",
-    "com.unity.test-framework": "1.1.19",
+    "com.unity.test-framework": "1.1.20",
     "com.unity.testtools.codecoverage": "0.3.0-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/WebRTC~/Packages/manifest.json
+++ b/WebRTC~/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.ide.visualstudio": "2.0.5",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.test-framework": "1.1.20",
-    "com.unity.testtools.codecoverage": "0.3.0-preview",
+    "com.unity.testtools.codecoverage": "0.4.2-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/WebRTC~/Packages/packages-lock.json
+++ b/WebRTC~/Packages/packages-lock.json
@@ -56,7 +56,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "0.3.0-preview",
+      "version": "0.4.2-preview",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/WebRTC~/Packages/packages-lock.json
+++ b/WebRTC~/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -24,7 +24,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.2",
+      "version": "2.0.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -45,11 +45,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/WebRTC~/ProjectSettings/ProjectVersion.txt
+++ b/WebRTC~/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.4.16f1
-m_EditorVersionWithRevision: 2019.4.16f1 (e05b6e02d63e)
+m_EditorVersion: 2019.4.19f1
+m_EditorVersionWithRevision: 2019.4.19f1 (ca5b14067cec)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "2.3.1-preview",
+  "version": "2.3.2-preview",
   "unity": "2019.4",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [


### PR DESCRIPTION
- Update README
- Add changes of the version `2.3.2` to CHANGELOG
- Upgrade Unity editor version `2019.4.19.f1`