### PR TITLE
chore: internet permission for Android

### DIFF
--- a/Editor/BuildProcessor.cs
+++ b/Editor/BuildProcessor.cs
@@ -51,6 +51,7 @@ namespace Unity.WebRTC.Editor
                 case BuildTarget.Android:
                     EnsureAndroidSdkVersion();
                     EnsureAndroidArchitecture();
+                    EnsureAndroidInternetPermission();
                     break;
                 case BuildTarget.iOS:
                     EnsureIOSArchitecture();
@@ -84,6 +85,16 @@ namespace Unity.WebRTC.Editor
                 Debug.LogWarning(
                     $"WebRTC apps require a target architecture to be set {RequiredAndroidArchitectures}. " +
                     $"Currently set to {PlayerSettings.Android.targetArchitectures}");
+            }
+        }
+
+        static void EnsureAndroidInternetPermission()
+        {
+            if (!PlayerSettings.Android.forceInternetPermission)
+            {
+                Debug.LogWarning(
+                    $"WebRTC apps require a internet permission on Android devices." +
+                    "Please check the \"Internet Access\" on your Build Settings.");
             }
         }
 

--- a/WebRTC~/ProjectSettings/ProjectSettings-android-vulkan.asset
+++ b/WebRTC~/ProjectSettings/ProjectSettings-android-vulkan.asset
@@ -155,7 +155,7 @@ PlayerSettings:
   stripEngineCode: 0
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
-  ForceInternetPermission: 0
+  ForceInternetPermission: 1
   ForceSDCardPermission: 0
   CreateWallpaper: 0
   APKExpansionFiles: 0

--- a/WebRTC~/ProjectSettings/ProjectSettings.asset
+++ b/WebRTC~/ProjectSettings/ProjectSettings.asset
@@ -155,7 +155,7 @@ PlayerSettings:
   stripEngineCode: 0
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
-  ForceInternetPermission: 0
+  ForceInternetPermission: 1
   ForceSDCardPermission: 0
   CreateWallpaper: 0
   APKExpansionFiles: 0


### PR DESCRIPTION
When `Internet Access` in Build Settings for Android is set `Auto`, WebRTC apps don't work.

![image](https://user-images.githubusercontent.com/1132081/115646379-0076be00-a35d-11eb-9151-ec37b3ab9161.png)

This change fixes the build process to output a warning log when `Internet Access` is not set `Required`.