### PR TITLE
fix: Enable hardware codec on Android platform 

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -3,21 +3,21 @@
 #include "Context.h"
 #include "EncoderFactory.h"
 
-#if defined(SUPPORT_OPENGL_CORE)
+#if SUPPORT_OPENGL_CORE
 #include "NvCodec/NvEncoderGL.h"
 #endif
 
-#if defined(SUPPORT_D3D11)
+#if SUPPORT_D3D11
 #include "NvCodec/NvEncoderD3D11.h"
 #endif
 
-#if defined(SUPPORT_D3D12)
+#if SUPPORT_D3D12
 #include "NvCodec/NvEncoderD3D12.h"
 #endif
 
 #include "SoftwareCodec/SoftwareEncoder.h"
 
-#if defined(SUPPORT_VULKAN) && defined(CUDA_PLATFORM)
+#if SUPPORT_VULKAN && CUDA_PLATFORM
 #include "NvCodec/NvEncoderCuda.h"
 #endif
 
@@ -35,10 +35,13 @@ namespace webrtc
 
     bool EncoderFactory::GetHardwareEncoderSupport()
     {
-#if defined(SUPPORT_METAL)
+#if UNITY_OSX || UNITY_IOS
         // todo(kazuki): check VideoToolbox compatibility
         return true;
-#elif defined(CUDA_PLATFORM)
+#elif UNITY_ANDROID
+        // todo(kazuki): check Android hwcodec compatibility
+        return true;
+#elif CUDA_PLATFORM
         if(!NvEncoder::LoadModule())
         {
             return false;
@@ -59,7 +62,7 @@ namespace webrtc
         std::unique_ptr<IEncoder> encoder;
         const GraphicsDeviceType deviceType = device->GetDeviceType();
         switch (deviceType) {
-#if defined(SUPPORT_D3D11)
+#if SUPPORT_D3D11
             case GRAPHICS_DEVICE_D3D11: {
                 if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
@@ -70,7 +73,7 @@ namespace webrtc
                 break;
             }
 #endif
-#if defined(SUPPORT_D3D12)
+#if SUPPORT_D3D12
             case GRAPHICS_DEVICE_D3D12: {
                 if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
@@ -81,15 +84,15 @@ namespace webrtc
                 break;
             }
 #endif
-#if defined(SUPPORT_OPENGL_CORE)
+#if SUPPORT_OPENGL_CORE
             case GRAPHICS_DEVICE_OPENGL: {
                 encoder = std::make_unique<NvEncoderGL>(width, height, device, textureFormat);
                 break;
             }
 #endif
-#if defined(SUPPORT_VULKAN)
+#if SUPPORT_VULKAN
             case GRAPHICS_DEVICE_VULKAN: {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
                 if (encoderType == UnityEncoderType::UnityEncoderHardware)
                 {
                     encoder = std::make_unique<NvEncoderCuda>(width, height, device, textureFormat);
@@ -100,7 +103,7 @@ namespace webrtc
                 break;
             }
 #endif            
-#if defined(SUPPORT_METAL)
+#if SUPPORT_METAL
             case GRAPHICS_DEVICE_METAL: {
                 encoder = std::make_unique<SoftwareEncoder>(width, height, device, textureFormat);
                 break;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -2,7 +2,7 @@
 
 #include "GraphicsDevice/GraphicsDeviceType.h"
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
 #include "Cuda/ICudaDevice.h"
 #endif
 
@@ -14,7 +14,7 @@ namespace webrtc
 class ITexture2D;
 
 class IGraphicsDevice
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     : public ICudaDevice
 #endif
 {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -26,7 +26,7 @@ VulkanGraphicsDevice::VulkanGraphicsDevice( IUnityGraphicsVulkan* unityVulkan, c
 //---------------------------------------------------------------------------------------------------------------------
 bool VulkanGraphicsDevice::InitV()
 {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     m_isCudaSupport = CUDA_SUCCESS == m_cudaContext.Init(m_instance, m_physicalDevice);
 #endif
     return VK_SUCCESS == CreateCommandPool();
@@ -35,7 +35,7 @@ bool VulkanGraphicsDevice::InitV()
 //---------------------------------------------------------------------------------------------------------------------
 
 void VulkanGraphicsDevice::ShutdownV() {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     m_cudaContext.Shutdown();
 #endif
     VULKAN_SAFE_DESTROY_COMMAND_POOL(m_device, m_commandPool, m_allocator);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "WebRTCConstants.h"
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
 #include "GraphicsDevice/Cuda/CudaContext.h"
 #endif
 #include "GraphicsDevice/IGraphicsDevice.h"
@@ -33,7 +33,7 @@ public:
     inline virtual GraphicsDeviceType GetDeviceType() const override;
     virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     virtual bool IsCudaSupport() override { return m_isCudaSupport; }
     virtual CUcontext GetCuContext() override { return m_cudaContext.GetContext(); }
 #endif
@@ -49,7 +49,7 @@ private:
     VkCommandPool           m_commandPool;
     uint32_t m_queueFamilyIndex;
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     CudaContext m_cudaContext;
     bool m_isCudaSupport;
 #endif
@@ -60,7 +60,7 @@ private:
 
 void* VulkanGraphicsDevice::GetEncodeDevicePtrV()
 {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     return reinterpret_cast<void*>(m_cudaContext.GetContext());
 #else
     return nullptr;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
@@ -35,7 +35,7 @@ void VulkanTexture2D::Shutdown()
     m_textureImageMemorySize = 0;
     m_device = VK_NULL_HANDLE;
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     m_cudaImage.Shutdown();
 #endif
 }
@@ -63,7 +63,7 @@ bool VulkanTexture2D::Init(const VkPhysicalDevice physicalDevice, const VkDevice
     m_textureImageMemory = m_unityVulkanImage.memory.memory;
     m_textureImageMemorySize = m_unityVulkanImage.memory.size;
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     return (CUDA_SUCCESS == m_cudaImage.Init(m_device, this));
 #else
     return true;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
@@ -3,7 +3,7 @@
 #include "WebRTCMacros.h"
 #include "GraphicsDevice/ITexture2D.h"
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
 #include "GraphicsDevice/Cuda/CudaImage.h"
 #endif
 
@@ -38,7 +38,7 @@ private:
     VkDeviceSize        m_textureImageMemorySize;
     VkDevice            m_device;
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     CudaImage           m_cudaImage;
 #endif
     VkFormat            m_textureFormat;
@@ -55,7 +55,7 @@ void* VulkanTexture2D::GetNativeTexturePtrV() { return  &m_unityVulkanImage; }
 const void* VulkanTexture2D::GetNativeTexturePtrV() const { return &m_unityVulkanImage; };
 void* VulkanTexture2D::GetEncodeTexturePtrV()
 {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     return m_cudaImage.GetArray();
 #else
     return nullptr;
@@ -63,7 +63,7 @@ void* VulkanTexture2D::GetEncodeTexturePtrV()
 }
 const void* VulkanTexture2D::GetEncodeTexturePtrV() const
 {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
     return m_cudaImage.GetArray();
 #else
     return nullptr;

--- a/Plugin~/WebRTCPlugin/PlatformBase.h
+++ b/Plugin~/WebRTCPlugin/PlatformBase.h
@@ -76,7 +76,7 @@
 #endif 
 
 #if UNITY_LINUX || UNITY_WIN
-#define CUDA_PLATFORM
+#define CUDA_PLATFORM 1
 #endif
 
 // COM-like Release macro

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -55,7 +55,7 @@ namespace webrtc
 
     std::vector<webrtc::SdpVideoFormat> UnityVideoEncoderFactory::GetHardwareEncoderFormats() const
     {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
         return { webrtc::CreateH264Format(
             webrtc::H264::kProfileConstrainedBaseline,
             webrtc::H264::kLevel5_1, "1") };
@@ -95,7 +95,7 @@ namespace webrtc
 
     std::unique_ptr<webrtc::VideoEncoder> UnityVideoEncoderFactory::CreateVideoEncoder(const webrtc::SdpVideoFormat& format)
     {
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
         if (IsFormatSupported(GetHardwareEncoderFormats(), format))
         {
             return std::make_unique<DummyVideoEncoder>(m_observer);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -228,7 +228,7 @@ extern "C"
 {
     UNITY_INTERFACE_EXPORT bool GetHardwareEncoderSupport()
     {
-#if defined(UNITY_WIN) || defined(UNITY_LINUX)
+#if CUDA_PLATFORM
         IGraphicsDevice* device = GraphicsUtility::GetGraphicsDevice();
         if(!device->IsCudaSupport())
         {

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -4,7 +4,7 @@
 #include "PlatformBase.h"
 #include "GraphicsDevice/GraphicsDevice.h"
 
-#if defined(SUPPORT_D3D11) // D3D11
+#if SUPPORT_D3D11 // D3D11
 
 #include <d3d11.h>
 #include <wrl/client.h>
@@ -12,21 +12,21 @@
 
 #endif
 
-#if defined(SUPPORT_METAL)  // Metal
+#if SUPPORT_METAL  // Metal
 #import <Metal/Metal.h>
 #endif
 
-#if defined(SUPPORT_OPENGL_CORE) // OpenGL
+#if SUPPORT_OPENGL_CORE // OpenGL
 #include <GL/glut.h>
 #endif
 
-#if defined(SUPPORT_VULKAN) // Vulkan
+#if SUPPORT_VULKAN // Vulkan
 
-#if defined(CUDA_PLATFORM)
+#if CUDA_PLATFORM
 #include <cuda.h>
 #endif
 
-#if defined(_WIN32)
+#if _WIN32
 #include <vulkan/vulkan_win32.h>
 #endif
 #include "GraphicsDevice/Vulkan/VulkanUtility.h"

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -6,14 +6,14 @@ namespace Unity.WebRTC.RuntimeTest
 {
     internal class ConditionalIgnore
     {
-        public const string UnsupportedHardwareForNvCodec = "IgnoreUnsupportedHardwareForNvCodec";
+        public const string UnsupportedHardwareForHardwareCodec = "IgnoreUnsupportedHardwareForHardwareCodec";
         public const string Direct3D12 = "IgnoreDirect3D12";
 
         [RuntimeInitializeOnLoadMethod]
         static void OnLoad()
         {
             var ignoreHardwareEncoderTest = !NativeMethods.GetHardwareEncoderSupport();
-            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedHardwareForNvCodec,
+            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedHardwareForHardwareCodec,
                 ignoreHardwareEncoderTest);
 
             ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(Direct3D12,

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -10,7 +10,7 @@ using Unity.Collections.LowLevel.Unsafe;
 namespace Unity.WebRTC.RuntimeTest
 {
     [TestFixture]
-    [ConditionalIgnore(ConditionalIgnore.UnsupportedHardwareForNvCodec, "Ignored hardware encoder test.")]
+    [ConditionalIgnore(ConditionalIgnore.UnsupportedHardwareForHardwareCodec, "Ignored hardware encoder test.")]
     class NativeAPITestWithHardwareEncoder : NativeAPITestWithSoftwareEncoder
     {
         [OneTimeSetUp]
@@ -471,7 +471,7 @@ namespace Unity.WebRTC.RuntimeTest
     }
 
     [TestFixture]
-    [ConditionalIgnore(ConditionalIgnore.UnsupportedHardwareForNvCodec, "Ignored hardware encoder test.")]
+    [ConditionalIgnore(ConditionalIgnore.UnsupportedHardwareForHardwareCodec, "Ignored hardware encoder test.")]
     [UnityPlatform(RuntimePlatform.WindowsEditor, RuntimePlatform.OSXEditor, RuntimePlatform.LinuxEditor)]
     class NativeAPITestWithHardwareEncoderAndEnterPlayModeOptionsEnabled : NativeAPITestWithHardwareEncoder, IPrebuildSetup
     {


### PR DESCRIPTION
Fixed that `EncoderFactory::GetHardwareEncoderSupport()` method always returned `false` on Android platform.