### PR TITLE
chore: Fix setting for the Android auto testing on Yamato CI

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -298,9 +298,9 @@ build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   name: Test {{ package.packagename }} with {{ editor.version }} on android device {{ target.name }}
   agent:
-    type: Unity::mobile::shield
-    image: mobile/android-execution-base:stable
-    flavor: b1.medium
+    type: Unity::mobile::android
+    image: mobile/android-execution-r19:stable
+    flavor: b1.large
   skip_checkout: true
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -305,15 +305,9 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}
   commands:
-    - |
-       # Download standalone UnityTestRunner
-       curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr.bat --output utr.bat
-       # Set the IP of the device. In case device gets lost, UTR will try to recconect to ANDROID_DEVICE_CONNECTION
+      -  command: curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+      -  command: |5-
        set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-       # Establish an ADB connection with the device
-       start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-       # List the connected devices
-       start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
        ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
   artifacts:
     logs:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -305,8 +305,8 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}
   commands:
-    - command: curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-    - command: |5-
+    - |
+      curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
   artifacts:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -298,17 +298,26 @@ build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
 test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   name: Test {{ package.packagename }} with {{ editor.version }} on android device {{ target.name }}
   agent:
-    type: Unity::mobile::android
-    image: mobile/android-execution-r19:stable
-    flavor: b1.large
+    type: Unity::mobile::shield
+    image: mobile/android-execution-base:stable
+    flavor: b1.medium
   skip_checkout: true
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}
   commands:
+    - wget http://artifactory-slo.bf.unity3d.com/artifactory/mobile-generic/android/ADBKeys.zip!/adbkey.pub -O %USERPROFILE%/.android/adbkey.pub
+    - wget http://artifactory-slo.bf.unity3d.com/artifactory/mobile-generic/android/ADBKeys.zip!/adbkey -O %USERPROFILE%/.android/adbkey
     - |
-      curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
+       # Download standalone UnityTestRunner
+       curl -s https://artifactory.internal.unity3d.com/core-automation/tools/utr-standalone/utr.bat --output utr.bat
+       # Set the IP of the device. In case device gets lost, UTR will try to recconect to ANDROID_DEVICE_CONNECTION
+       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+       # Establish an ADB connection with the device
+       start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+       # List the connected devices
+       start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+       NetSh Advfirewall set allprofiles state off
+       ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
   artifacts:
     logs:
       paths:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -305,10 +305,10 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}
   commands:
-      -  command: curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-      -  command: |5-
-       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-       ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
+    -  command: curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    -  command: |5-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
   artifacts:
     logs:
       paths:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -305,8 +305,8 @@ test_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}
   commands:
-    -  command: curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-    -  command: |5-
+    - command: curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+    - command: |5-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       ./utr --suite=playmode --platform=android --player-load-path=build/players --artifacts_path=build/test-results
   artifacts:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -476,8 +476,10 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% for target in test_targets %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-{% if target.is_gpu == "true" or target.name == "macos" -%}
+{% if target.is_gpu == "true" or target.name == "macos" %}
+{% if target.name != "ios" %} # todo(kazuki): workaround
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
+{% endif -%}
 {% endif -%}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
- Changed ADB keys.
- Remove auto testing for iOS platform temporarily 