### PR TITLE
fix: Fix bugs of opengl API on android

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -62,9 +62,10 @@ namespace webrtc
         case UnityRenderingExtTextureFormat::kUnityRenderingExtFormatR8G8B8A8_SNorm:
         case UnityRenderingExtTextureFormat::kUnityRenderingExtFormatR8G8B8A8_UInt:
         case UnityRenderingExtTextureFormat::kUnityRenderingExtFormatR8G8B8A8_SInt:
+            return libyuv::FOURCC_ABGR;
         case UnityRenderingExtTextureFormat::kUnityRenderingExtFormatA8R8G8B8_SRGB:
         case UnityRenderingExtTextureFormat::kUnityRenderingExtFormatA8R8G8B8_UNorm:
-            return libyuv::FOURCC_ABGR;
+            return libyuv::FOURCC_BGRA;
         default:
             return libyuv::FOURCC_ANY;
         }

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -80,10 +80,13 @@ void UnityVideoRenderer::ConvertVideoFrameToTextureAndWriteToBuffer(int width, i
     if (tempBuffer.size() != size)
         tempBuffer.resize(size);
 
-    libyuv::ConvertFromI420(
+    if(0 > libyuv::ConvertFromI420(
         i420_buffer->DataY(), i420_buffer->StrideY(), i420_buffer->DataU(),
         i420_buffer->StrideU(), i420_buffer->DataV(), i420_buffer->StrideV(),
-        tempBuffer.data(), 0, width, height, format);
+        tempBuffer.data(), 0, width, height, format))
+    {
+        RTC_LOG(LS_INFO) << "failed libyuv::ConvertFromI420";
+    }
 }
 
 } // end namespace webrtc


### PR DESCRIPTION
`GL_BGRA_EXT` is not supported by some Android devices. 

`GraphicsUtility::ConvertRGBToI420Buffer` method does not support **RGBA** color format, so this fix is changing the operation for converting RGB to I420 on Android.