### PR TITLE
Fix: crash when exit Play mode

### DIFF
--- a/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
+++ b/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
@@ -217,6 +217,11 @@ class MultiVideoReceiveSample : MonoBehaviour
     {
         foreach (var stream in receiveStreamList)
         {
+            foreach (var track in stream.GetVideoTracks())
+            {
+                stream.RemoveTrack(track);
+                track.Dispose();
+            }
             stream.Dispose();
         }
         receiveStreamList.Clear();

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -129,6 +129,23 @@ class MultiplePeerConnectionsSample : MonoBehaviour
     {
         StopCoroutine(updateCoroutine);
         updateCoroutine = null;
+
+        foreach (var track in sourceVideoStream.GetTracks())
+        {
+            sourceVideoStream.RemoveTrack(track);
+            track.Dispose();
+        }
+        foreach (var track in receiveVideoStream1.GetTracks())
+        {
+            receiveVideoStream1.RemoveTrack(track);
+            track.Dispose();
+        }
+        foreach (var track in receiveVideoStream2.GetTracks())
+        {
+            receiveVideoStream2.RemoveTrack(track);
+            track.Dispose();
+        }
+
         sourceVideoStream.Dispose();
         sourceVideoStream = null;
         sourceImage.texture = null;

--- a/Samples~/MungeSDP/MungeSDPSample.cs
+++ b/Samples~/MungeSDP/MungeSDPSample.cs
@@ -208,6 +208,18 @@ class MungeSDPSample : MonoBehaviour
     {
         StopCoroutine(updateCoroutine);
         updateCoroutine = null;
+
+        foreach (var track in sourceVideoStream.GetTracks())
+        {
+            sourceVideoStream.RemoveTrack(track);
+            track.Dispose();
+        }
+        foreach (var track in receiveVideoStream.GetTracks())
+        {
+            receiveVideoStream.RemoveTrack(track);
+            track.Dispose();
+        }
+
         sourceVideoStream.Dispose();
         sourceVideoStream = null;
         sourceImage.texture = null;

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -159,6 +159,12 @@ class VideoReceiveSample : MonoBehaviour
             _pc1.RemoveTrack(sender);
         }
 
+        foreach (var track in receiveStream.GetTracks())
+        {
+            receiveStream.RemoveTrack(track);
+            track.Dispose();
+        }
+
         pc1Senders.Clear();
         addTracksButton.interactable = true;
         removeTracksButton.interactable = false;
@@ -199,6 +205,8 @@ class VideoReceiveSample : MonoBehaviour
 
     private void HangUp()
     {
+        RemoveTracks();
+
         videoStream.Dispose();
         receiveStream.Dispose();
         videoStream = null;


### PR DESCRIPTION
Some sample occurs crash when exit Play mode after press `HangUp`.
It caused by `VideoTrack` does not dispose。