### PR TITLE
chore: Upgrade XCode version 12.2 for CI

### DIFF
--- a/.yamato/upm-ci-libwebrtc.yml
+++ b/.yamato/upm-ci-libwebrtc.yml
@@ -8,7 +8,7 @@ platforms:
     build_command: BuildScripts~/build_libwebrtc_win.cmd
   - name: macos
     type: Unity::VM::osx
-    image: slough-ops/macos-10.14-xcode:stable
+    image: slough-ops/macos-10.14-xcode:latest
     flavor: m1.mac  
     build_command: BuildScripts~/build_libwebrtc_macos.sh
   - name: linux
@@ -23,7 +23,7 @@ platforms:
     build_command: BuildScripts~/build_libwebrtc_android.sh
   - name: ios
     type: Unity::VM::osx
-    image: slough-ops/macos-10.14-xcode:stable
+    image: slough-ops/macos-10.14-xcode:latest
     flavor: m1.mac  
     build_command: BuildScripts~/build_libwebrtc_ios.sh
 projects:

--- a/.yamato/upm-ci-libwebrtc.yml
+++ b/.yamato/upm-ci-libwebrtc.yml
@@ -8,7 +8,7 @@ platforms:
     build_command: BuildScripts~/build_libwebrtc_win.cmd
   - name: macos
     type: Unity::VM::osx
-    image: slough-ops/macos-10.14-xcode:latest
+    image: package-ci/mac:latest
     flavor: m1.mac  
     build_command: BuildScripts~/build_libwebrtc_macos.sh
   - name: linux
@@ -23,7 +23,7 @@ platforms:
     build_command: BuildScripts~/build_libwebrtc_android.sh
   - name: ios
     type: Unity::VM::osx
-    image: slough-ops/macos-10.14-xcode:latest
+    image: package-ci/mac:latest
     flavor: m1.mac  
     build_command: BuildScripts~/build_libwebrtc_ios.sh
 projects:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -326,7 +326,7 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 {% for editor in editors %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-{% if target.name != "macos" OR param.platform != "standalone" -%}
+{% if target.name != "macos" or param.platform != "standalone" -%}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -324,8 +324,8 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 
 {% for target in test_targets %}
 {% for editor in editors %}
-{% if target.name != "macos" -%}
 {% for param in target.test_params %}
+{% if target.name != "macos" OR param.platform != "standalone" -%}
 {% for gfx_type in target.gfx_types %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
@@ -398,8 +398,8 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endfor %}
-{% endfor %}
 {% endif -%}
+{% endfor %}
 {% endfor %}
 {% endfor %}
 

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -26,8 +26,8 @@ platforms:
   - name: macos
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode:latest
-    gpu_image: slough-ops/macos-10.14-xcode:latest
+    image: package-ci/mac:latest
+    gpu_image: package-ci/mac:latest
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_mac.sh
     test_command: BuildScripts~/test_plugin_mac.sh
@@ -35,8 +35,8 @@ platforms:
   - name: ios
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode:latest
-    gpu_image: slough-ops/macos-10.14-xcode:latest
+    image: package-ci/mac:latest
+    gpu_image: package-ci/mac:latest
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_ios.sh
     test_command: BuildScripts~/test_plugin_ios.sh
@@ -134,7 +134,7 @@ test_targets:
         platform: standalone
   - name: macos
     type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode:latest
+    image: package-ci/mac:latest
     flavor: m1.mac
     gfx_types:
       - name: metal

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -35,8 +35,8 @@ platforms:
   - name: ios
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
-    image: package-ci/mac:latest
-    gpu_image: package-ci/mac:latest
+    image: slough-ops/macos-10.14-xcode:latest
+    gpu_image: slough-ops/macos-10.14-xcode:latest
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_ios.sh
     test_command: BuildScripts~/test_plugin_ios.sh

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -326,7 +326,7 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 {% for editor in editors %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-{% if target.name != "macos" or param.platform != "standalone" %}
+{% if target.name != "macos" %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -35,8 +35,8 @@ platforms:
   - name: ios
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode:latest
-    gpu_image: slough-ops/macos-10.14-xcode:latest
+    image: package-ci/mac:latest
+    gpu_image: package-ci/mac:latest
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_ios.sh
     test_command: BuildScripts~/test_plugin_ios.sh

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -224,7 +224,7 @@ build_{{ package.name }}_{{ editor.version }}_ios:
   name : Build {{ package.packagename }} with {{ editor.version }} for ios device
   agent:
     type: Unity::VM::osx
-    image: mobile/macos-10.13-testing:stable
+    image: package-ci/mac:latest
     flavor: b1.large
   commands:
     - |
@@ -271,7 +271,7 @@ build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   name : Build {{ package.packagename }} with {{ editor.version }} for android device {{ target.name }}
   agent:
     type: Unity::VM::osx
-    image: mobile/macos-10.13-testing:stable
+    image: package-ci/mac:latest
     flavor: b1.xlarge
   commands:
     - |

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -325,8 +325,8 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 {% for target in test_targets %}
 {% for editor in editors %}
 {% for param in target.test_params %}
-{% if target.name != "macos" OR param.platform != "standalone" -%}
 {% for gfx_type in target.gfx_types %}
+{% if target.name != "macos" OR param.platform != "standalone" -%}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:
@@ -342,12 +342,8 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
-{% endfor %}
-{% endfor %}
 {% else -%}
 
-{% for param in target.test_params %}
-{% for gfx_type in target.gfx_types %}
 build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Build {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:
@@ -397,8 +393,8 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
         - "upm-ci~/test-results/**"
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endfor %}
 {% endif -%}
+{% endfor %}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -390,9 +390,6 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
     EDITOR_VERSION: {{ editor.version }}
     EXTRA_EDITOR_ARG: {{ gfx_type.extra-editor-arg }}
   commands:
-    - |
-      find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
-      cp -rf upm-ci~/package/Runtime/Plugins Runtime/
     - BuildScripts~/test_package_mac.sh
   artifacts:
     {{ package.name }}_{{ param.backend }}_{{ editor.version }}_{{ target.name }}_test_results: 

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -26,8 +26,8 @@ platforms:
   - name: macos
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode
-    gpu_image: slough-ops/macos-10.14-xcode
+    image: slough-ops/macos-10.14-xcode:latest
+    gpu_image: slough-ops/macos-10.14-xcode:latest
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_mac.sh
     test_command: BuildScripts~/test_plugin_mac.sh
@@ -35,8 +35,8 @@ platforms:
   - name: ios
     type: Unity::metal::macmini
     gpu_type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode
-    gpu_image: slough-ops/macos-10.14-xcode
+    image: slough-ops/macos-10.14-xcode:latest
+    gpu_image: slough-ops/macos-10.14-xcode:latest
     flavor: m1.mac
     build_command: BuildScripts~/build_plugin_ios.sh
     test_command: BuildScripts~/test_plugin_ios.sh
@@ -134,7 +134,7 @@ test_targets:
         platform: standalone
   - name: macos
     type: Unity::metal::macmini
-    image: slough-ops/macos-10.14-xcode
+    image: slough-ops/macos-10.14-xcode:latest
     flavor: m1.mac
     gfx_types:
       - name: metal

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -399,7 +399,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
       paths:
         - "upm-ci~/test-results/**"
   dependencies:
-    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endfor %}
 {% endfor %}
 {% endif -%}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -326,7 +326,7 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 {% for editor in editors %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-{% if target.name != "macos" or param.platform != "standalone" -%}
+{% if target.name != "macos" or param.platform != "standalone" %}
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:
@@ -342,7 +342,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
-{% else -%}
+{% else %}
 
 build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Build {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
@@ -393,7 +393,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
         - "upm-ci~/test-results/**"
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endif -%}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -141,12 +141,16 @@ test_targets:
         extra-editor-arg: force-metal
     test_params:
       - backend: mono
+        additional_component_arg: StandaloneSupport-Mono
         platform: editmode
       - backend: mono
+        additional_component_arg: StandaloneSupport-Mono
         platform: playmode
       - backend: mono
+        additional_component_arg: StandaloneSupport-Mono
         platform: standalone
       - backend: il2cpp
+        additional_component_arg: StandaloneSupport-IL2CPP
         platform: standalone
 
 test_targets_android:
@@ -344,6 +348,31 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
 
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
+build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
+  name : Build {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
+  agent:
+    type: Unity::VM::osx
+    image: package-ci/mac:latest
+    flavor: m1.mac
+  commands:
+    - |
+      find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
+      cp -rf upm-ci~/package/Runtime/Plugins Runtime/
+    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - unity-downloader-cli -c Editor -c {{ param.additional_component_arg }} -u {{ editor.version }} --fast -w
+    - curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr --output utr
+    - chmod +x ./utr
+    - ./utr --suite=playmode --platform=StandaloneOSX --editor-location=.Editor --testproject=WebRTC~ --player-save-path=build/players --architecture=x64 --artifacts_path=build/logs --scripting-backend={{ param.backend }} --build-only
+  artifacts:
+    players:
+      paths:
+        - "build/players/**"
+    logs:
+      paths:
+        - "build/logs/**"
+  dependencies:
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
+
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:
@@ -351,15 +380,15 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
     image: {{ target.image }}
     flavor: {{ target.flavor }}
   variables:
-      TEMPLATE_FILE: BuildScripts~/template/remote.sh.template
-      PACKAGE_DIR: com.unity.webrtc
-      TEST_PROJECT_DIR: com.unity.webrtc/WebRTC~
-      TEST_RESULT_DIR: upm-ci~/test-results/
-      TEST_TARGET: {{ target.name }}
-      TEST_PLATFORM: {{ param.platform }}
-      SCRIPTING_BACKEND: {{ param.backend }}  
-      EDITOR_VERSION: {{ editor.version }}
-      EXTRA_EDITOR_ARG: {{ gfx_type.extra-editor-arg }}
+    TEMPLATE_FILE: BuildScripts~/template/remote.sh.template
+    PACKAGE_DIR: com.unity.webrtc
+    PLAYER_LOAD_PATH: build/players
+    TEST_RESULT_DIR: upm-ci~/test-results/
+    TEST_TARGET: {{ target.name }}
+    TEST_PLATFORM: {{ param.platform }}
+    SCRIPTING_BACKEND: {{ param.backend }}  
+    EDITOR_VERSION: {{ editor.version }}
+    EXTRA_EDITOR_ARG: {{ gfx_type.extra-editor-arg }}
   commands:
     - |
       find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
@@ -370,7 +399,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
       paths:
         - "upm-ci~/test-results/**"
   dependencies:
-    - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endfor %}
 {% endfor %}
 {% endif -%}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -342,7 +342,8 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
-{% else %}
+
+{% elsif param.platform == "standalone" %}
 
 build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Build {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
@@ -393,6 +394,37 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
         - "upm-ci~/test-results/**"
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
+
+{% else %}
+
+test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
+  name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
+  agent:
+    type: {{ target.type }}
+    image: {{ target.image }}
+    flavor: {{ target.flavor }}
+  variables:
+      TEMPLATE_FILE: BuildScripts~/template/remote.sh.template
+      PACKAGE_DIR: com.unity.webrtc
+      TEST_PROJECT_DIR: com.unity.webrtc/WebRTC~
+      TEST_RESULT_DIR: upm-ci~/test-results/
+      TEST_TARGET: {{ target.name }}
+      TEST_PLATFORM: {{ param.platform }}
+      SCRIPTING_BACKEND: {{ param.backend }}  
+      EDITOR_VERSION: {{ editor.version }}
+      EXTRA_EDITOR_ARG: {{ gfx_type.extra-editor-arg }}
+  commands:
+    - |
+      find upm-ci~/packages/ -name "*.tgz" | xargs -I file tar xvf file -C upm-ci~
+      cp -rf upm-ci~/package/Runtime/Plugins Runtime/
+    - BuildScripts~/test_package_mac.sh
+  artifacts:
+    {{ package.name }}_{{ param.backend }}_{{ editor.version }}_{{ target.name }}_test_results: 
+      paths:
+        - "upm-ci~/test-results/**"
+  dependencies:
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
+
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/BuildScripts~/build_plugin_ios.sh
+++ b/BuildScripts~/build_plugin_ios.sh
@@ -23,6 +23,7 @@ cmake . \
   -B build
 
 xcodebuild -sdk iphonesimulator \
+  -arch "x86_64" \
   -project build/webrtc.xcodeproj \
   -target WebRTCPlugin \
   -configuration Release

--- a/BuildScripts~/template/remote.sh.template
+++ b/BuildScripts~/template/remote.sh.template
@@ -58,7 +58,8 @@ unity-downloader-cli \
   --suite=${suite} \
   --platform=${platform} \
   --player-load-path=${PLAYER_LOAD_PATH} \
-  --artifacts_path=${ARTIFACT_DIR}
+  --artifacts_path=${ARTIFACT_DIR} \
+  --player-connection-ip=${BOKKEN_DEVICE_IP}
 result=$?
 
 # return exit-code

--- a/BuildScripts~/template/remote.sh.template
+++ b/BuildScripts~/template/remote.sh.template
@@ -47,22 +47,18 @@ curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-stand
 chmod +x ./utr
 
 # download unity editor
-unity-downloader-cli          \
-  -u ${EDITOR_VERSION}        \
+unity-downloader-cli \
+  -u ${EDITOR_VERSION} \
   ${additional_component_arg} \
-  --wait                      \
+  --wait \
   --published
 
 # run utr
-./utr                                                       \
-  --suite=${suite}                                          \
-  --platform=${platform}                                    \
-  --scripting-backend=${SCRIPTING_BACKEND}                  \
-  --extra-editor-arg="-${EXTRA_EDITOR_ARG}"                 \
-  --testproject=${HOME}/${TEST_PROJECT_DIR}                 \
-  --editor-location=${HOME}/.Editor                         \
-  --artifacts_path=${ARTIFACT_DIR}                          \
-  --architecture=${architecture}
+./utr \
+  --suite=${suite} \
+  --platform=${platform} \
+  --player-load-path=${PLAYER_LOAD_PATH} \
+  --artifacts_path=${ARTIFACT_DIR}
 result=$?
 
 # return exit-code

--- a/BuildScripts~/template/remote.sh.template
+++ b/BuildScripts~/template/remote.sh.template
@@ -13,17 +13,22 @@ platform=Editor
 architecture=x64
 suite=playmode
 
-if [ ${TEST_PLATFORM} = "standalone" ]; then
-  if [ ${TEST_TARGET} = "ios" ]; then
+if [ ${TEST_PLATFORM} = "standalone" ]
+then
+  if [ ${TEST_TARGET} = "ios" ]
+  then
     additional_component_arg="-c editor -c iOS"
     architecture=arm64
     platform=iOS
-  elif [ ${TEST_TARGET} = "iossimulator" ]; then
+  elif [ ${TEST_TARGET} = "iossimulator" ]
+  then
     additional_component_arg="-c editor -c iOS"
     platform=iOS
-  elif [ ${TEST_TARGET} = "macos" ]; then
+  elif [ ${TEST_TARGET} = "macos" ]
+  then
     platform=StandaloneOSX
-    if [ ${SCRIPTING_BACKEND} = "il2cpp" ]; then
+    if [ ${SCRIPTING_BACKEND} = "il2cpp" ]
+    then
       additional_component_arg="-c editor -c StandaloneSupport-IL2CPP"
     else
       additional_component_arg="-c editor -c StandaloneSupport-Mono"
@@ -31,7 +36,8 @@ if [ ${TEST_PLATFORM} = "standalone" ]; then
   fi
 fi
 
-if [ ${TEST_PLATFORM} = "editmode" ]; then
+if [ ${TEST_PLATFORM} = "editmode" ]
+then
   suite=editor
 fi
 
@@ -46,21 +52,36 @@ curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-stand
   --output utr
 chmod +x ./utr
 
-# download unity editor
-unity-downloader-cli \
-  -u ${EDITOR_VERSION} \
-  ${additional_component_arg} \
-  --wait \
-  --published
+if [ ${TEST_PLATFORM} = "standalone" ]
+then
+  # run utr
+  ./utr \
+    --suite=${suite} \
+    --platform=${platform} \
+    --player-load-path=${PLAYER_LOAD_PATH} \
+    --artifacts_path=${ARTIFACT_DIR} \
+    --player-connection-ip=${BOKKEN_DEVICE_IP}
+  result=$?
+else
+  # download unity editor
+  unity-downloader-cli \
+    -u ${EDITOR_VERSION} \
+    ${additional_component_arg} \
+    --wait \
+    --published
 
-# run utr
-./utr \
-  --suite=${suite} \
-  --platform=${platform} \
-  --player-load-path=${PLAYER_LOAD_PATH} \
-  --artifacts_path=${ARTIFACT_DIR} \
-  --player-connection-ip=${BOKKEN_DEVICE_IP}
-result=$?
+  # run utr
+  ./utr \
+    --suite=${suite} \
+    --platform=${platform} \
+    --scripting-backend=${SCRIPTING_BACKEND} \
+    --extra-editor-arg="-${EXTRA_EDITOR_ARG}" \
+    --testproject=${HOME}/${TEST_PROJECT_DIR} \
+    --editor-location=${HOME}/.Editor \
+    --artifacts_path=${ARTIFACT_DIR} \
+    --architecture=${architecture}
+  result=$?
+fi
 
 # return exit-code
 exit $result

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -40,9 +40,13 @@ scp -i ${IDENTITY} -r ~/remote.sh bokken@${BOKKEN_DEVICE_IP}:~/remote.sh
 # copy build player
 scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/
 
+set +e
+
 # run remote.sh on the remote machine
 ssh -i ${IDENTITY} bokken@${BOKKEN_DEVICE_IP} ~/remote.sh
 result=$?
+
+set -e
 
 # copy artifacts from the remote machine
 mkdir -p ${TEST_RESULT_DIR}

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -43,9 +43,12 @@ scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/
 # run remote.sh on the remote machine
 ssh -i ${IDENTITY} bokken@${BOKKEN_DEVICE_IP} ~/remote.sh
 result=$?
+
+# copy artifacts from the remote machine
+mkdir -p ${TEST_RESULT_DIR}
+scp -i ${IDENTITY} -r bokken@${BOKKEN_DEVICE_IP}:~/test-results ${TEST_RESULT_DIR}
+
+# return ssh commend results 
 if [ $result -ne 0 ]; then
   exit $result
 fi
-
-mkdir -p ${TEST_RESULT_DIR}
-scp -i ${IDENTITY} -r bokken@${BOKKEN_DEVICE_IP}:~/test-results ${TEST_RESULT_DIR}

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -39,7 +39,10 @@ chmod +x ~/remote.sh
 scp -i ${IDENTITY} -r ~/remote.sh bokken@${BOKKEN_DEVICE_IP}:~/remote.sh
 
 # copy build player
-scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/
+if [ ${TEST_PLATFORM} = "standalone" ]
+then
+  scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/
+fi
 
 set +e
 

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -25,6 +25,7 @@ brew install gettext
 envsubst ' \
   $SCRIPTING_BACKEND \
   $EXTRA_EDITOR_ARG \
+  $PLAYER_LOAD_PATH \
   $TEST_PROJECT_DIR \
   $TEST_TARGET \
   $TEST_PLATFORM \
@@ -38,6 +39,8 @@ scp -i ${IDENTITY} -r ${YAMATO_SOURCE_DIR} bokken@${BOKKEN_DEVICE_IP}:~/${PACKAG
 
 # copy shell script to remote machine
 scp -i ${IDENTITY} -r ~/remote.sh bokken@${BOKKEN_DEVICE_IP}:~/remote.sh
+
+scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/build
 
 # run remote.sh on the remote machine
 ssh -i ${IDENTITY} bokken@${BOKKEN_DEVICE_IP} ~/remote.sh

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -34,13 +34,11 @@ envsubst ' \
   > ~/remote.sh
 chmod +x ~/remote.sh
 
-# copy package to remote machine
-scp -i ${IDENTITY} -r ${YAMATO_SOURCE_DIR} bokken@${BOKKEN_DEVICE_IP}:~/${PACKAGE_DIR}
-
 # copy shell script to remote machine
 scp -i ${IDENTITY} -r ~/remote.sh bokken@${BOKKEN_DEVICE_IP}:~/remote.sh
 
-scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/build
+# copy build player
+scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/
 
 # run remote.sh on the remote machine
 ssh -i ${IDENTITY} bokken@${BOKKEN_DEVICE_IP} ~/remote.sh

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -23,6 +23,7 @@ brew install gettext
 
 # render template
 envsubst ' \
+  $BOKKEN_DEVICE_IP \
   $SCRIPTING_BACKEND \
   $EXTRA_EDITOR_ARG \
   $PLAYER_LOAD_PATH \

--- a/BuildScripts~/test_package_mac.sh
+++ b/BuildScripts~/test_package_mac.sh
@@ -38,10 +38,13 @@ chmod +x ~/remote.sh
 # copy shell script to remote machine
 scp -i ${IDENTITY} -r ~/remote.sh bokken@${BOKKEN_DEVICE_IP}:~/remote.sh
 
-# copy build player
 if [ ${TEST_PLATFORM} = "standalone" ]
 then
+  # copy build player to remote machine
   scp -i ${IDENTITY} -r build bokken@${BOKKEN_DEVICE_IP}:~/
+else
+  # copy package to remote machine
+  scp -i ${IDENTITY} -r ${YAMATO_SOURCE_DIR} bokken@${BOKKEN_DEVICE_IP}:~/${PACKAGE_DIR}  
 fi
 
 set +e


### PR DESCRIPTION
This pull request updates the macos image to upgrade XCode version 12.2.
Since XCode 12.2, we can build and test for Apple Silicon. Apple Silicon will be supported near future.