### PR TITLE
feat: expose access to webrtc's default AudioDeviceModule

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -22,9 +22,9 @@ namespace webrtc
     {
     public:
         static ContextManager* GetInstance() { return &s_instance; }
-     
+
         Context* GetContext(int uid) const;
-        Context* CreateContext(int uid, UnityEncoderType encoderType);
+        Context* CreateContext(int uid, UnityEncoderType encoderType, bool useDirectAudio);
         void DestroyContext(int uid);
         void SetCurContext(Context*);
         bool Exists(Context* context);
@@ -55,8 +55,8 @@ namespace webrtc
     class Context : public IVideoEncoderObserver
     {
     public:
-        
-        explicit Context(int uid = -1, UnityEncoderType encoderType = UnityEncoderHardware);
+
+        explicit Context(int uid = -1, UnityEncoderType encoderType = UnityEncoderHardware, bool useDirectAudio=false);
         ~Context();
 
         // Utility
@@ -89,7 +89,7 @@ namespace webrtc
         // StatsReport
         void AddStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report);
         void DeleteStatsReport(const webrtc::RTCStatsReport* report);
-    
+
         // DataChannel
         DataChannelObject* CreateDataChannel(PeerConnectionObject* obj, const char* label, const DataChannelInit& options);
         void AddDataChannel(std::unique_ptr<DataChannelObject>& channel);
@@ -136,7 +136,7 @@ namespace webrtc
         std::map<const webrtc::MediaStreamTrackInterface*, std::unique_ptr<VideoEncoderParameter>> m_mapVideoEncoderParameter;
         std::map<const DataChannelObject*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
         std::map<const uint32_t, std::unique_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
- 
+
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
         std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -411,7 +411,7 @@ extern "C"
         delegateSetResolution = func;
     }
 
-    UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid, UnityEncoderType encoderType)
+    UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid, UnityEncoderType encoderType, bool useDirectAudio)
     {
         auto ctx = ContextManager::GetInstance()->GetContext(uid);
         if (ctx != nullptr)
@@ -419,7 +419,7 @@ extern "C"
             DebugLog("Already created context with ID %d", uid);
             return ctx;
         }
-        ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType);
+        ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType, useDirectAudio);
         return ctx;
     }
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -15,14 +15,14 @@ namespace Unity.WebRTC
         private IntPtr renderFunction;
         private IntPtr textureUpdateFunction;
 
-        public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware)
+        public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware, bool useDirectAudio = false)
         {
             if (encoderType == EncoderType.Hardware && !NativeMethods.GetHardwareEncoderSupport())
             {
                 throw new ArgumentException("Hardware encoder is not supported");
             }
 
-            var ptr = NativeMethods.ContextCreate(id, encoderType);
+            var ptr = NativeMethods.ContextCreate(id, encoderType, useDirectAudio);
             return new Context(ptr, id);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -303,7 +303,7 @@ namespace Unity.WebRTC
         }
 #endif
 
-        public static void Initialize(EncoderType type = EncoderType.Hardware)
+        public static void Initialize(EncoderType type = EncoderType.Hardware, bool directAudio = false)
         {
             // todo(kazuki): Add this event to avoid crash caused by hot-reload.
             // Dispose of all before reloading assembly.
@@ -334,7 +334,7 @@ namespace Unity.WebRTC
 #if UNITY_IOS && !UNITY_EDITOR
             NativeMethods.RegisterRenderingWebRTCPlugin();
 #endif
-            s_context = Context.Create(encoderType:type);
+            s_context = Context.Create(encoderType:type, useDirectAudio:directAudio);
             NativeMethods.SetCurrentContext(s_context.self);
             s_syncContext = SynchronizationContext.Current;
             var flipShader = Resources.Load<Shader>("Flip");
@@ -613,7 +613,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void RegisterDebugLog(DelegateDebugLog func);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreate(int uid, EncoderType encoderType);
+        public static extern IntPtr ContextCreate(int uid, EncoderType encoderType, bool useDirectAudio);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDestroy(int uid);
         [DllImport(WebRTC.Lib)]


### PR DESCRIPTION
This PR adds a `bool` parameter to `WebRTC.Initialize()` which can be used to engage webrtc's default `AudioDeviceModule` and communicate directly to platform hardware.  The motivation is to allow spatialized stereo audio over WebRTC  to have direct access to the platform's speakers/mic instead of going through Unity's 3D audio spatialization system.  These changes allow pre-spatialized audio to **Just Work**™ over webrtc, for example: the HiFi Spatialized Audio API:

https://www.highfidelity.com/api

This has only been tested on linux (Ubuntu-20.04) however it should work on other platforms since there are no platform-dependent changes here.