### PR TITLE
fix: Video decoder support on DirectX12

### DIFF
--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -968,11 +968,14 @@ namespace Unity.WebRTC
 
         public static void UpdateRendererTexture(IntPtr callback, Texture texture, uint rendererId)
         {
+#if !UNITY_2020_1_OR_NEWER
             if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D12)
             {
                 throw new NotSupportedException(
-                    "CommandBuffer.IssuePluginCustomTextureUpdateV2 method is Direct3D12 is not supported ");
+                    "CommandBuffer.IssuePluginCustomTextureUpdateV2 method is not supported " +
+                    "when using Direct3D12 on Unity2019 or older.");
             }
+#endif
             _command.IssuePluginCustomTextureUpdateV2(callback, texture, rendererId);
             Graphics.ExecuteCommandBuffer(_command);
             _command.Clear();

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -8,7 +8,7 @@ namespace Unity.WebRTC.RuntimeTest
     {
         public const string UnsupportedHardwareForHardwareCodec = "IgnoreUnsupportedHardwareForHardwareCodec";
         public const string UnsupportedReceiveVideoOnHardware = "IgnoreUnsupportedReceiveVideoOnHardware";
-        public const string Direct3D12 = "IgnoreDirect3D12";
+        public const string UnsupportedPlatformVideoDecoder = "IgnoreUnsupportedPlatformVideoDecoder";
 
         [RuntimeInitializeOnLoadMethod]
         static void OnLoad()
@@ -21,8 +21,10 @@ namespace Unity.WebRTC.RuntimeTest
             ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedReceiveVideoOnHardware,
                 ignoreReceiveVideoTest);
 
-            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(Direct3D12,
+#if !UNITY_2020_1_OR_NEWER
+            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedPlatformVideoDecoder,
                 SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D12);
+#endif
         }
     }
 }

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -436,7 +436,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest]
-        [ConditionalIgnore(ConditionalIgnore.Direct3D12,
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoDecoderMethods.UpdateRendererTexture is not supported on Direct3D12.")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
         public IEnumerator CallVideoDecoderMethods()

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -70,7 +70,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        [ConditionalIgnore(ConditionalIgnore.Direct3D12,
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoStreamTrack.UpdateReceiveTexture is not supported on Direct3D12")]
         public IEnumerator VideoReceive()
         {


### PR DESCRIPTION
Since Unity2020 `CommandBuffer.IssuePluginCustomTextureUpdateV2` API is supported on DX12, so changed the condition in the the `VideoDecoderMethods` class.