### PR TITLE
doc: Reduce the chance noob devs will miss critical (crash-preventing) build info

### DIFF
--- a/Plugin~/README.md
+++ b/Plugin~/README.md
@@ -110,6 +110,14 @@ To build plugin, you need to execute command in the `BuildScripts~` folder.
 - [BuildScripts~/build_plugin_linux.sh](../BuildScripts~/build_plugin_linux.sh)
 - [BuildScripts~/build_plugin_win.cmd](../BuildScripts~/build_plugin_win.cmd)
 
+### Deploying the Plugin
+
+When you run the build, `webrtc.dll` will be placed in `Packages\com.unity.webrtc\Runtime\Plugins\x86_64`. You should then be able to verify the following settings in the Unity Inspector window.
+
+**WARNING:** If "Load on startup" is not ticked, your editor will crash when running your project. ([#444](https://github.com/Unity-Technologies/com.unity.webrtc/issues/444))
+
+<img src="../Documentation~/images/inspector_webrtc_plugin.png" width=400 align=center>
+
 ## Debug
 
 The `WebRTC` project properties must be adjusted to match your environment in order to build the plugin. 
@@ -117,9 +125,3 @@ The `WebRTC` project properties must be adjusted to match your environment in or
 Set the Unity.exe path under `Command` and the project path under `Command Arguments`. Once set, during debugging the Unity Editor will run and breakpoints will be enabled.  
 
 <img src="../Documentation~/images/command_config_vs2017.png" width=600 align=center>
-
-### Deploying the Plugin
-
-When you run the build, `webrtc.dll` will be placed in `Packages\com.unity.webrtc\Runtime\Plugins\x86_64`. You should then be able to verify the following settings in the Unity Inspector window. 
-
-<img src="../Documentation~/images/inspector_webrtc_plugin.png" width=400 align=center>

--- a/Plugin~/README.md
+++ b/Plugin~/README.md
@@ -114,7 +114,7 @@ To build plugin, you need to execute command in the `BuildScripts~` folder.
 
 When you run the build, `webrtc.dll` will be placed in `Packages\com.unity.webrtc\Runtime\Plugins\x86_64`. You should then be able to verify the following settings in the Unity Inspector window.
 
-**WARNING:** If "Load on startup" is not ticked, your editor will crash when running your project. ([#444](https://github.com/Unity-Technologies/com.unity.webrtc/issues/444))
+**WARNING:** If "Load on startup" is not ticked, your editor will crash when running your project. This may become unticked after you make a change to the plugin. ([#444](https://github.com/Unity-Technologies/com.unity.webrtc/issues/444))
 
 <img src="../Documentation~/images/inspector_webrtc_plugin.png" width=400 align=center>
 


### PR DESCRIPTION
Fixes issue https://github.com/Unity-Technologies/com.unity.webrtc/issues/444.

I might just be an idiot but it's quite easy for noob developers to miss an absolutely **critical** step in native plugin dev process, which is that "Load on startup" needs to be ticked.

As demonstrated in issue https://github.com/Unity-Technologies/com.unity.webrtc/issues/444, the crash logs are incredibly obscure (as C++ is in general) and do not point at the right issue. Although the solution is already in the README, it's non-obvious and put as a subheading under an unrelated section. This makes it decently likely people miss this step, especially as the phrase "Deploying" generally refers to what developers do _after_ their code is working and ready for staging/prod, which may not register in their mind when they're presumably trying to hack with the plugin to make something actually work first.

For good measure, to prevent this PEBCAK, I've added a big **WARNING** in the right place.