### PR TITLE
chore: validate graphics format on video stream track constructor

### DIFF
--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -16,12 +16,11 @@ namespace Unity.WebRTC
 
         UnityVideoRenderer m_renderer;
 
-        private static RenderTexture CreateRenderTexture(int width, int height,
-            RenderTextureFormat format)
+        private static RenderTexture CreateRenderTexture(int width, int height, GraphicsFormat format)
         {
             // todo::(kazuki) Increase the supported formats.
-            RenderTextureFormat supportedFormat
-                = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
+            GraphicsFormat supportedFormat
+                = WebRTC.GetSupportedGraphicsFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             if (format != supportedFormat)
             {
                 throw new ArgumentException(
@@ -76,7 +75,7 @@ namespace Unity.WebRTC
             m_needFlip = true;
             var format = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
             m_sourceTexture = new Texture2D(width, height, format, TextureCreationFlags.None);
-            var renderTextureFormat = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var renderTextureFormat = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
             m_destTexture = CreateRenderTexture(m_sourceTexture.width, m_sourceTexture.height, renderTextureFormat);
 
             m_renderer = new UnityVideoRenderer(WebRTC.Context.CreateVideoRenderer(), this);
@@ -111,7 +110,7 @@ namespace Unity.WebRTC
                 UnityEngine.Graphics.Blit(m_sourceTexture, m_destTexture, WebRTC.flipMat);
             }
 
-            WebRTC.Context.Encode(self);
+            WebRTC.Context.Encode(GetSelfOrThrow());
         }
 
         /// <summary>
@@ -123,7 +122,7 @@ namespace Unity.WebRTC
         /// <param name="width"></param>
         /// <param name="height"></param>
         public VideoStreamTrack(string label, UnityEngine.RenderTexture source)
-            : this(label, source, CreateRenderTexture(source.width, source.height, source.format), source.width,
+            : this(label, source, CreateRenderTexture(source.width, source.height, source.graphicsFormat), source.width,
                 source.height)
         {
         }
@@ -131,8 +130,7 @@ namespace Unity.WebRTC
         public VideoStreamTrack(string label, UnityEngine.Texture source)
             : this(label,
                 source,
-                CreateRenderTexture(source.width, source.height,
-                    WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType)),
+                CreateRenderTexture(source.width, source.height, source.graphicsFormat),
                 source.width,
                 source.height)
         {
@@ -154,8 +152,8 @@ namespace Unity.WebRTC
         public VideoStreamTrack(string label, IntPtr texturePtr, int width, int height, GraphicsFormat format)
             : base(WebRTC.Context.CreateVideoTrack(label))
         {
-            WebRTC.Context.SetVideoEncoderParameter(self, width, height, format, texturePtr);
-            WebRTC.Context.InitializeEncoder(self);
+            WebRTC.Context.SetVideoEncoderParameter(GetSelfOrThrow(), width, height, format, texturePtr);
+            WebRTC.Context.InitializeEncoder(GetSelfOrThrow());
             tracks.Add(this);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Runtime.InteropServices;
-using UnityEngine;
-using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
@@ -412,59 +412,59 @@ namespace Unity.WebRTC
             return System.IO.Path.GetFileName(Lib);
         }
 
-        public static RenderTextureFormat GetSupportedRenderTextureFormat(UnityEngine.Rendering.GraphicsDeviceType type)
+        public static RenderTextureFormat GetSupportedRenderTextureFormat(GraphicsDeviceType type)
         {
             switch (type)
             {
-                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D11:
-                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D12:
-                case UnityEngine.Rendering.GraphicsDeviceType.Vulkan:
+                case GraphicsDeviceType.Direct3D11:
+                case GraphicsDeviceType.Direct3D12:
+                case GraphicsDeviceType.Vulkan:
                     return RenderTextureFormat.BGRA32;
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLCore:
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES2:
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3:
+                case GraphicsDeviceType.OpenGLCore:
+                case GraphicsDeviceType.OpenGLES2:
+                case GraphicsDeviceType.OpenGLES3:
                     return RenderTextureFormat.ARGB32;
-                case UnityEngine.Rendering.GraphicsDeviceType.Metal:
+                case GraphicsDeviceType.Metal:
                     return RenderTextureFormat.BGRA32;
             }
-            return RenderTextureFormat.Default;
+            throw new ArgumentException($"Graphics device type {type} not supported");
         }
 
         public static GraphicsFormat GetSupportedGraphicsFormat(GraphicsDeviceType type)
         {
             switch (type)
             {
-                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D11:
-                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D12:
+                case GraphicsDeviceType.Direct3D11:
+                case GraphicsDeviceType.Direct3D12:
                     return GraphicsFormat.B8G8R8A8_SRGB;
-                case UnityEngine.Rendering.GraphicsDeviceType.Vulkan:
+                case GraphicsDeviceType.Vulkan:
                     return GraphicsFormat.R8G8B8A8_SRGB;
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLCore:
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES2:
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3:
+                case GraphicsDeviceType.OpenGLCore:
+                case GraphicsDeviceType.OpenGLES2:
+                case GraphicsDeviceType.OpenGLES3:
                     return GraphicsFormat.R8G8B8A8_SRGB;
-                case UnityEngine.Rendering.GraphicsDeviceType.Metal:
+                case GraphicsDeviceType.Metal:
                     return GraphicsFormat.B8G8R8A8_SRGB;
             }
-            throw new ArgumentException("Graphics device type not supported");
+            throw new ArgumentException($"Graphics device type {type} not supported");
         }
 
         public static TextureFormat GetSupportedTextureFormat(GraphicsDeviceType type)
         {
             switch (type)
             {
-                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D11:
-                case UnityEngine.Rendering.GraphicsDeviceType.Direct3D12:
-                case UnityEngine.Rendering.GraphicsDeviceType.Vulkan:
+                case GraphicsDeviceType.Direct3D11:
+                case GraphicsDeviceType.Direct3D12:
+                case GraphicsDeviceType.Vulkan:
                     return TextureFormat.BGRA32;
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLCore:
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES2:
-                case UnityEngine.Rendering.GraphicsDeviceType.OpenGLES3:
+                case GraphicsDeviceType.OpenGLCore:
+                case GraphicsDeviceType.OpenGLES2:
+                case GraphicsDeviceType.OpenGLES3:
                     return TextureFormat.ARGB32;
-                case UnityEngine.Rendering.GraphicsDeviceType.Metal:
+                case GraphicsDeviceType.Metal:
                     return TextureFormat.BGRA32;
             }
-            throw new ArgumentException("Graphics device type not supported");
+            throw new ArgumentException($"Graphics device type {type} not supported");
         }
 
         internal static IEnumerable<T> Deserialize<T>(IntPtr buf, int length, Func<IntPtr, T> constructor) where T : class

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -412,6 +412,17 @@ namespace Unity.WebRTC
             return System.IO.Path.GetFileName(Lib);
         }
 
+        public static void ValidateGraphicsFormat(GraphicsFormat format)
+        {
+            // ToDo: Increase the supported formats.
+            GraphicsFormat supportedFormat = GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
+            if (format != supportedFormat)
+            {
+                throw new ArgumentException(
+                    $"This graphics format {format} is not supported for streaming, please use supportedFormat: {supportedFormat}");
+            }
+        }
+
         public static RenderTextureFormat GetSupportedRenderTextureFormat(GraphicsDeviceType type)
         {
             switch (type)

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -431,20 +431,41 @@ namespace Unity.WebRTC
 
         public static GraphicsFormat GetSupportedGraphicsFormat(GraphicsDeviceType type)
         {
-            switch (type)
+            if (QualitySettings.activeColorSpace == ColorSpace.Linear)
             {
-                case GraphicsDeviceType.Direct3D11:
-                case GraphicsDeviceType.Direct3D12:
-                    return GraphicsFormat.B8G8R8A8_SRGB;
-                case GraphicsDeviceType.Vulkan:
-                    return GraphicsFormat.R8G8B8A8_SRGB;
-                case GraphicsDeviceType.OpenGLCore:
-                case GraphicsDeviceType.OpenGLES2:
-                case GraphicsDeviceType.OpenGLES3:
-                    return GraphicsFormat.R8G8B8A8_SRGB;
-                case GraphicsDeviceType.Metal:
-                    return GraphicsFormat.B8G8R8A8_SRGB;
+                switch (type)
+                {
+                    case GraphicsDeviceType.Direct3D11:
+                    case GraphicsDeviceType.Direct3D12:
+                        return GraphicsFormat.B8G8R8A8_SRGB;
+                    case GraphicsDeviceType.Vulkan:
+                        return GraphicsFormat.R8G8B8A8_SRGB;
+                    case GraphicsDeviceType.OpenGLCore:
+                    case GraphicsDeviceType.OpenGLES2:
+                    case GraphicsDeviceType.OpenGLES3:
+                        return GraphicsFormat.R8G8B8A8_SRGB;
+                    case GraphicsDeviceType.Metal:
+                        return GraphicsFormat.B8G8R8A8_SRGB;
+                }
             }
+            else
+            {
+                switch (type)
+                {
+                    case GraphicsDeviceType.Direct3D11:
+                    case GraphicsDeviceType.Direct3D12:
+                        return GraphicsFormat.B8G8R8A8_UNorm;
+                    case GraphicsDeviceType.Vulkan:
+                        return GraphicsFormat.R8G8B8A8_UNorm;
+                    case GraphicsDeviceType.OpenGLCore:
+                    case GraphicsDeviceType.OpenGLES2:
+                    case GraphicsDeviceType.OpenGLES3:
+                        return GraphicsFormat.R8G8B8A8_UNorm;
+                    case GraphicsDeviceType.Metal:
+                        return GraphicsFormat.B8G8R8A8_UNorm;
+                }
+            }
+
             throw new ArgumentException($"Graphics device type {type} not supported");
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -425,20 +425,8 @@ namespace Unity.WebRTC
 
         public static RenderTextureFormat GetSupportedRenderTextureFormat(GraphicsDeviceType type)
         {
-            switch (type)
-            {
-                case GraphicsDeviceType.Direct3D11:
-                case GraphicsDeviceType.Direct3D12:
-                case GraphicsDeviceType.Vulkan:
-                    return RenderTextureFormat.BGRA32;
-                case GraphicsDeviceType.OpenGLCore:
-                case GraphicsDeviceType.OpenGLES2:
-                case GraphicsDeviceType.OpenGLES3:
-                    return RenderTextureFormat.ARGB32;
-                case GraphicsDeviceType.Metal:
-                    return RenderTextureFormat.BGRA32;
-            }
-            throw new ArgumentException($"Graphics device type {type} not supported");
+            var graphicsFormat = GetSupportedGraphicsFormat(type);
+            return GraphicsFormatUtility.GetRenderTextureFormat(graphicsFormat);
         }
 
         public static GraphicsFormat GetSupportedGraphicsFormat(GraphicsDeviceType type)
@@ -462,20 +450,8 @@ namespace Unity.WebRTC
 
         public static TextureFormat GetSupportedTextureFormat(GraphicsDeviceType type)
         {
-            switch (type)
-            {
-                case GraphicsDeviceType.Direct3D11:
-                case GraphicsDeviceType.Direct3D12:
-                case GraphicsDeviceType.Vulkan:
-                    return TextureFormat.BGRA32;
-                case GraphicsDeviceType.OpenGLCore:
-                case GraphicsDeviceType.OpenGLES2:
-                case GraphicsDeviceType.OpenGLES3:
-                    return TextureFormat.ARGB32;
-                case GraphicsDeviceType.Metal:
-                    return TextureFormat.BGRA32;
-            }
-            throw new ArgumentException($"Graphics device type {type} not supported");
+            var graphicsFormat = GetSupportedGraphicsFormat(type);
+            return GraphicsFormatUtility.GetTextureFormat(graphicsFormat);
         }
 
         internal static IEnumerable<T> Deserialize<T>(IntPtr buf, int length, Func<IntPtr, T> constructor) where T : class

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -24,6 +24,24 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void GraphicsFormat()
+        {
+            var graphicsFormat = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
+            var renderTextureFormat = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var textureFormat = WebRTC.GetSupportedTextureFormat(SystemInfo.graphicsDeviceType);
+
+            var rt = new RenderTexture(10, 10, 0, renderTextureFormat);
+            rt.Create();
+            Assert.That(rt.graphicsFormat, Is.EqualTo(graphicsFormat));
+
+            var tx = new Texture2D(10, 10, textureFormat, false);
+            Assert.That(tx.graphicsFormat, Is.EqualTo(graphicsFormat));
+
+            Object.DestroyImmediate(rt);
+            Object.DestroyImmediate(tx);
+        }
+
+        [Test]
         public void Construct()
         {
             var width = 256;


### PR DESCRIPTION
add validate method `ValidateGraphicsFormat` and check graphics format on video stream track constructor. 