### PR TITLE
feat: Add OnConnectionStateChange event on RTCPeerConnection

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -99,6 +99,15 @@ namespace webrtc
             onIceConnectionChange(this, new_state);
         }
     }
+
+    void PeerConnectionObject::OnConnectionChange(PeerConnectionInterface::PeerConnectionState new_state)
+    {
+        if(onConnectionStateChange != nullptr)
+        {
+            onConnectionStateChange(this, new_state);
+        }
+    }
+
     // Called any time the IceGatheringState changes.
     void PeerConnectionObject::OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState new_state)
     {

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -16,6 +16,7 @@ namespace webrtc
     using DelegateIceCandidate = void(*)(PeerConnectionObject*, const char*, const char*, const int);
     using DelegateOnIceConnectionChange = void(*)(PeerConnectionObject*, webrtc::PeerConnectionInterface::IceConnectionState);
     using DelegateOnIceGatheringChange = void(*)(PeerConnectionObject*, webrtc::PeerConnectionInterface::IceGatheringState);
+    using DelegateOnConnectionStateChange = void(*)(PeerConnectionObject*, webrtc::PeerConnectionInterface::PeerConnectionState);
     using DelegateOnDataChannel = void(*)(PeerConnectionObject*, DataChannelObject*);
     using DelegateOnRenegotiationNeeded = void(*)(PeerConnectionObject*);
     using DelegateOnTrack = void(*)(PeerConnectionObject*, webrtc::RtpTransceiverInterface*);
@@ -49,7 +50,8 @@ namespace webrtc
 
         void RegisterLocalSdpReady(DelegateLocalSdpReady callback) { onLocalSdpReady = callback; }
         void RegisterIceCandidate(DelegateIceCandidate callback) { onIceCandidate = callback; }
-        void RegisterIceConnectionChange(DelegateOnIceConnectionChange callback) { onIceConnectionChange = callback; };
+        void RegisterIceConnectionChange(DelegateOnIceConnectionChange callback) { onIceConnectionChange = callback; }
+        void RegisterConnectionStateChange(DelegateOnConnectionStateChange callback) { onConnectionStateChange = callback; }
         void RegisterIceGatheringChange(DelegateOnIceGatheringChange callback) { onIceGatheringChange = callback; }
         void RegisterOnDataChannel(DelegateOnDataChannel callback) { onDataChannel = callback; }
         void RegisterOnRenegotiationNeeded(DelegateOnRenegotiationNeeded callback) { onRenegotiationNeeded = callback; }
@@ -74,11 +76,17 @@ namespace webrtc
         // has begun.
         void OnRenegotiationNeeded() override;
         // Called any time the IceConnectionState changes.
-        void OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState new_state) override;
+        void OnIceConnectionChange(
+            PeerConnectionInterface::IceConnectionState new_state) override;
+        // Called any time the PeerConnectionState changes.
+        virtual void OnConnectionChange(
+            PeerConnectionInterface::PeerConnectionState new_state) override;
         // Called any time the IceGatheringState changes.
-        void OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState new_state) override;
+        void OnIceGatheringChange(
+            PeerConnectionInterface::IceGatheringState new_state) override;
         // A new ICE candidate has been gathered.
-        void OnIceCandidate(const webrtc::IceCandidateInterface* candidate) override;
+        void OnIceCandidate(
+            const IceCandidateInterface* candidate) override;
         // Ice candidates have been removed.
         void OnIceCandidatesRemoved(const std::vector<cricket::Candidate>& candidates) override {}
         // Called when the ICE connection receiving status changes.
@@ -100,6 +108,7 @@ namespace webrtc
         DelegateCreateSDFailure onCreateSDFailure = nullptr;
         DelegateIceCandidate onIceCandidate = nullptr;
         DelegateLocalSdpReady onLocalSdpReady = nullptr;
+        DelegateOnConnectionStateChange onConnectionStateChange = nullptr;
         DelegateOnIceConnectionChange onIceConnectionChange = nullptr;
         DelegateOnIceGatheringChange onIceGatheringChange = nullptr;
         DelegateOnDataChannel onDataChannel = nullptr;

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -789,6 +789,12 @@ extern "C"
     {
         obj->RegisterIceGatheringChange(callback);
     }
+
+    UNITY_INTERFACE_EXPORT void PeerConnectionRegisterConnectionStateChange(PeerConnectionObject* obj, DelegateOnConnectionStateChange callback)
+    {
+        obj->RegisterConnectionStateChange(callback);
+    }
+
     
     UNITY_INTERFACE_EXPORT void PeerConnectionRegisterOnIceCandidate(PeerConnectionObject*obj, DelegateIceCandidate callback)
     {

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -543,6 +543,8 @@ namespace Unity.WebRTC
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnIceConnectionChange(IntPtr ptr, RTCIceConnectionState state);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void DelegateNativeOnConnectionStateChange(IntPtr ptr, RTCPeerConnectionState state);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnIceGatheringChange(IntPtr ptr, RTCIceGatheringState state);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnIceCandidate(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr)] string candidate, [MarshalAs(UnmanagedType.LPStr)] string sdpMid, int sdpMlineIndex);
@@ -621,6 +623,8 @@ namespace Unity.WebRTC
         public static extern void PeerConnectionRegisterOnSetSessionDescFailure(IntPtr context, IntPtr connection, DelegateNativePeerConnectionSetSessionDescFailure onFailure);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterIceConnectionChange(IntPtr ptr, DelegateNativeOnIceConnectionChange callback);
+        [DllImport(WebRTC.Lib)]
+        public static extern void PeerConnectionRegisterConnectionStateChange(IntPtr ptr, DelegateNativeOnConnectionStateChange callback);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterIceGatheringChange(IntPtr ptr, DelegateNativeOnIceGatheringChange callback);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -621,8 +621,9 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(op7.IsCompleted, Is.True);
 
             var op8 = new WaitUntilWithTimeout(() =>
-                iceState1 == RTCIceConnectionState.Connected &&
-                iceState2 == RTCIceConnectionState.Connected, 5000);
+                (iceState1 == RTCIceConnectionState.Connected || iceState1 == RTCIceConnectionState.Completed) &&
+                (iceState2 == RTCIceConnectionState.Connected || iceState2 == RTCIceConnectionState.Completed)
+                , 5000);
             yield return op8;
             Assert.That(op8.IsCompleted, Is.True);
 


### PR DESCRIPTION
`RTCPeerConnection.OnConnectionStateChange` event notifies when changed state of `RTCPeerConnectionState`.

Should rebase on this PR https://github.com/Unity-Technologies/com.unity.webrtc/pull/319