### PR TITLE
fix: Change public to internal to fix scripting API docs

### DIFF
--- a/Samples~/Scripts/BackButton.cs
+++ b/Samples~/Scripts/BackButton.cs
@@ -3,7 +3,7 @@ using UnityEngine.SceneManagement;
 
 namespace Unity.WebRTC.Samples
 {
-    public class BackButton : MonoBehaviour
+    internal class BackButton : MonoBehaviour
     {
         [SerializeField]
         GameObject m_BackButton;

--- a/Samples~/Scripts/SceneSelectUI.cs
+++ b/Samples~/Scripts/SceneSelectUI.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 
 namespace Unity.WebRTC.Samples
 {
-    public static class WebRTCSettings
+    internal static class WebRTCSettings
     {
         private static bool s_enableHWCodec = false;
         private static bool s_limitTextureSize = true;
@@ -27,7 +27,7 @@ namespace Unity.WebRTC.Samples
         }
     }
 
-    public class SceneSelectUI : MonoBehaviour
+    internal class SceneSelectUI : MonoBehaviour
     {
         [SerializeField] private Toggle toggleEnableHWCodec;
         [SerializeField] private Toggle toggleLimitTextureSize;


### PR DESCRIPTION
Remove unused APIs from Scripting API of the package documents.
![image](https://user-images.githubusercontent.com/1132081/118101746-e3d91d80-b412-11eb-848f-68e5f8a26cd3.png)
