### PR TITLE
fix: Fixed the issue that CreateDataChannel method returns null

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -115,12 +115,26 @@ namespace webrtc
             }
             config.servers.push_back(iceServer);
         }
-        int iceTransportPolicy = configJson["iceTransportPolicy"].asInt();
-        if(iceTransportPolicy != 0) config.type = static_cast<PeerConnectionInterface::IceTransportsType>(iceTransportPolicy);
+        Json::Value iceTransportPolicy = configJson["iceTransportPolicy"];
+        if (!iceTransportPolicy.isNull())
+        {
+            config.type = static_cast<PeerConnectionInterface::IceTransportsType>(iceTransportPolicy.asInt());
+        }
         Json::Value enableDtlsSrtp = configJson["enableDtlsSrtp"];
-        if (enableDtlsSrtp != 0) config.enable_dtls_srtp = enableDtlsSrtp.asBool();
-        config.ice_candidate_pool_size = configJson["iceCandidatePoolSize"].asInt();
-        config.bundle_policy = static_cast<PeerConnectionInterface::BundlePolicy>(configJson["bundlePolicy"].asInt());
+        if (!enableDtlsSrtp.isNull())
+        {
+            config.enable_dtls_srtp = enableDtlsSrtp.asBool();
+        }
+        Json::Value iceCandidatePoolSize = configJson["iceCandidatePoolSize"];
+        if (!iceCandidatePoolSize.isNull())
+        {
+            config.ice_candidate_pool_size = iceCandidatePoolSize.asInt();
+        }
+        Json::Value bundlePolicy = configJson["bundlePolicy"];
+        if (!bundlePolicy.isNull())
+        {
+            config.bundle_policy = static_cast<PeerConnectionInterface::BundlePolicy>(bundlePolicy.asInt());
+        }
         config.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
         config.enable_implicit_rollback = true;
         return true;

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -116,24 +116,24 @@ namespace webrtc
             config.servers.push_back(iceServer);
         }
         Json::Value iceTransportPolicy = configJson["iceTransportPolicy"];
-        if (!iceTransportPolicy.isNull())
+        if(iceTransportPolicy["hasValue"].asBool())
         {
-            config.type = static_cast<PeerConnectionInterface::IceTransportsType>(iceTransportPolicy.asInt());
+            config.type = static_cast<PeerConnectionInterface::IceTransportsType>(iceTransportPolicy["value"].asInt());
         }
         Json::Value enableDtlsSrtp = configJson["enableDtlsSrtp"];
-        if (!enableDtlsSrtp.isNull())
+        if (enableDtlsSrtp["hasValue"].asBool())
         {
-            config.enable_dtls_srtp = enableDtlsSrtp.asBool();
+            config.enable_dtls_srtp = enableDtlsSrtp["value"].asBool();
         }
         Json::Value iceCandidatePoolSize = configJson["iceCandidatePoolSize"];
-        if (!iceCandidatePoolSize.isNull())
+        if (iceCandidatePoolSize["hasValue"].asBool())
         {
-            config.ice_candidate_pool_size = iceCandidatePoolSize.asInt();
+            config.ice_candidate_pool_size = iceCandidatePoolSize["value"].asInt();
         }
         Json::Value bundlePolicy = configJson["bundlePolicy"];
-        if (!bundlePolicy.isNull())
+        if (bundlePolicy["hasValue"].asBool())
         {
-            config.bundle_policy = static_cast<PeerConnectionInterface::BundlePolicy>(bundlePolicy.asInt());
+            config.bundle_policy = static_cast<PeerConnectionInterface::BundlePolicy>(bundlePolicy["value"].asInt());
         }
         config.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
         config.enable_implicit_rollback = true;

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -229,6 +229,8 @@ namespace webrtc
             root["iceServers"].append(jsonIceServer);
         }
         root["iceTransportPolicy"] = _config.type;
+        if(_config.enable_dtls_srtp.has_value())
+            root["enableDtlsSrtp"] = _config.enable_dtls_srtp.value();
         root["iceCandidatePoolSize"] = _config.ice_candidate_pool_size;
         root["bundlePolicy"] = _config.bundle_policy;
 

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -228,11 +228,21 @@ namespace webrtc
             }
             root["iceServers"].append(jsonIceServer);
         }
-        root["iceTransportPolicy"] = _config.type;
-        if(_config.enable_dtls_srtp.has_value())
-            root["enableDtlsSrtp"] = _config.enable_dtls_srtp.value();
-        root["iceCandidatePoolSize"] = _config.ice_candidate_pool_size;
-        root["bundlePolicy"] = _config.bundle_policy;
+        root["iceTransportPolicy"] = Json::Value(Json::objectValue);
+        root["iceTransportPolicy"]["hasValue"] = true;
+        root["iceTransportPolicy"]["value"] = _config.type;
+
+        root["enableDtlsSrtp"] = Json::Value(Json::objectValue);
+        root["enableDtlsSrtp"]["hasValue"] = _config.enable_dtls_srtp.has_value();
+        root["enableDtlsSrtp"]["value"] = _config.enable_dtls_srtp.value_or(false);
+
+        root["iceCandidatePoolSize"] = Json::Value(Json::objectValue);
+        root["iceCandidatePoolSize"]["hasValue"] = true;
+        root["iceCandidatePoolSize"]["value"] = _config.ice_candidate_pool_size;
+            
+        root["bundlePolicy"] = Json::Value(Json::objectValue);
+        root["bundlePolicy"]["hasValue"] = true;
+        root["bundlePolicy"]["value"] = _config.bundle_policy;
 
         Json::StreamWriterBuilder builder;
         return Json::writeString(builder, root);

--- a/Runtime/Scripts/Internal/Marshalling.cs
+++ b/Runtime/Scripts/Internal/Marshalling.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Unity.WebRTC
 {
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalInt
     {
@@ -19,8 +19,28 @@ namespace Unity.WebRTC
         {
             return new OptionalInt { hasValue = a.HasValue, value = a.GetValueOrDefault() };
         }
+
+        public static OptionalInt FromEnum<T>(T? a) where T : struct
+        {
+            Type type = typeof(T);
+            if (!type.IsEnum)
+                throw new ArgumentException();
+
+            return new OptionalInt {hasValue = a.HasValue, value = Convert.ToInt32(a.GetValueOrDefault()) };
+        }
+
+        public T? AsEnum<T>() where T : struct
+        {
+            if(!hasValue)
+                return null;
+            Type type = typeof(T);
+            if (!type.IsEnum)
+                return null;
+            return (T)Enum.ToObject(typeof(T), value);
+        }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalUlong
     {
@@ -38,6 +58,7 @@ namespace Unity.WebRTC
         }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalUshort
     {
@@ -55,6 +76,7 @@ namespace Unity.WebRTC
         }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalShort
     {
@@ -72,6 +94,7 @@ namespace Unity.WebRTC
         }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalUint
     {
@@ -89,6 +112,7 @@ namespace Unity.WebRTC
         }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalDouble
     {
@@ -106,6 +130,7 @@ namespace Unity.WebRTC
         }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct OptionalBool
     {
@@ -124,6 +149,7 @@ namespace Unity.WebRTC
         }
     }
 
+    [Serializable]
     [StructLayout(LayoutKind.Sequential)]
     internal struct MarshallingArray<T> where T : struct
     {

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -394,7 +394,8 @@ namespace Unity.WebRTC
         {
             IntPtr ptr = NativeMethods.PeerConnectionGetConfiguration(GetSelfOrThrow());
             string str = ptr.AsAnsiStringWithFreeMem();
-            return JsonUtility.FromJson<RTCConfiguration>(str);
+            var conf = JsonUtility.FromJson<RTCConfigurationInternal>(str);
+            return new RTCConfiguration(ref conf);
         }
 
         /// <summary>
@@ -430,7 +431,9 @@ namespace Unity.WebRTC
         /// <seealso cref="GetConfiguration()"/>
         public RTCErrorType SetConfiguration(ref RTCConfiguration configuration)
         {
-            return NativeMethods.PeerConnectionSetConfiguration(GetSelfOrThrow(), JsonUtility.ToJson(configuration));
+            var conf_ = configuration.Cast();
+            string str = JsonUtility.ToJson(conf_);
+            return NativeMethods.PeerConnectionSetConfiguration(GetSelfOrThrow(), str);
         }
 
         /// <summary>
@@ -457,7 +460,8 @@ namespace Unity.WebRTC
         /// <seealso cref="RTCPeerConnection()"/>
         public RTCPeerConnection(ref RTCConfiguration configuration)
         {
-            string configStr = JsonUtility.ToJson(configuration);
+            var conf_ = configuration.Cast();
+            string configStr = JsonUtility.ToJson(conf_);
             self = WebRTC.Context.CreatePeerConnection(configStr);
             if (self == IntPtr.Zero)
             {

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -252,19 +252,51 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
-        public RTCIceTransportPolicy iceTransportPolicy;
+        public RTCIceTransportPolicy? iceTransportPolicy;
         /// <summary>
         ///
         /// </summary>
-        public RTCBundlePolicy bundlePolicy;
+        public RTCBundlePolicy? bundlePolicy;
         /// <summary>
         ///
         /// </summary>
-        public int iceCandidatePoolSize;
+        public int? iceCandidatePoolSize;
         /// <summary>
         ///
         /// </summary>
-        public bool enableDtlsSrtp;
+        public bool? enableDtlsSrtp;
+
+        internal RTCConfiguration(ref RTCConfigurationInternal v)
+        {
+            iceServers = v.iceServers;
+            iceTransportPolicy = v.iceTransportPolicy.AsEnum<RTCIceTransportPolicy>();
+            bundlePolicy = v.bundlePolicy.AsEnum<RTCBundlePolicy>();
+            iceCandidatePoolSize = v.iceCandidatePoolSize;
+            enableDtlsSrtp = v.enableDtlsSrtp;
+        }
+
+        internal RTCConfigurationInternal Cast()
+        {
+            RTCConfigurationInternal instance = new RTCConfigurationInternal
+            {
+                iceServers = this.iceServers,
+                iceTransportPolicy = OptionalInt.FromEnum(this.iceTransportPolicy),
+                bundlePolicy = OptionalInt.FromEnum(this.bundlePolicy),
+                iceCandidatePoolSize = this.iceCandidatePoolSize,
+                enableDtlsSrtp = this.enableDtlsSrtp
+            };
+            return instance;
+        }
+    }
+
+    [Serializable]
+    struct RTCConfigurationInternal
+    {
+        public RTCIceServer[] iceServers;
+        public OptionalInt iceTransportPolicy;
+        public OptionalInt bundlePolicy;
+        public OptionalInt iceCandidatePoolSize;
+        public OptionalBool enableDtlsSrtp;
     }
 
     /// <summary>

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -25,6 +25,8 @@ namespace Unity.WebRTC.RuntimeTest
                 }
             };
             config.iceTransportPolicy = RTCIceTransportPolicy.All;
+            config.iceCandidatePoolSize = 0;
+            config.bundlePolicy = RTCBundlePolicy.BundlePolicyBalanced;
             return config;
         }
 

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -79,15 +79,18 @@ namespace Unity.WebRTC.RuntimeTest
             var peer = new RTCPeerConnection(ref config);
 
             var config2 = peer.GetConfiguration();
-            Assert.NotNull(config.iceServers);
-            Assert.NotNull(config2.iceServers);
-            Assert.AreEqual(config.iceServers.Length, config2.iceServers.Length);
-            Assert.AreEqual(config.iceServers[0].username, config2.iceServers[0].username);
-            Assert.AreEqual(config.iceServers[0].credential, config2.iceServers[0].credential);
-            Assert.AreEqual(config.iceServers[0].urls, config2.iceServers[0].urls);
-            Assert.AreEqual(config.iceTransportPolicy, config2.iceTransportPolicy);
-            Assert.AreEqual(config.iceCandidatePoolSize, config2.iceCandidatePoolSize);
-            Assert.AreEqual(config.bundlePolicy, config2.bundlePolicy);
+            Assert.That(config.iceServers, Is.Not.Null);
+            Assert.That(config2.iceServers, Is.Not.Null);
+            Assert.That(config.iceServers.Length, Is.EqualTo(config2.iceServers.Length));
+            Assert.That(config.iceServers[0].username, Is.EqualTo(config2.iceServers[0].username));
+            Assert.That(config.iceServers[0].credential, Is.EqualTo(config2.iceServers[0].credential));
+            Assert.That(config.iceServers[0].urls, Is.EqualTo(config2.iceServers[0].urls));
+            Assert.That(config.iceTransportPolicy, Is.EqualTo(RTCIceTransportPolicy.All));
+            Assert.That(config.iceTransportPolicy, Is.EqualTo(config2.iceTransportPolicy));
+            Assert.That(config.enableDtlsSrtp, Is.Null);
+            Assert.That(config.enableDtlsSrtp, Is.EqualTo(config2.enableDtlsSrtp));
+            Assert.That(config.iceCandidatePoolSize, Is.EqualTo(config2.iceCandidatePoolSize));
+            Assert.That(config.bundlePolicy, Is.EqualTo(config2.bundlePolicy));
 
             peer.Close();
             peer.Dispose();


### PR DESCRIPTION
The issue has been occured since this [PR](https://github.com/Unity-Technologies/com.unity.webrtc/pull/419).

The new parameter should be optional, but this was defined as a required parameter. This pull request redefines parameters in `RTCConfiguration` as optional values.