### PR TITLE
fix: Fix TrickleIce sample

### DIFF
--- a/Samples~/TrickleIce/TrickleIceSample.cs
+++ b/Samples~/TrickleIce/TrickleIceSample.cs
@@ -27,7 +27,7 @@ class TrickleIceSample : MonoBehaviour
 #pragma warning restore 0649
 
     private RTCPeerConnection _pc1;
-
+    private RTCRtpTransceiver _transceiver;
 
     private float beginTime = 0f;
     private Dictionary<GameObject, RTCIceServer> iceServers
@@ -175,7 +175,7 @@ class TrickleIceSample : MonoBehaviour
         _pc1 = new RTCPeerConnection(ref configuration);
         _pc1.OnIceCandidate = OnIceCandidate;
         _pc1.OnIceGatheringStateChange = OnIceGatheringStateChange;
-
+        _transceiver = _pc1.AddTransceiver(TrackKind.Video);
         StartCoroutine(CreateOffer(_pc1));
     }
 
@@ -243,6 +243,7 @@ class TrickleIceSample : MonoBehaviour
             }
         }
 
+        _transceiver.Dispose();
         _pc1.Close();
         _pc1 = null;
         gatherCandidatesButton.interactable = true;


### PR DESCRIPTION
Changing arguments of the `CreateOffer` method that affected the behaviour of the `TrickleIce` sample.
The process of gathering ICE candidate has not occurred after calling `SetLocalDescription` caused by previous changes.