### PR TITLE
Help Windows devs save major debugging time with first time builds

### DIFF
--- a/Plugin~/README.md
+++ b/Plugin~/README.md
@@ -15,6 +15,8 @@ On windows, [chocolatey](https://chocolatey.org/) is used to install.
 choco install cuda --version=10.1
 
 # Install Windows SDK
+# WARNING: If you have versions of Windows SDK earlier than Version 1809,
+# compiling the plugin will fail. Make sure to uninstall earlier versions.
 choco install -y vcredist2010 vcredist2013 vcredist140 windows-sdk-10-version-1809-all
 
 # Install Vulkan


### PR DESCRIPTION
This PR relates to this issue: https://github.com/Unity-Technologies/com.unity.webrtc/issues/434

A Windows developer's first time build will fail if they have older versions of Windows SDK installed. However the C++ compiler is incredibly vague, and debugging the issue can take days to figure out. I have added a warning to `README.md` to prevent this.