### PR TITLE
chore: check windows architecture in build process

### DIFF
--- a/Editor/BuildProcessor.cs
+++ b/Editor/BuildProcessor.cs
@@ -58,6 +58,9 @@ namespace Unity.WebRTC.Editor
                 case BuildTarget.StandaloneOSX:
                     EnsureOSXArchitecture();
                     break;
+                case BuildTarget.StandaloneWindows:
+                    throw new BuildFailedException(
+                        "Windows 32bit(x86) architecture is not supported by WebRTC package.");
             }
         }
 


### PR DESCRIPTION
webrtc package supported only x64 architecture on windows.

Issue: https://github.com/Unity-Technologies/com.unity.webrtc/issues/307

`BuildTarget.StandaloneWindows` is windows 32bit buildtarget.
`BuildTarget.StandaloneWindows64` is windows 64bit buildtarget.