### PR TITLE
chore: remove offer to receive video/audio options

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -240,6 +240,7 @@ namespace webrtc
     {
         webrtc::PeerConnectionInterface::RTCOfferAnswerOptions _options;
         _options.ice_restart = options.iceRestart;
+        _options.voice_activity_detection = options.voiceActivityDetection;
         connection->CreateOffer(this, _options);
     }
 
@@ -247,6 +248,7 @@ namespace webrtc
     {
         webrtc::PeerConnectionInterface::RTCOfferAnswerOptions _options;
         _options.ice_restart = options.iceRestart;
+        _options.voice_activity_detection = options.voiceActivityDetection;
         connection->CreateAnswer(this, _options);
     }
 

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -236,16 +236,14 @@ namespace webrtc
         return Json::writeString(builder, root);
     }
 
-    void PeerConnectionObject::CreateOffer(const RTCOfferOptions & options)
+    void PeerConnectionObject::CreateOffer(const RTCOfferAnswerOptions & options)
     {
         webrtc::PeerConnectionInterface::RTCOfferAnswerOptions _options;
         _options.ice_restart = options.iceRestart;
-        _options.offer_to_receive_audio = options.offerToReceiveAudio;
-        _options.offer_to_receive_video = options.offerToReceiveVideo;
         connection->CreateOffer(this, _options);
     }
 
-    void PeerConnectionObject::CreateAnswer(const RTCAnswerOptions& options)
+    void PeerConnectionObject::CreateAnswer(const RTCOfferAnswerOptions& options)
     {
         webrtc::PeerConnectionInterface::RTCOfferAnswerOptions _options;
         _options.ice_restart = options.iceRestart;

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -39,8 +39,8 @@ namespace webrtc
         bool GetSessionDescription(const webrtc::SessionDescriptionInterface* sdp, RTCSessionDescription& desc) const;
         webrtc::RTCErrorType SetConfiguration(const std::string& config);
         std::string GetConfiguration() const;
-        void CreateOffer(const RTCOfferOptions& options);
-        void CreateAnswer(const RTCAnswerOptions& options);
+        void CreateOffer(const RTCOfferAnswerOptions& options);
+        void CreateAnswer(const RTCOfferAnswerOptions& options);
         void ReceiveStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report);
 
         void RegisterCallbackCreateSD(DelegateCreateSDSuccess onSuccess, DelegateCreateSDFailure onFailure)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -769,12 +769,12 @@ extern "C"
         return ConvertPtrArrayFromRefPtrArray<RtpTransceiverInterface>(obj->connection->GetTransceivers(), length);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionCreateOffer(PeerConnectionObject* obj, const RTCOfferOptions* options)
+    UNITY_INTERFACE_EXPORT void PeerConnectionCreateOffer(PeerConnectionObject* obj, const RTCOfferAnswerOptions* options)
     {
         obj->CreateOffer(*options);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionCreateAnswer(PeerConnectionObject* obj, const RTCAnswerOptions* options)
+    UNITY_INTERFACE_EXPORT void PeerConnectionCreateAnswer(PeerConnectionObject* obj, const RTCOfferAnswerOptions* options)
     {
         obj->CreateAnswer(*options);
     }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -138,14 +138,7 @@ namespace webrtc
         int sdpMLineIndex;
     };
 
-    struct RTCOfferOptions
-    {
-        bool iceRestart;
-        bool offerToReceiveAudio;
-        bool offerToReceiveVideo;
-    };
-
-    struct RTCAnswerOptions
+    struct RTCOfferAnswerOptions
     {
         bool iceRestart;
     };

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -141,6 +141,7 @@ namespace webrtc
     struct RTCOfferAnswerOptions
     {
         bool iceRestart;
+        bool voiceActivityDetection;
     };
     
 } // end namespace webrtc

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -571,7 +571,7 @@ namespace Unity.WebRTC
         /// <param name="options"> A parameter to request for the offer. </param>
         /// <returns></returns>
         /// <seealso cref="CreateAnswer"/>
-        public RTCSessionDescriptionAsyncOperation CreateOffer(ref RTCOfferOptions options)
+        public RTCSessionDescriptionAsyncOperation CreateOffer(RTCOfferAnswerOptions options = default)
         {
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateOffer(GetSelfOrThrow(), ref options);
@@ -584,7 +584,7 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public RTCSessionDescriptionAsyncOperation CreateAnswer(ref RTCAnswerOptions options)
+        public RTCSessionDescriptionAsyncOperation CreateAnswer(RTCOfferAnswerOptions options = default)
         {
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateAnswer(GetSelfOrThrow(), ref options);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -568,11 +568,12 @@ namespace Unity.WebRTC
         /// Create an SDP (Session Description Protocol) offer to start a new connection
         /// to a remote peer.
         /// </summary>
-        /// <param name="options"> A parameter to request for the offer. </param>
+        /// <param name="iceRestart"></param>
         /// <returns></returns>
         /// <seealso cref="CreateAnswer"/>
-        public RTCSessionDescriptionAsyncOperation CreateOffer(RTCOfferAnswerOptions options = default)
+        public RTCSessionDescriptionAsyncOperation CreateOffer(bool iceRestart = false)
         {
+            RTCOfferAnswerOptions options = new RTCOfferAnswerOptions {iceRestart = iceRestart};
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateOffer(GetSelfOrThrow(), ref options);
             return m_opSessionDesc;
@@ -582,10 +583,11 @@ namespace Unity.WebRTC
         /// Create an SDP (Session Description Protocol) answer to start a new connection
         /// to a remote peer.
         /// </summary>
-        /// <param name="options"></param>
+        /// <param name="iceRestart"></param>
         /// <returns></returns>
-        public RTCSessionDescriptionAsyncOperation CreateAnswer(RTCOfferAnswerOptions options = default)
+        public RTCSessionDescriptionAsyncOperation CreateAnswer(bool iceRestart = false)
         {
+            RTCOfferAnswerOptions options = new RTCOfferAnswerOptions {iceRestart = iceRestart};
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateAnswer(GetSelfOrThrow(), ref options);
             return m_opSessionDesc;

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -568,12 +568,11 @@ namespace Unity.WebRTC
         /// Create an SDP (Session Description Protocol) offer to start a new connection
         /// to a remote peer.
         /// </summary>
-        /// <param name="iceRestart"></param>
+        /// <param name="options"></param>
         /// <returns></returns>
         /// <seealso cref="CreateAnswer"/>
-        public RTCSessionDescriptionAsyncOperation CreateOffer(bool iceRestart = false)
+        public RTCSessionDescriptionAsyncOperation CreateOffer(ref RTCOfferAnswerOptions options)
         {
-            RTCOfferAnswerOptions options = new RTCOfferAnswerOptions {iceRestart = iceRestart};
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateOffer(GetSelfOrThrow(), ref options);
             return m_opSessionDesc;
@@ -583,11 +582,10 @@ namespace Unity.WebRTC
         /// Create an SDP (Session Description Protocol) answer to start a new connection
         /// to a remote peer.
         /// </summary>
-        /// <param name="iceRestart"></param>
+        /// <param name="options"></param>
         /// <returns></returns>
-        public RTCSessionDescriptionAsyncOperation CreateAnswer(bool iceRestart = false)
+        public RTCSessionDescriptionAsyncOperation CreateAnswer(ref RTCOfferAnswerOptions options)
         {
-            RTCOfferAnswerOptions options = new RTCOfferAnswerOptions {iceRestart = iceRestart};
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateAnswer(GetSelfOrThrow(), ref options);
             return m_opSessionDesc;

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -578,6 +578,13 @@ namespace Unity.WebRTC
             return m_opSessionDesc;
         }
 
+        public RTCSessionDescriptionAsyncOperation CreateOffer()
+        {
+            m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
+            NativeMethods.PeerConnectionCreateOffer(GetSelfOrThrow(), ref RTCOfferAnswerOptions.Default);
+            return m_opSessionDesc;
+        }
+
         /// <summary>
         /// Create an SDP (Session Description Protocol) answer to start a new connection
         /// to a remote peer.
@@ -588,6 +595,13 @@ namespace Unity.WebRTC
         {
             m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
             NativeMethods.PeerConnectionCreateAnswer(GetSelfOrThrow(), ref options);
+            return m_opSessionDesc;
+        }
+
+        public RTCSessionDescriptionAsyncOperation CreateAnswer()
+        {
+            m_opSessionDesc = new RTCSessionDescriptionAsyncOperation();
+            NativeMethods.PeerConnectionCreateAnswer(GetSelfOrThrow(), ref RTCOfferAnswerOptions.Default);
             return m_opSessionDesc;
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -174,17 +174,7 @@ namespace Unity.WebRTC
     /// <summary>
     ///
     /// </summary>
-    public struct RTCOfferOptions
-    {
-        [MarshalAs(UnmanagedType.U1)]
-        public bool iceRestart;
-        [MarshalAs(UnmanagedType.U1)]
-        public bool offerToReceiveAudio;
-        [MarshalAs(UnmanagedType.U1)]
-        public bool offerToReceiveVideo;
-    }
-
-    public struct RTCAnswerOptions
+    public struct RTCOfferAnswerOptions
     {
         [MarshalAs(UnmanagedType.U1)]
         public bool iceRestart;
@@ -637,9 +627,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr PeerConnectionGetConfiguration(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionCreateOffer(IntPtr ptr, ref RTCOfferOptions options);
+        public static extern void PeerConnectionCreateOffer(IntPtr ptr, ref RTCOfferAnswerOptions options);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionCreateAnswer(IntPtr ptr, ref RTCAnswerOptions options);
+        public static extern void PeerConnectionCreateAnswer(IntPtr ptr, ref RTCOfferAnswerOptions options);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterCallbackCreateSD(IntPtr ptr, DelegateCreateSDSuccess onSuccess, DelegateCreateSDFailure onFailure);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -179,10 +179,19 @@ namespace Unity.WebRTC
         public static RTCOfferAnswerOptions Default =
             new RTCOfferAnswerOptions {iceRestart = false, voiceActivityDetection = true};
 
+        /// <summary>
+        ///
+        /// </summary>
         [MarshalAs(UnmanagedType.U1)]
         public bool iceRestart;
+        /// <summary>
+        ///
+        /// </summary>
+        /// <remarks>
+        /// this property is not supported yet.
+        /// </remarks>
         [MarshalAs(UnmanagedType.U1)]
-        public bool voiceActivityDetection; // this property is not supported yet.
+        public bool voiceActivityDetection;
     }
 
     /// <summary>

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -176,8 +176,13 @@ namespace Unity.WebRTC
     /// </summary>
     public struct RTCOfferAnswerOptions
     {
+        public static RTCOfferAnswerOptions Default =
+            new RTCOfferAnswerOptions {iceRestart = false, voiceActivityDetection = true};
+
         [MarshalAs(UnmanagedType.U1)]
         public bool iceRestart;
+        [MarshalAs(UnmanagedType.U1)]
+        public bool voiceActivityDetection; // this property is not supported yet.
     }
 
     /// <summary>

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -151,7 +151,7 @@ class BandwidthSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -397,7 +397,7 @@ class BandwidthSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer();
+        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -151,7 +151,7 @@ class BandwidthSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -397,7 +397,7 @@ class BandwidthSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -50,13 +50,6 @@ class BandwidthSample : MonoBehaviour
     private const int width = 1280;
     private const int height = 720;
 
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false, offerToReceiveAudio = true, offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions {iceRestart = false,};
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -158,7 +151,7 @@ class BandwidthSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -404,7 +397,7 @@ class BandwidthSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref _answerOptions);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/ChangeCodecs/ChangeCodecsSample.cs
+++ b/Samples~/ChangeCodecs/ChangeCodecsSample.cs
@@ -146,7 +146,7 @@ class ChangeCodecsSample : MonoBehaviour
 
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -309,7 +309,7 @@ class ChangeCodecsSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer();
+        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/ChangeCodecs/ChangeCodecsSample.cs
+++ b/Samples~/ChangeCodecs/ChangeCodecsSample.cs
@@ -146,7 +146,7 @@ class ChangeCodecsSample : MonoBehaviour
 
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -309,7 +309,7 @@ class ChangeCodecsSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/ChangeCodecs/ChangeCodecsSample.cs
+++ b/Samples~/ChangeCodecs/ChangeCodecsSample.cs
@@ -40,15 +40,6 @@ class ChangeCodecsSample : MonoBehaviour
     private const int width = 1280;
     private const int height = 720;
 
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false,
-        offerToReceiveAudio = true,
-        offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions { iceRestart = false, };
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -155,7 +146,7 @@ class ChangeCodecsSample : MonoBehaviour
 
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -318,7 +309,7 @@ class ChangeCodecsSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref _answerOptions);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/DataChannel/DataChannelSample.cs
+++ b/Samples~/DataChannel/DataChannelSample.cs
@@ -26,18 +26,6 @@ class DataChannelSample : MonoBehaviour
     private DelegateOnClose onDataChannelClose;
     private DelegateOnDataChannel onDataChannel;
 
-    private RTCOfferOptions OfferOptions = new RTCOfferOptions
-    {
-        iceRestart = false,
-        offerToReceiveAudio = true,
-        offerToReceiveVideo = false
-    };
-
-    private RTCAnswerOptions AnswerOptions = new RTCAnswerOptions
-    {
-        iceRestart = false,
-    };
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -158,7 +146,7 @@ class DataChannelSample : MonoBehaviour
         dataChannel.OnOpen = onDataChannelOpen;
 
         Debug.Log("pc1 createOffer start");
-        var op = pc1.CreateOffer(ref OfferOptions);
+        var op = pc1.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -188,7 +176,7 @@ class DataChannelSample : MonoBehaviour
 
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="pc"></param>
     /// <param name="streamEvent"></param>
@@ -246,7 +234,7 @@ class DataChannelSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = pc2.CreateAnswer(ref AnswerOptions);
+        var op3 = pc2.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/DataChannel/DataChannelSample.cs
+++ b/Samples~/DataChannel/DataChannelSample.cs
@@ -146,7 +146,7 @@ class DataChannelSample : MonoBehaviour
         dataChannel.OnOpen = onDataChannelOpen;
 
         Debug.Log("pc1 createOffer start");
-        var op = pc1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc1.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -234,7 +234,7 @@ class DataChannelSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = pc2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = pc2.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/DataChannel/DataChannelSample.cs
+++ b/Samples~/DataChannel/DataChannelSample.cs
@@ -146,7 +146,7 @@ class DataChannelSample : MonoBehaviour
         dataChannel.OnOpen = onDataChannelOpen;
 
         Debug.Log("pc1 createOffer start");
-        var op = pc1.CreateOffer();
+        var op = pc1.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -234,7 +234,7 @@ class DataChannelSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = pc2.CreateAnswer();
+        var op3 = pc2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/MediaStream/MediaStream.unity
+++ b/Samples~/MediaStream/MediaStream.unity
@@ -970,7 +970,7 @@ GameObject:
   - component: {fileID: 934963287}
   - component: {fileID: 934963290}
   m_Layer: 0
-  m_Name: Main Camera
+  m_Name: MainCamera
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -35,18 +35,6 @@ class MediaStreamSample : MonoBehaviour
     private StringBuilder trackInfos;
     private bool videoUpdateStarted;
 
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false,
-        offerToReceiveAudio = true,
-        offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions
-    {
-        iceRestart = false,
-    };
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -124,7 +112,7 @@ class MediaStreamSample : MonoBehaviour
     IEnumerator PcOnNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -257,7 +245,7 @@ class MediaStreamSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref _answerOptions);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -112,7 +112,7 @@ class MediaStreamSample : MonoBehaviour
     IEnumerator PcOnNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -245,7 +245,7 @@ class MediaStreamSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -112,7 +112,7 @@ class MediaStreamSample : MonoBehaviour
     IEnumerator PcOnNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -245,7 +245,7 @@ class MediaStreamSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer();
+        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/Menu/Menu.unity
+++ b/Samples~/Menu/Menu.unity
@@ -1017,8 +1017,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -100}
-  m_SizeDelta: {x: 0, y: -200}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &524198427
 MonoBehaviour:
@@ -2988,8 +2988,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 584.0001}
-  m_SizeDelta: {x: 0, y: 800}
+  m_AnchoredPosition: {x: 0, y: 0.0}
+  m_SizeDelta: {x: 0, y: 1500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1648950605
 MonoBehaviour:
@@ -3838,8 +3838,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 65202134}
   m_HandleRect: {fileID: 65202133}
   m_Direction: 2
-  m_Value: -0.0000002090245
-  m_Size: 0.27
+  m_Value: 1
+  m_Size: 0.36466667
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
+++ b/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
@@ -129,7 +129,7 @@ class MultiVideoReceiveSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -288,7 +288,7 @@ class MultiVideoReceiveSample : MonoBehaviour
         // Since the 'remote' side has no media stream we need
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
-        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
+++ b/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
@@ -129,7 +129,7 @@ class MultiVideoReceiveSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -288,7 +288,7 @@ class MultiVideoReceiveSample : MonoBehaviour
         // Since the 'remote' side has no media stream we need
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
-        var op3 = otherPc.CreateAnswer();
+        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
+++ b/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
@@ -36,13 +36,6 @@ class MultiVideoReceiveSample : MonoBehaviour
     private const int width = 1280;
     private const int height = 720;
 
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false, offerToReceiveAudio = false, offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions {iceRestart = false,};
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -136,7 +129,7 @@ class MultiVideoReceiveSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -295,7 +288,7 @@ class MultiVideoReceiveSample : MonoBehaviour
         // Since the 'remote' side has no media stream we need
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
-        var op3 = otherPc.CreateAnswer(ref _answerOptions);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -158,7 +158,7 @@ class MultiplePeerConnectionsSample : MonoBehaviour
 
     private static IEnumerator NegotiationPeer(RTCPeerConnection localPeer, RTCPeerConnection remotePeer)
     {
-        var opCreateOffer = localPeer.CreateOffer();
+        var opCreateOffer = localPeer.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return opCreateOffer;
 
         if (opCreateOffer.IsError)
@@ -172,7 +172,7 @@ class MultiplePeerConnectionsSample : MonoBehaviour
         Debug.Log($"Offer from LocalPeer \n {offerDesc.sdp}");
         yield return remotePeer.SetRemoteDescription(ref offerDesc);
 
-        var opCreateAnswer = remotePeer.CreateAnswer();
+        var opCreateAnswer = remotePeer.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return opCreateAnswer;
 
         if (opCreateAnswer.IsError)

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -158,7 +158,7 @@ class MultiplePeerConnectionsSample : MonoBehaviour
 
     private static IEnumerator NegotiationPeer(RTCPeerConnection localPeer, RTCPeerConnection remotePeer)
     {
-        var opCreateOffer = localPeer.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var opCreateOffer = localPeer.CreateOffer();
         yield return opCreateOffer;
 
         if (opCreateOffer.IsError)
@@ -172,7 +172,7 @@ class MultiplePeerConnectionsSample : MonoBehaviour
         Debug.Log($"Offer from LocalPeer \n {offerDesc.sdp}");
         yield return remotePeer.SetRemoteDescription(ref offerDesc);
 
-        var opCreateAnswer = remotePeer.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var opCreateAnswer = remotePeer.CreateAnswer();
         yield return opCreateAnswer;
 
         if (opCreateAnswer.IsError)

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -17,13 +17,6 @@ class MultiplePeerConnectionsSample : MonoBehaviour
     [SerializeField] private Transform rotateObject;
 #pragma warning restore 0649
 
-    private static RTCOfferOptions offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false, offerToReceiveAudio = true, offerToReceiveVideo = true
-    };
-
-    private static RTCAnswerOptions answerOptions = new RTCAnswerOptions {iceRestart = false,};
-
     private static RTCConfiguration configuration = new RTCConfiguration
     {
         iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}}
@@ -165,7 +158,7 @@ class MultiplePeerConnectionsSample : MonoBehaviour
 
     private static IEnumerator NegotiationPeer(RTCPeerConnection localPeer, RTCPeerConnection remotePeer)
     {
-        var opCreateOffer = localPeer.CreateOffer(ref offerOptions);
+        var opCreateOffer = localPeer.CreateOffer();
         yield return opCreateOffer;
 
         if (opCreateOffer.IsError)
@@ -179,7 +172,7 @@ class MultiplePeerConnectionsSample : MonoBehaviour
         Debug.Log($"Offer from LocalPeer \n {offerDesc.sdp}");
         yield return remotePeer.SetRemoteDescription(ref offerDesc);
 
-        var opCreateAnswer = remotePeer.CreateAnswer(ref answerOptions);
+        var opCreateAnswer = remotePeer.CreateAnswer();
         yield return opCreateAnswer;
 
         if (opCreateAnswer.IsError)

--- a/Samples~/MungeSDP/MungeSDPSample.cs
+++ b/Samples~/MungeSDP/MungeSDPSample.cs
@@ -114,7 +114,7 @@ class MungeSDPSample : MonoBehaviour
 
     private IEnumerator CreateOffer()
     {
-        var op = pcLocal.CreateOffer();
+        var op = pcLocal.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (op.IsError)
@@ -157,7 +157,7 @@ class MungeSDPSample : MonoBehaviour
 
     private IEnumerator CreateAnswer()
     {
-        var op = pcRemote.CreateAnswer();
+        var op = pcRemote.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (op.IsError)

--- a/Samples~/MungeSDP/MungeSDPSample.cs
+++ b/Samples~/MungeSDP/MungeSDPSample.cs
@@ -22,13 +22,6 @@ class MungeSDPSample : MonoBehaviour
     [SerializeField] private Transform rotateObject;
 #pragma warning restore 0649
 
-    private RTCOfferOptions offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false, offerToReceiveAudio = true, offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions answerOptions = new RTCAnswerOptions {iceRestart = false,};
-
     private RTCConfiguration configuration = new RTCConfiguration
     {
         iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}}
@@ -121,7 +114,7 @@ class MungeSDPSample : MonoBehaviour
 
     private IEnumerator CreateOffer()
     {
-        var op = pcLocal.CreateOffer(ref offerOptions);
+        var op = pcLocal.CreateOffer();
         yield return op;
 
         if (op.IsError)
@@ -164,7 +157,7 @@ class MungeSDPSample : MonoBehaviour
 
     private IEnumerator CreateAnswer()
     {
-        var op = pcRemote.CreateAnswer(ref answerOptions);
+        var op = pcRemote.CreateAnswer();
         yield return op;
 
         if (op.IsError)

--- a/Samples~/MungeSDP/MungeSDPSample.cs
+++ b/Samples~/MungeSDP/MungeSDPSample.cs
@@ -114,7 +114,7 @@ class MungeSDPSample : MonoBehaviour
 
     private IEnumerator CreateOffer()
     {
-        var op = pcLocal.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pcLocal.CreateOffer();
         yield return op;
 
         if (op.IsError)
@@ -157,7 +157,7 @@ class MungeSDPSample : MonoBehaviour
 
     private IEnumerator CreateAnswer()
     {
-        var op = pcRemote.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op = pcRemote.CreateAnswer();
         yield return op;
 
         if (op.IsError)

--- a/Samples~/PeerConnection/PeerConnectionSample.cs
+++ b/Samples~/PeerConnection/PeerConnectionSample.cs
@@ -38,13 +38,6 @@ class PeerConnectionSample : MonoBehaviour
     private const int width = 1280;
     private const int height = 720;
 
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false, offerToReceiveAudio = true, offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions {iceRestart = false,};
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -180,7 +173,7 @@ class PeerConnectionSample : MonoBehaviour
 
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -326,7 +319,7 @@ class PeerConnectionSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref _answerOptions);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/PeerConnection/PeerConnectionSample.cs
+++ b/Samples~/PeerConnection/PeerConnectionSample.cs
@@ -173,7 +173,7 @@ class PeerConnectionSample : MonoBehaviour
 
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -319,7 +319,7 @@ class PeerConnectionSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer();
+        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/PeerConnection/PeerConnectionSample.cs
+++ b/Samples~/PeerConnection/PeerConnectionSample.cs
@@ -173,7 +173,7 @@ class PeerConnectionSample : MonoBehaviour
 
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -319,7 +319,7 @@ class PeerConnectionSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/Stats/StatsSample.cs
+++ b/Samples~/Stats/StatsSample.cs
@@ -152,7 +152,7 @@ class StatsSample : MonoBehaviour
         dataChannel.OnOpen = onDataChannelOpen;
 
         Debug.Log("pc1 createOffer start");
-        var op = pc1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc1.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -227,7 +227,7 @@ class StatsSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = pc2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = pc2.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/Stats/StatsSample.cs
+++ b/Samples~/Stats/StatsSample.cs
@@ -31,18 +31,6 @@ class StatsSample : MonoBehaviour
     private DelegateOnDataChannel onDataChannel = null;
     private int currentValue = -1;
 
-    private RTCOfferOptions OfferOptions = new RTCOfferOptions
-    {
-        iceRestart = false,
-        offerToReceiveAudio = true,
-        offerToReceiveVideo = false
-    };
-
-    private RTCAnswerOptions AnswerOptions = new RTCAnswerOptions
-    {
-        iceRestart = false,
-    };
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -164,7 +152,7 @@ class StatsSample : MonoBehaviour
         dataChannel.OnOpen = onDataChannelOpen;
 
         Debug.Log("pc1 createOffer start");
-        var op = pc1.CreateOffer(ref OfferOptions);
+        var op = pc1.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -239,7 +227,7 @@ class StatsSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = pc2.CreateAnswer(ref AnswerOptions);
+        var op3 = pc2.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/Stats/StatsSample.cs
+++ b/Samples~/Stats/StatsSample.cs
@@ -152,7 +152,7 @@ class StatsSample : MonoBehaviour
         dataChannel.OnOpen = onDataChannelOpen;
 
         Debug.Log("pc1 createOffer start");
-        var op = pc1.CreateOffer();
+        var op = pc1.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -227,7 +227,7 @@ class StatsSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = pc2.CreateAnswer();
+        var op3 = pc2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/TrickleIce/TrickleIceSample.cs
+++ b/Samples~/TrickleIce/TrickleIceSample.cs
@@ -33,16 +33,7 @@ class TrickleIceSample : MonoBehaviour
     private Dictionary<GameObject, RTCIceServer> iceServers
         = new Dictionary<GameObject, RTCIceServer>();
 
-    private GameObject selectedOption = null; 
-
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false,
-        offerToReceiveAudio = true,
-        offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions { iceRestart = false, };
+    private GameObject selectedOption = null;
 
     private void Awake()
     {
@@ -153,7 +144,7 @@ class TrickleIceSample : MonoBehaviour
 
     IEnumerator CreateOffer(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)

--- a/Samples~/TrickleIce/TrickleIceSample.cs
+++ b/Samples~/TrickleIce/TrickleIceSample.cs
@@ -144,7 +144,7 @@ class TrickleIceSample : MonoBehaviour
 
     IEnumerator CreateOffer(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)

--- a/Samples~/TrickleIce/TrickleIceSample.cs
+++ b/Samples~/TrickleIce/TrickleIceSample.cs
@@ -144,7 +144,7 @@ class TrickleIceSample : MonoBehaviour
 
     IEnumerator CreateOffer(RTCPeerConnection pc)
     {
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -110,7 +110,7 @@ class VideoReceiveSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer();
+        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
         yield return op;
 
         if (!op.IsError)
@@ -263,7 +263,7 @@ class VideoReceiveSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer();
+        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -30,13 +30,6 @@ class VideoReceiveSample : MonoBehaviour
     private DelegateOnNegotiationNeeded pc1OnNegotiationNeeded;
     private bool videoUpdateStarted;
 
-    private RTCOfferOptions _offerOptions = new RTCOfferOptions
-    {
-        iceRestart = false, offerToReceiveAudio = true, offerToReceiveVideo = true
-    };
-
-    private RTCAnswerOptions _answerOptions = new RTCAnswerOptions {iceRestart = false,};
-
     private void Awake()
     {
         WebRTC.Initialize(WebRTCSettings.EncoderType);
@@ -117,7 +110,7 @@ class VideoReceiveSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref _offerOptions);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -270,7 +263,7 @@ class VideoReceiveSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref _answerOptions);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -110,7 +110,7 @@ class VideoReceiveSample : MonoBehaviour
     IEnumerator PeerNegotiationNeeded(RTCPeerConnection pc)
     {
         Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+        var op = pc.CreateOffer();
         yield return op;
 
         if (!op.IsError)
@@ -263,7 +263,7 @@ class VideoReceiveSample : MonoBehaviour
         // to pass in the right constraints in order for it to
         // accept the incoming offer of audio and video.
 
-        var op3 = otherPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+        var op3 = otherPc.CreateAnswer();
         yield return op3;
         if (!op3.IsError)
         {

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -129,14 +129,14 @@ namespace Unity.WebRTC.RuntimeTest
             channel1.OnOpen = () => { channel1Opened = true; };
             channel1.OnClose = () => { channel1Closed = true; };
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -74,7 +74,7 @@ namespace Unity.WebRTC.RuntimeTest
             config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
             var peer = new RTCPeerConnection(ref config);
 
-            // Cannot be set along with "maxRetransmits" and "maxPacketLifeTime" 
+            // Cannot be set along with "maxRetransmits" and "maxPacketLifeTime"
             var options = new RTCDataChannelInit
             {
                 id = 231,
@@ -129,16 +129,14 @@ namespace Unity.WebRTC.RuntimeTest
             channel1.OnOpen = () => { channel1Opened = true; };
             channel1.OnClose = () => { channel1Closed = true; };
 
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -129,14 +129,14 @@ namespace Unity.WebRTC.RuntimeTest
             channel1.OnOpen = () => { channel1Opened = true; };
             channel1.OnClose = () => { channel1Closed = true; };
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -264,7 +264,7 @@ namespace Unity.WebRTC.RuntimeTest
             transceiver1.Direction = RTCRtpTransceiverDirection.RecvOnly;
             Assert.IsNull(transceiver1.CurrentDirection);
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -276,7 +276,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.True(transceiver2.Sender.ReplaceTrack(audioTrack));
             transceiver2.Direction = RTCRtpTransceiverDirection.SendOnly;
 
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -301,7 +301,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op = peer.CreateOffer();
 
             yield return op;
             Assert.True(op.IsDone);
@@ -318,7 +318,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            var op = peer.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op = peer.CreateAnswer();
 
             yield return op;
             Assert.True(op.IsDone);
@@ -342,14 +342,14 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             peer1.CreateDataChannel("data");
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
 
             Assert.True(op4.IsDone);
@@ -367,7 +367,7 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator SetLocalDescription()
         {
             var peer = new RTCPeerConnection();
-            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op = peer.CreateOffer();
             yield return op;
             Assert.True(op.IsDone);
             Assert.False(op.IsError);
@@ -411,14 +411,14 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             var channel1 = peer1.CreateDataChannel("data");
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -463,7 +463,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = new AudioStreamTrack("audio");
             var sender = peer.AddTrack(track, stream);
 
-            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op = peer.CreateOffer();
             yield return op;
             Assert.True(op.IsDone);
             Assert.False(op.IsError);
@@ -496,7 +496,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = new AudioStreamTrack("audio");
             var sender = peer1.AddTrack(track, stream);
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -533,14 +533,14 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -582,7 +582,7 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -597,7 +597,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             Assert.That(peer2.AddIceCandidate(peer2ReceiveCandidateQueue.Dequeue()), Is.True);
 
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -725,14 +725,14 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -900,14 +900,14 @@ namespace Unity.WebRTC.RuntimeTest
 
         private IEnumerator SignalingOffer(RTCPeerConnection @from, RTCPeerConnection to)
         {
-            var op1 = @from.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = @from.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = @from.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = to.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = to.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = to.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = to.SetLocalDescription(ref desc);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -264,7 +264,7 @@ namespace Unity.WebRTC.RuntimeTest
             transceiver1.Direction = RTCRtpTransceiverDirection.RecvOnly;
             Assert.IsNull(transceiver1.CurrentDirection);
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -276,7 +276,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.True(transceiver2.Sender.ReplaceTrack(audioTrack));
             transceiver2.Direction = RTCRtpTransceiverDirection.SendOnly;
 
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -301,7 +301,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            var op = peer.CreateOffer();
+            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
 
             yield return op;
             Assert.True(op.IsDone);
@@ -318,7 +318,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            var op = peer.CreateAnswer();
+            var op = peer.CreateAnswer(ref RTCOfferAnswerOptions.Default);
 
             yield return op;
             Assert.True(op.IsDone);
@@ -342,14 +342,14 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             peer1.CreateDataChannel("data");
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
 
             Assert.True(op4.IsDone);
@@ -367,7 +367,7 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator SetLocalDescription()
         {
             var peer = new RTCPeerConnection();
-            var op = peer.CreateOffer();
+            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op;
             Assert.True(op.IsDone);
             Assert.False(op.IsError);
@@ -411,14 +411,14 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             var channel1 = peer1.CreateDataChannel("data");
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -463,7 +463,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = new AudioStreamTrack("audio");
             var sender = peer.AddTrack(track, stream);
 
-            var op = peer.CreateOffer();
+            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op;
             Assert.True(op.IsDone);
             Assert.False(op.IsError);
@@ -496,7 +496,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = new AudioStreamTrack("audio");
             var sender = peer1.AddTrack(track, stream);
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -533,14 +533,14 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -582,7 +582,7 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -597,7 +597,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             Assert.That(peer2.AddIceCandidate(peer2ReceiveCandidateQueue.Dequeue()), Is.True);
 
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -725,14 +725,14 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            var op1 = peer1.CreateOffer();
+            var op1 = peer1.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -900,14 +900,14 @@ namespace Unity.WebRTC.RuntimeTest
 
         private IEnumerator SignalingOffer(RTCPeerConnection @from, RTCPeerConnection to)
         {
-            var op1 = @from.CreateOffer();
+            var op1 = @from.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             var desc = op1.Desc;
             var op2 = @from.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = to.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = to.CreateAnswer();
+            var op4 = to.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             desc = op4.Desc;
             var op5 = to.SetLocalDescription(ref desc);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -264,9 +264,7 @@ namespace Unity.WebRTC.RuntimeTest
             transceiver1.Direction = RTCRtpTransceiverDirection.RecvOnly;
             Assert.IsNull(transceiver1.CurrentDirection);
 
-            RTCOfferOptions options1 = new RTCOfferOptions {offerToReceiveAudio = true};
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -278,7 +276,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.True(transceiver2.Sender.ReplaceTrack(audioTrack));
             transceiver2.Direction = RTCRtpTransceiverDirection.SendOnly;
 
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -303,8 +301,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            RTCOfferOptions options = default;
-            var op = peer.CreateOffer(ref options);
+            var op = peer.CreateOffer();
 
             yield return op;
             Assert.True(op.IsDone);
@@ -321,8 +318,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            RTCAnswerOptions options = default;
-            var op = peer.CreateAnswer(ref options);
+            var op = peer.CreateAnswer();
 
             yield return op;
             Assert.True(op.IsDone);
@@ -346,16 +342,14 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             peer1.CreateDataChannel("data");
 
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
 
             Assert.True(op4.IsDone);
@@ -373,8 +367,7 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator SetLocalDescription()
         {
             var peer = new RTCPeerConnection();
-            RTCOfferOptions options = default;
-            var op = peer.CreateOffer(ref options);
+            var op = peer.CreateOffer();
             yield return op;
             Assert.True(op.IsDone);
             Assert.False(op.IsError);
@@ -418,16 +411,14 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
             var channel1 = peer1.CreateDataChannel("data");
 
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -472,8 +463,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = new AudioStreamTrack("audio");
             var sender = peer.AddTrack(track, stream);
 
-            RTCOfferOptions options = default;
-            var op = peer.CreateOffer(ref options);
+            var op = peer.CreateOffer();
             yield return op;
             Assert.True(op.IsDone);
             Assert.False(op.IsError);
@@ -506,8 +496,7 @@ namespace Unity.WebRTC.RuntimeTest
             var track = new AudioStreamTrack("audio");
             var sender = peer1.AddTrack(track, stream);
 
-            RTCOfferOptions options1 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -544,16 +533,14 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -740,16 +727,14 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);
@@ -917,16 +902,14 @@ namespace Unity.WebRTC.RuntimeTest
 
         private IEnumerator SignalingOffer(RTCPeerConnection @from, RTCPeerConnection to)
         {
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = @from.CreateOffer(ref options1);
+            var op1 = @from.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = @from.SetLocalDescription(ref desc);
             yield return op2;
             var op3 = to.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = to.CreateAnswer(ref options2);
+            var op4 = to.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = to.SetLocalDescription(ref desc);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -582,9 +582,7 @@ namespace Unity.WebRTC.RuntimeTest
             MediaStream stream = Audio.CaptureStream();
             peer1.AddTrack(stream.GetTracks().First());
 
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peer1.CreateOffer(ref options1);
+            var op1 = peer1.CreateOffer();
             yield return op1;
             var desc = op1.Desc;
             var op2 = peer1.SetLocalDescription(ref desc);
@@ -599,7 +597,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             Assert.That(peer2.AddIceCandidate(peer2ReceiveCandidateQueue.Dequeue()), Is.True);
 
-            var op4 = peer2.CreateAnswer(ref options2);
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             desc = op4.Desc;
             var op5 = peer2.SetLocalDescription(ref desc);

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -125,7 +125,7 @@ namespace Unity.WebRTC.RuntimeTest
                 transceiver.Direction = RTCRtpTransceiverDirection.SendOnly;
             }
 
-            var op1 = peers[0].CreateOffer();
+            var op1 = peers[0].CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return op1;
             Assert.That(op1.IsError, Is.False, op1.Error.message);
             var desc = op1.Desc;
@@ -137,7 +137,7 @@ namespace Unity.WebRTC.RuntimeTest
             var op3 = peers[1].SetRemoteDescription(ref desc);
             yield return op3;
             Assert.That(op3.IsError, Is.False, op3.Error.message);
-            var op4 = peers[1].CreateAnswer();
+            var op4 = peers[1].CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
             Assert.That(op4.IsError, Is.False, op4.Error.message);
             desc = op4.Desc;

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -125,7 +125,7 @@ namespace Unity.WebRTC.RuntimeTest
                 transceiver.Direction = RTCRtpTransceiverDirection.SendOnly;
             }
 
-            var op1 = peers[0].CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var op1 = peers[0].CreateOffer();
             yield return op1;
             Assert.That(op1.IsError, Is.False, op1.Error.message);
             var desc = op1.Desc;
@@ -137,7 +137,7 @@ namespace Unity.WebRTC.RuntimeTest
             var op3 = peers[1].SetRemoteDescription(ref desc);
             yield return op3;
             Assert.That(op3.IsError, Is.False, op3.Error.message);
-            var op4 = peers[1].CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var op4 = peers[1].CreateAnswer();
             yield return op4;
             Assert.That(op4.IsError, Is.False, op4.Error.message);
             desc = op4.Desc;

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -118,6 +118,13 @@ namespace Unity.WebRTC.RuntimeTest
                     peers[0].AddTrack(track, m_stream);
                 }
             }
+
+            // Because some platform can't accept H264 codec for receive.
+            foreach (var transceiver in peers[0].GetTransceivers())
+            {
+                transceiver.Direction = RTCRtpTransceiverDirection.SendOnly;
+            }
+
             var op1 = peers[0].CreateOffer();
             yield return op1;
             Assert.That(op1.IsError, Is.False, op1.Error.message);

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -118,9 +118,7 @@ namespace Unity.WebRTC.RuntimeTest
                     peers[0].AddTrack(track, m_stream);
                 }
             }
-            RTCOfferOptions options1 = default;
-            RTCAnswerOptions options2 = default;
-            var op1 = peers[0].CreateOffer(ref options1);
+            var op1 = peers[0].CreateOffer();
             yield return op1;
             Assert.That(op1.IsError, Is.False, op1.Error.message);
             var desc = op1.Desc;
@@ -132,7 +130,7 @@ namespace Unity.WebRTC.RuntimeTest
             var op3 = peers[1].SetRemoteDescription(ref desc);
             yield return op3;
             Assert.That(op3.IsError, Is.False, op3.Error.message);
-            var op4 = peers[1].CreateAnswer(ref options2);
+            var op4 = peers[1].CreateAnswer();
             yield return op4;
             Assert.That(op4.IsError, Is.False, op4.Error.message);
             desc = op4.Desc;

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -106,10 +106,7 @@ namespace Unity.WebRTC.RuntimeTest
             offerPc.OnIceCandidate = candidate => answerPc.AddIceCandidate(candidate);
             answerPc.OnIceCandidate = candidate => offerPc.AddIceCandidate(candidate);
 
-            var offerOption = new RTCOfferOptions {offerToReceiveVideo = true};
-            var answerOption = new RTCAnswerOptions {iceRestart = false};
-
-            var pc1CreateOffer = offerPc.CreateOffer(ref offerOption);
+            var pc1CreateOffer = offerPc.CreateOffer();
             yield return pc1CreateOffer;
             Assert.False(pc1CreateOffer.IsError);
             var offerDesc = pc1CreateOffer.Desc;
@@ -122,7 +119,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return pc2SetRemoteDescription;
             Assert.False(pc2SetRemoteDescription.IsError);
 
-            var pc2CreateAnswer = answerPc.CreateAnswer(ref answerOption);
+            var pc2CreateAnswer = answerPc.CreateAnswer();
             yield return pc2CreateAnswer;
             Assert.False(pc2CreateAnswer.IsError);
             var answerDesc = pc2CreateAnswer.Desc;

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -106,7 +106,7 @@ namespace Unity.WebRTC.RuntimeTest
             offerPc.OnIceCandidate = candidate => answerPc.AddIceCandidate(candidate);
             answerPc.OnIceCandidate = candidate => offerPc.AddIceCandidate(candidate);
 
-            var pc1CreateOffer = offerPc.CreateOffer();
+            var pc1CreateOffer = offerPc.CreateOffer(ref RTCOfferAnswerOptions.Default);
             yield return pc1CreateOffer;
             Assert.False(pc1CreateOffer.IsError);
             var offerDesc = pc1CreateOffer.Desc;
@@ -119,7 +119,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return pc2SetRemoteDescription;
             Assert.False(pc2SetRemoteDescription.IsError);
 
-            var pc2CreateAnswer = answerPc.CreateAnswer();
+            var pc2CreateAnswer = answerPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return pc2CreateAnswer;
             Assert.False(pc2CreateAnswer.IsError);
             var answerDesc = pc2CreateAnswer.Desc;

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -106,7 +106,7 @@ namespace Unity.WebRTC.RuntimeTest
             offerPc.OnIceCandidate = candidate => answerPc.AddIceCandidate(candidate);
             answerPc.OnIceCandidate = candidate => offerPc.AddIceCandidate(candidate);
 
-            var pc1CreateOffer = offerPc.CreateOffer(ref RTCOfferAnswerOptions.Default);
+            var pc1CreateOffer = offerPc.CreateOffer();
             yield return pc1CreateOffer;
             Assert.False(pc1CreateOffer.IsError);
             var offerDesc = pc1CreateOffer.Desc;
@@ -119,7 +119,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return pc2SetRemoteDescription;
             Assert.False(pc2SetRemoteDescription.IsError);
 
-            var pc2CreateAnswer = answerPc.CreateAnswer(ref RTCOfferAnswerOptions.Default);
+            var pc2CreateAnswer = answerPc.CreateAnswer();
             yield return pc2CreateAnswer;
             Assert.False(pc2CreateAnswer.IsError);
             var answerDesc = pc2CreateAnswer.Desc;


### PR DESCRIPTION
from `peer_connection_interface.h`
```
    // These options are left as backwards compatibility for clients who need
    // "Plan B" semantics. Clients who have switched to "Unified Plan" semantics
    // should use the RtpTransceiver API (AddTransceiver) instead.
    //
    // offer_to_receive_X set to 1 will cause a media description to be
    // generated in the offer, even if no tracks of that type have been added.
    // Values greater than 1 are treated the same.
    //
    // If set to 0, the generated directional attribute will not include the
    // "recv" direction (meaning it will be "sendonly" or "inactive".
```

So, I use Direction property on Transceiver for changing `Send / Recv` .