### PR TITLE
chore: Fixed build error of native plugin on Linux

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -65,7 +65,7 @@ test_targets:
         platform: standalone
   - name: linux
     type: Unity::VM
-    image: renderstreaming/ubuntu-18.04:latest
+    image: renderstreaming/ubuntu-18.04:v0.2.13-668913
     flavor: b1.large
     is_gpu: false
     gfx_types:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -12,6 +12,7 @@ platforms:
     type: Unity::VM
     gpu_type: Unity::VM::GPU
     image: renderstreaming/win10:latest
+    gpu_image: renderstreaming/win10:latest
     flavor: b1.large
     build_command: BuildScripts~/build_plugin_win.cmd
     test_command: BuildScripts~/test_plugin_win.cmd
@@ -19,7 +20,8 @@ platforms:
   - name: linux
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/ubuntu-18.04:latest
+    image: renderstreaming/ubuntu-18.04:v0.2.13-668913
+    gpu_image: renderstreaming/ubuntu-18.04:latest
     flavor: b1.large
     build_command: BuildScripts~/build_plugin_linux.sh
     test_command: BuildScripts~/test_plugin_linux.sh
@@ -28,6 +30,7 @@ platforms:
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
     image: slough-ops/macos-10.14-xcode
+    gpu_image: slough-ops/macos-10.14-xcode
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_mac.sh
     test_command: BuildScripts~/test_plugin_mac.sh
@@ -36,6 +39,7 @@ platforms:
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
     image: slough-ops/macos-10.14-xcode
+    gpu_image: slough-ops/macos-10.14-xcode
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_ios.sh
     test_command: BuildScripts~/test_plugin_ios.sh
@@ -164,7 +168,7 @@ test_webrtc_plugin_{{ platform.name }}:
   name: Test webrtc plugin {{ platform.name }}
   agent:
     type: {{ platform.gpu_type }}
-    image: {{ platform.image }}
+    image: {{ platform.gpu_image }}
     flavor: {{ platform.flavor }}
   commands:
     - {{ platform.test_command }}

--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 if [ ! -e "$(pwd)/depot_tools" ]
 then

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 if [ ! -e "$(pwd)/depot_tools" ]
 then

--- a/BuildScripts~/build_libwebrtc_linux.sh
+++ b/BuildScripts~/build_libwebrtc_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 if [ ! -e "$(pwd)/depot_tools" ]
 then

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 if [ ! -e "$(pwd)/depot_tools" ]
 then

--- a/BuildScripts~/build_plugin_ios.sh
+++ b/BuildScripts~/build_plugin_ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~

--- a/BuildScripts~/build_plugin_mac.sh
+++ b/BuildScripts~/build_plugin_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-mac.zip
 export SOLUTION_DIR=$(pwd)/Plugin~

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 #
 # BOKKEN_DEVICE_IP: 

--- a/BuildScripts~/test_plugin_ios.sh
+++ b/BuildScripts~/test_plugin_ios.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~

--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~

--- a/BuildScripts~/test_plugin_mac.sh
+++ b/BuildScripts~/test_plugin_mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M85/webrtc-mac.zip
 export SOLUTION_DIR=$(pwd)/Plugin~


### PR DESCRIPTION
- Changed the bokken image version to build a native plugin on linux
- Added `-eu` option to exit immediately if a command exits with a non-zero status.