### PR TITLE
fix: Fixed key duplication error when calling `RTCPeerConnection.AddTrack`

### DIFF
--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -509,7 +509,9 @@ namespace Unity.WebRTC
             }
 
             var streamId = stream == null ? Guid.NewGuid().ToString() : stream.Id;
-            return new RTCRtpSender(NativeMethods.PeerConnectionAddTrack(GetSelfOrThrow(), track.GetSelfOrThrow(), streamId), this);
+            IntPtr ptr = NativeMethods.PeerConnectionAddTrack(
+                GetSelfOrThrow(), track.GetSelfOrThrow(), streamId);
+            return CreateSender(ptr);
         }
 
         /// <summary>
@@ -519,7 +521,8 @@ namespace Unity.WebRTC
         /// <seealso cref="AddTrack"/>
         public void RemoveTrack(RTCRtpSender sender)
         {
-            NativeMethods.PeerConnectionRemoveTrack(GetSelfOrThrow(), sender.self);
+            NativeMethods.PeerConnectionRemoveTrack(
+                GetSelfOrThrow(), sender.self);
         }
 
         /// <summary>
@@ -529,7 +532,9 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track)
         {
-            return new RTCRtpTransceiver(NativeMethods.PeerConnectionAddTransceiver(GetSelfOrThrow(), track.GetSelfOrThrow()), this);
+            IntPtr ptr = NativeMethods.PeerConnectionAddTransceiver(
+                GetSelfOrThrow(), track.GetSelfOrThrow());
+            return CreateTransceiver(ptr);
         }
 
         /// <summary>
@@ -539,7 +544,9 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(TrackKind kind)
         {
-            return new RTCRtpTransceiver(NativeMethods.PeerConnectionAddTransceiverWithType(GetSelfOrThrow(), kind), this);
+            IntPtr ptr = NativeMethods.PeerConnectionAddTransceiverWithType(
+                GetSelfOrThrow(), kind);
+            return CreateTransceiver(ptr);
         }
 
         /// <summary>
@@ -548,7 +555,8 @@ namespace Unity.WebRTC
         /// <param name="candidate"></param>
         public bool AddIceCandidate(RTCIceCandidate candidate)
         {
-            return NativeMethods.PeerConnectionAddIceCandidate(GetSelfOrThrow(), candidate.self);
+            return NativeMethods.PeerConnectionAddIceCandidate(
+                GetSelfOrThrow(), candidate.self);
         }
 
         /// <summary>

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -624,6 +624,61 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        public IEnumerator TransceiverReturnsSender()
+        {
+            RTCConfiguration config = default;
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
+
+            MediaStream stream1 = Audio.CaptureStream();
+            peer1.AddTrack(stream1.GetTracks().First());
+
+            RTCOfferOptions options1 = default;
+            RTCAnswerOptions options2 = default;
+            var op1 = peer1.CreateOffer(ref options1);
+            yield return op1;
+            var desc = op1.Desc;
+            var op2 = peer1.SetLocalDescription(ref desc);
+            yield return op2;
+            var op3 = peer2.SetRemoteDescription(ref desc);
+            yield return op3;
+            var op4 = peer2.CreateAnswer(ref options2);
+            yield return op4;
+            desc = op4.Desc;
+            var op5 = peer2.SetLocalDescription(ref desc);
+            yield return op5;
+            var op6 = peer1.SetRemoteDescription(ref desc);
+            yield return op6;
+
+            var op7 = new WaitUntilWithTimeout(
+                () => peer1.IceConnectionState == RTCIceConnectionState.Connected ||
+                      peer1.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op7;
+            Assert.True(op7.IsCompleted);
+            var op8 = new WaitUntilWithTimeout(
+                () => peer2.IceConnectionState == RTCIceConnectionState.Connected ||
+                      peer2.IceConnectionState == RTCIceConnectionState.Completed, 5000);
+            yield return op8;
+
+            Assert.That(peer2.GetTransceivers().Count(), Is.EqualTo(1));
+            RTCRtpSender sender1 = peer2.GetTransceivers().First().Sender;
+            Assert.That(sender1, Is.Not.Null);
+
+            MediaStream stream2 = Audio.CaptureStream();
+            RTCRtpSender sender2 = peer2.AddTrack(stream2.GetTracks().First());
+            Assert.That(sender2, Is.Not.Null);
+            Assert.That(sender1, Is.EqualTo(sender2));
+
+            peer1.Dispose();
+            peer2.Dispose();
+        }
+
+        [UnityTest]
+        [Timeout(5000)]
         public IEnumerator PeerConnectionStateChange()
         {
             RTCConfiguration config = default;


### PR DESCRIPTION
This fix avoids key duplication error when calling `RTCPeerConnection.AddTrack`
```
ArgumentException: Item has already been added. Key in dictionary: '140720295394096'  Key being added: '140720295394096'
System.Collections.Hashtable.Insert (System.Object key, System.Object nvalue, System.Boolean add) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
System.Collections.Hashtable.Add (System.Object key, System.Object value) (at <eae584ce26bc40229c1b1aa476bfa589>:0)
Unity.WebRTC.WeakReferenceTable.Add (System.Object key, System.Object value) (at Library/PackageCache/com.unity.webrtc@2.3.2-preview/Runtime/Scripts/WeakReferenceTable.cs:20)
Unity.WebRTC.RTCRtpSender..ctor (System.IntPtr ptr, Unity.WebRTC.RTCPeerConnection peer) (at Library/PackageCache/com.unity.webrtc@2.3.2-preview/Runtime/Scripts/RTCRtpSender.cs:19)
Unity.WebRTC.RTCPeerConnection.AddTrack (Unity.WebRTC.MediaStreamTrack track, Unity.WebRTC.MediaStream stream) (at Library/PackageCache/com.unity.webrtc@2.3.2-preview/Runtime/Scripts/RTCPeerConnection.cs:494)
```