### PR TITLE
chore: remove label argument from MediaStream/MediaStreamTrack

### DIFF
--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -4,11 +4,11 @@ namespace Unity.WebRTC
 {
     public class AudioStreamTrack : MediaStreamTrack
     {
-        public AudioStreamTrack(string label) : base(WebRTC.Context.CreateAudioTrack(label))
+        public AudioStreamTrack() : this(WebRTC.Context.CreateAudioTrack(Guid.NewGuid().ToString()))
         {
         }
 
-        public AudioStreamTrack(IntPtr sourceTrack) : base(sourceTrack)
+        internal AudioStreamTrack(IntPtr sourceTrack) : base(sourceTrack)
         {
         }
     }
@@ -17,12 +17,12 @@ namespace Unity.WebRTC
     {
         private static bool started;
 
-        public static MediaStream CaptureStream(string streamlabel = "audiostream", string label="audio")
+        public static MediaStream CaptureStream()
         {
             started = true;
 
-            var stream = new MediaStream(WebRTC.Context.CreateMediaStream(streamlabel));
-            var track = new AudioStreamTrack(WebRTC.Context.CreateAudioTrack(label));
+            var stream = new MediaStream();
+            var track = new AudioStreamTrack();
             stream.AddTrack(track);
             return stream;
         }

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -24,8 +24,8 @@ namespace Unity.WebRTC
             return tex;
         }
 
-        internal VideoStreamTrack(string label, Texture source, RenderTexture dest, int width, int height)
-            : this(label, dest.GetNativeTexturePtr(), width, height, source.graphicsFormat)
+        internal VideoStreamTrack(Texture source, RenderTexture dest, int width, int height)
+            : this(dest.GetNativeTexturePtr(), width, height, source.graphicsFormat)
         {
             m_needFlip = true;
             m_sourceTexture = source;
@@ -107,11 +107,9 @@ namespace Unity.WebRTC
         /// Creates a new VideoStream object.
         /// The track is created with a `source`.
         /// </summary>
-        /// <param name="label"></param>
         /// <param name="source"></param>
-        public VideoStreamTrack(string label, Texture source)
-            : this(label,
-                source,
+        public VideoStreamTrack(Texture source)
+            : this(source,
                 CreateRenderTexture(source.width, source.height),
                 source.width,
                 source.height)
@@ -126,13 +124,12 @@ namespace Unity.WebRTC
         ///
         /// See Also: Texture.GetNativeTexturePtr
         /// </summary>
-        /// <param name="label"></param>
         /// <param name="texturePtr"></param>
         /// <param name="width"></param>
         /// <param name="height"></param>
         /// <param name="format"></param>
-        public VideoStreamTrack(string label, IntPtr texturePtr, int width, int height, GraphicsFormat format)
-            : base(WebRTC.Context.CreateVideoTrack(label))
+        public VideoStreamTrack(IntPtr texturePtr, int width, int height, GraphicsFormat format)
+            : base(WebRTC.Context.CreateVideoTrack(Guid.NewGuid().ToString()))
         {
             WebRTC.ValidateTextureSize(width, height, Application.platform, WebRTC.GetEncoderType());
             WebRTC.ValidateGraphicsFormat(format);
@@ -210,14 +207,14 @@ namespace Unity.WebRTC
             var rt = new UnityEngine.RenderTexture(width, height, depthValue, format);
             rt.Create();
             cam.targetTexture = rt;
-            return new VideoStreamTrack(cam.name, rt);
+            return new VideoStreamTrack(rt);
         }
 
 
         public static MediaStream CaptureStream(this Camera cam, int width, int height, int bitrate,
             RenderTextureDepth depth = RenderTextureDepth.DEPTH_24)
         {
-            var stream = new MediaStream(WebRTC.Context.CreateMediaStream("videostream"));
+            var stream = new MediaStream();
             var track = cam.CaptureStreamTrack(width, height, bitrate, depth);
             stream.AddTrack(track);
             return stream;

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -231,7 +231,7 @@ class VideoReceiveSample : MonoBehaviour
         webCamTexture.Play();
         yield return new WaitUntil(() => webCamTexture.didUpdateThisFrame);
 
-        videoStreamTrack = new VideoStreamTrack("video", webCamTexture);
+        videoStreamTrack = new VideoStreamTrack(webCamTexture);
         sourceImage.texture = webCamTexture;
     }
 

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -73,6 +73,18 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("Context")]
+        public void CreateAndDeleteAudioTrack()
+        {
+            var value = NativeMethods.GetHardwareEncoderSupport();
+            var context = Context.Create(
+                encoderType: value ? EncoderType.Hardware : EncoderType.Software);
+            var track = context.CreateAudioTrack("audio");
+            context.DeleteMediaStreamTrack(track);
+            context.Dispose();
+        }
+
+        [Test]
+        [Category("Context")]
         public void CreateAndDeleteVideoTrack()
         {
             var value = NativeMethods.GetHardwareEncoderSupport();

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -34,6 +34,17 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [Category("MediaStream")]
+        public void EqualId()
+        {
+            var guid = Guid.NewGuid().ToString();
+            var stream = new MediaStream(WebRTC.Context.CreateMediaStream(guid));
+            Assert.That(stream, Is.Not.Null);
+            Assert.That(stream.Id, Is.EqualTo(guid));
+            stream.Dispose();
+        }
+
+        [Test]
+        [Category("MediaStream")]
         public void AccessAfterDisposed()
         {
             var stream = new MediaStream();

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -64,7 +64,7 @@ namespace Unity.WebRTC.RuntimeTest
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
             var stream = new MediaStream();
-            var track = new VideoStreamTrack("video", rt);
+            var track = new VideoStreamTrack(rt);
 
             // wait for the end of the initialization for encoder on the render thread.
             yield return 0;
@@ -88,7 +88,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void AddAndRemoveAudioStreamTrack()
         {
             var stream = new MediaStream();
-            var track = new AudioStreamTrack("audio");
+            var track = new AudioStreamTrack();
             Assert.That(TrackKind.Audio, Is.EqualTo(track.Kind));
             Assert.That(stream.GetAudioTracks(), Has.Count.EqualTo(0));
             Assert.That(stream.AddTrack(track), Is.True);
@@ -351,7 +351,7 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
-            var track2 = new VideoStreamTrack("video2", rt);
+            var track2 = new VideoStreamTrack(rt);
             yield return 0;
 
             Assert.That(videoStream.AddTrack(track2), Is.True);
@@ -379,8 +379,8 @@ namespace Unity.WebRTC.RuntimeTest
         [Timeout(5000)]
         public IEnumerator ReceiverGetStreams()
         {
-            var audioTrack = new AudioStreamTrack("audio");
-            var stream = new MediaStream(WebRTC.Context.CreateMediaStream("audiostream"));
+            var audioTrack = new AudioStreamTrack();
+            var stream = new MediaStream();
             stream.AddTrack(audioTrack);
             yield return 0;
 

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -38,6 +38,26 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void EqualIdWithAudioTrack()
+        {
+            var guid = Guid.NewGuid().ToString();
+            var track = new MediaStreamTrack(WebRTC.Context.CreateAudioTrack(guid));
+            Assert.That(track, Is.Not.Null);
+            Assert.That(track.Id, Is.EqualTo(guid));
+            track.Dispose();
+        }
+
+        [Test]
+        public void EqualIdWithVideoTrack()
+        {
+            var guid = Guid.NewGuid().ToString();
+            var track = new MediaStreamTrack(WebRTC.Context.CreateVideoTrack(guid));
+            Assert.That(track, Is.Not.Null);
+            Assert.That(track.Id, Is.EqualTo(guid));
+            track.Dispose();
+        }
+
+        [Test]
         public void AccessAfterDisposed()
         {
             var width = 256;

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -31,7 +31,7 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = new VideoStreamTrack("video", rt);
+            var track = new VideoStreamTrack(rt);
             Assert.That(track, Is.Not.Null);
             track.Dispose();
             Object.DestroyImmediate(rt);
@@ -45,7 +45,7 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = new VideoStreamTrack("video", rt);
+            var track = new VideoStreamTrack(rt);
             Assert.That(track, Is.Not.Null);
             track.Dispose();
             Assert.That(() => { var id = track.Id; }, Throws.TypeOf<InvalidOperationException>());
@@ -61,7 +61,7 @@ namespace Unity.WebRTC.RuntimeTest
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
 
-            Assert.That(() => { new VideoStreamTrack("video", rt); }, Throws.TypeOf<ArgumentException>());
+            Assert.That(() => { new VideoStreamTrack(rt); }, Throws.TypeOf<ArgumentException>());
             Object.DestroyImmediate(rt);
         }
 
@@ -75,7 +75,7 @@ namespace Unity.WebRTC.RuntimeTest
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
 
-            Assert.That(() => { new VideoStreamTrack("video", rt); }, Throws.TypeOf<ArgumentException>());
+            Assert.That(() => { new VideoStreamTrack(rt); }, Throws.TypeOf<ArgumentException>());
 
             Object.DestroyImmediate(rt);
         }
@@ -92,7 +92,7 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
             var rt = new RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = new VideoStreamTrack("video", rt);
+            var track = new VideoStreamTrack(rt);
             Assert.NotNull(track);
 
             // wait for the end of the initialization for encoder on the render thread.
@@ -153,7 +153,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void AddAndRemoveAudioStreamTrack()
         {
             var stream = new MediaStream();
-            var track = new AudioStreamTrack("audio");
+            var track = new AudioStreamTrack();
             Assert.AreEqual(TrackKind.Audio, track.Kind);
             Assert.AreEqual(0, stream.GetAudioTracks().Count());
             Assert.True(stream.AddTrack(track));
@@ -174,7 +174,7 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = new VideoStreamTrack("video", rt);
+            var track = new VideoStreamTrack(rt);
 
             track.Dispose();
             Object.DestroyImmediate(rt);
@@ -191,11 +191,11 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             var rt1 = new UnityEngine.RenderTexture(width, height, 0, format);
             rt1.Create();
-            var track1 = new VideoStreamTrack("video1", rt1);
+            var track1 = new VideoStreamTrack(rt1);
 
             var rt2 = new UnityEngine.RenderTexture(width, height, 0, format);
             rt2.Create();
-            var track2 = new VideoStreamTrack("video2", rt2);
+            var track2 = new VideoStreamTrack(rt2);
 
             // wait for initialization encoder on render thread.
             yield return new WaitForSeconds(0.1f);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -239,7 +239,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void GetTransceivers()
         {
             var peer = new RTCPeerConnection();
-            var track = new AudioStreamTrack("audio");
+            var track = new AudioStreamTrack();
 
             var sender = peer.AddTrack(track);
             Assert.That(peer.GetTransceivers().ToList(), Has.Count.EqualTo(1));
@@ -258,7 +258,7 @@ namespace Unity.WebRTC.RuntimeTest
             var config = GetDefaultConfiguration();
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
-            var audioTrack = new AudioStreamTrack("audio");
+            var audioTrack = new AudioStreamTrack();
 
             var transceiver1 = peer1.AddTransceiver(TrackKind.Audio);
             transceiver1.Direction = RTCRtpTransceiverDirection.RecvOnly;
@@ -460,7 +460,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var peer = new RTCPeerConnection();
             var stream = new MediaStream();
-            var track = new AudioStreamTrack("audio");
+            var track = new AudioStreamTrack();
             var sender = peer.AddTrack(track, stream);
 
             var op = peer.CreateOffer();
@@ -493,7 +493,7 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
 
             var stream = new MediaStream();
-            var track = new AudioStreamTrack("audio");
+            var track = new AudioStreamTrack();
             var sender = peer1.AddTrack(track, stream);
 
             var op1 = peer1.CreateOffer();
@@ -862,8 +862,8 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
 
-            var stream = new MediaStream(WebRTC.Context.CreateMediaStream("audiostream"));
-            var track = new AudioStreamTrack(WebRTC.Context.CreateAudioTrack("audio"));
+            var stream = new MediaStream();
+            var track = new AudioStreamTrack();
             stream.AddTrack(track);
             RTCRtpSender sender = peer1.AddTrack(track, stream);
 


### PR DESCRIPTION
- remove label argument
- use `Guid` instead of label 
- add `EqualId` test

related: https://github.com/Unity-Technologies/UnityRenderStreaming/issues/464