### PR TITLE
doc: Save Windows devs first time build debug time (issue #441)

### DIFF
--- a/Plugin~/README.md
+++ b/Plugin~/README.md
@@ -109,6 +109,7 @@ To build plugin, you need to execute command in the `BuildScripts~` folder.
 - [BuildScripts~/build_plugin_ios.sh](../BuildScripts~/build_plugin_ios.sh)
 - [BuildScripts~/build_plugin_linux.sh](../BuildScripts~/build_plugin_linux.sh)
 - [BuildScripts~/build_plugin_win.cmd](../BuildScripts~/build_plugin_win.cmd)
+    - If you encounter `LNK1120`, `LNK2001` or `LNK2019` errors while running this build script, it's possible that you may need to open `Plugin~/build64/webrtc.sln` and build from within Visual Studio 2019 instead. You can also use it for development. See issue [#441](https://github.com/Unity-Technologies/com.unity.webrtc/issues/441) for more info.
 
 ## Debug
 

--- a/Plugin~/README.md
+++ b/Plugin~/README.md
@@ -109,7 +109,9 @@ To build plugin, you need to execute command in the `BuildScripts~` folder.
 - [BuildScripts~/build_plugin_ios.sh](../BuildScripts~/build_plugin_ios.sh)
 - [BuildScripts~/build_plugin_linux.sh](../BuildScripts~/build_plugin_linux.sh)
 - [BuildScripts~/build_plugin_win.cmd](../BuildScripts~/build_plugin_win.cmd)
-    - If you encounter `LNK1120`, `LNK2001` or `LNK2019` errors while running this build script, it's possible that you may need to open `Plugin~/build64/webrtc.sln` and build from within Visual Studio 2019 instead. You can also use it for development. See issue [#441](https://github.com/Unity-Technologies/com.unity.webrtc/issues/441) for more info.
+    - Note: If you encounter `LNK1120`, `LNK2001` or `LNK2019` errors while running this build script, it's possible that you may need to open `Plugin~/build64/webrtc.sln` and build from within Visual Studio 2019 instead. You can also use it for development. ([#441](https://github.com/Unity-Technologies/com.unity.webrtc/issues/441))
+
+Alternatively, after the script has been run, a project ready for your IDE or other build tools is ready for you to use/build with (the name of the folder differs based on the target platform, check the script for more details).
 
 ## Debug
 


### PR DESCRIPTION
Solves issue https://github.com/Unity-Technologies/com.unity.webrtc/issues/441.

Issue https://github.com/Unity-Technologies/com.unity.webrtc/issues/441 shows that on some Windows environments, building will fail at the linking stage when running `build_plugin_win.cmd`, probably due to having multiple C++ compilers on the user's computer.

This PR adds a message in README.md in similar vein to PR https://github.com/Unity-Technologies/com.unity.webrtc/pull/438 that gives a solution/workaround for Windows devs encountering linker issues.

I'm not really sure this is the best solution to the problem, ideally a change to the CMake that would make it link the correct standard library version would be best. But as a temporary thing, this works, and is [actually a valid use of CMake as described in my issue post.](https://github.com/Unity-Technologies/com.unity.webrtc/issues/441)

I think this might actually lead to a better developer experience too, because using the project files made by CMake when deving probably leads to better intellisense.