### PR TITLE
fix: crash windows vulkan on VideoReceieSample

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -504,14 +504,14 @@ namespace webrtc
     UnityVideoRenderer* Context::CreateVideoRenderer()
     {
         auto rendererId = GenerateRendererId();
-        auto renderer = std::make_unique<UnityVideoRenderer>(rendererId);
-        m_mapVideoRenderer[rendererId] = std::move(renderer);
+        auto renderer = std::make_shared<UnityVideoRenderer>(rendererId);
+        m_mapVideoRenderer[rendererId] = renderer;
         return m_mapVideoRenderer[rendererId].get();
     }
 
-    UnityVideoRenderer* Context::GetVideoRenderer(uint32_t id)
+    std::shared_ptr<UnityVideoRenderer> Context::GetVideoRenderer(uint32_t id)
     {
-        return m_mapVideoRenderer[id].get();
+        return m_mapVideoRenderer[id];
     }
 
     void Context::DeleteVideoRenderer(UnityVideoRenderer* renderer)

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -101,7 +101,7 @@ namespace webrtc
 
         // Renderer
         UnityVideoRenderer* CreateVideoRenderer();
-        UnityVideoRenderer* GetVideoRenderer(uint32_t id);
+        std::shared_ptr<UnityVideoRenderer> GetVideoRenderer(uint32_t id);
         void DeleteVideoRenderer(UnityVideoRenderer* renderer);
 
         // RtpSender
@@ -139,7 +139,7 @@ namespace webrtc
         std::map<const webrtc::PeerConnectionInterface*, rtc::scoped_refptr<SetSessionDescriptionObserver>> m_mapSetSessionDescriptionObserver;
         std::map<const webrtc::MediaStreamTrackInterface*, std::unique_ptr<VideoEncoderParameter>> m_mapVideoEncoderParameter;
         std::map<const DataChannelObject*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
-        std::map<const uint32_t, std::unique_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
+        std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
 
         std::map<webrtc::AudioTrackInterface*, std::unique_ptr<AudioTrackSinkAdapter>> m_mapAudioTrackAndSink;
 

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -91,6 +91,16 @@ namespace webrtc
             onTrack(this, transceiver.get());
         }
     }
+
+    void PeerConnectionObject::OnRemoveTrack(rtc::scoped_refptr<RtpReceiverInterface> receiver)
+    {
+        if (onRemoveTrack != nullptr)
+        {
+            onRemoveTrack(this, receiver.get());
+        }
+    }
+
+
     // Called any time the IceConnectionState changes.
     void PeerConnectionObject::OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState new_state)
     {

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -20,6 +20,7 @@ namespace webrtc
     using DelegateOnDataChannel = void(*)(PeerConnectionObject*, DataChannelObject*);
     using DelegateOnRenegotiationNeeded = void(*)(PeerConnectionObject*);
     using DelegateOnTrack = void(*)(PeerConnectionObject*, webrtc::RtpTransceiverInterface*);
+    using DelegateOnRemoveTrack = void(*)(PeerConnectionObject*, webrtc::RtpReceiverInterface*);
 
     class PeerConnectionObject
         : public webrtc::CreateSessionDescriptionObserver
@@ -57,6 +58,7 @@ namespace webrtc
         void RegisterOnDataChannel(DelegateOnDataChannel callback) { onDataChannel = callback; }
         void RegisterOnRenegotiationNeeded(DelegateOnRenegotiationNeeded callback) { onRenegotiationNeeded = callback; }
         void RegisterOnTrack(DelegateOnTrack callback) { onTrack = callback; }
+        void RegisterOnRemoveTrack(DelegateOnRemoveTrack callback) { onRemoveTrack = callback; }
 
         //webrtc::CreateSessionDescriptionObserver
         // This callback transfers the ownership of the |desc|.
@@ -103,6 +105,8 @@ namespace webrtc
         // https://w3c.github.io/webrtc-pc/#set-description
         void OnTrack(rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) override;
 
+        void OnRemoveTrack(rtc::scoped_refptr<RtpReceiverInterface> receiver) override;
+
         friend class DataChannelObject;
 
         DelegateCreateSDSuccess onCreateSDSuccess = nullptr;
@@ -115,6 +119,7 @@ namespace webrtc
         DelegateOnDataChannel onDataChannel = nullptr;
         DelegateOnRenegotiationNeeded onRenegotiationNeeded = nullptr;
         DelegateOnTrack onTrack = nullptr;
+        DelegateOnRemoveTrack onRemoveTrack = nullptr;
         rtc::scoped_refptr<webrtc::PeerConnectionInterface> connection = nullptr;
     private:
         Context& context;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -29,6 +29,7 @@ namespace webrtc
     IUnityGraphics* s_Graphics = nullptr;
     Context* s_context = nullptr;
     std::map<const MediaStreamTrackInterface*, std::unique_ptr<IEncoder>> s_mapEncoder;
+    std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> s_mapVideoRenderer;
     std::unique_ptr <Clock> s_clock;
 
     const UnityProfilerMarkerDesc* s_MarkerEncode = nullptr;
@@ -117,6 +118,7 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
         /// The actual value of UnityGfxRenderer is returned on second time.
 
         s_mapEncoder.clear();
+        s_mapVideoRenderer.clear();
 
         UnityGfxRenderer renderer =
             s_UnityInterfaces->Get<IUnityGraphics>()->GetRenderer();
@@ -147,6 +149,7 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
     case kUnityGfxDeviceEventShutdown:
     {
         s_mapEncoder.clear();
+        s_mapVideoRenderer.clear();
 
         if (s_gfxDevice != nullptr)
         {
@@ -337,27 +340,17 @@ static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)
             // DebugLog("VideoRenderer not found, rendererId:%d", params->userData);
             return;
         }
+        s_mapVideoRenderer[params->userData] = renderer;
         {
             ScopedProfiler profiler(*s_MarkerDecode);
-            renderer->ConvertVideoFrameToTextureAndWriteToBuffer(params->width, params->height, ConvertTextureFormat(params->format));
+            renderer.get()->ConvertVideoFrameToTextureAndWriteToBuffer(params->width, params->height, ConvertTextureFormat(params->format));
         }
-        if (!renderer->RenderTryLock())
-        {
-            return;
-        }
-        params->texData = renderer->tempBuffer.data();
+        params->texData = renderer.get()->tempBuffer.data();
     }
     if (event == kUnityRenderingExtEventUpdateTextureEndV2)
     {
         auto params = reinterpret_cast<UnityRenderingExtTextureUpdateParamsV2 *>(data);
-
-        auto renderer = s_context->GetVideoRenderer(params->userData);
-        if (renderer == nullptr)
-        {
-            // DebugLog("VideoRenderer not found, rendererId:%d", params->userData);
-            return;
-        }
-        renderer->RenderUnLock();
+        s_mapVideoRenderer.erase(params->userData);
     }
 }
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -330,18 +330,31 @@ static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)
     if (event == kUnityRenderingExtEventUpdateTextureBeginV2)
     {
         auto params = reinterpret_cast<UnityRenderingExtTextureUpdateParamsV2 *>(data);
-        
+
         auto renderer = s_context->GetVideoRenderer(params->userData);
         if (renderer == nullptr)
         {
             // DebugLog("VideoRenderer not found, rendererId:%d", params->userData);
             return;
         }
+        renderer->usedByRenderThread = true;
         {
             ScopedProfiler profiler(*s_MarkerDecode);
             renderer->ConvertVideoFrameToTextureAndWriteToBuffer(params->width, params->height, ConvertTextureFormat(params->format));
         }
         params->texData = renderer->tempBuffer.data();
+    }
+    if (event == kUnityRenderingExtEventUpdateTextureEndV2)
+    {
+        auto params = reinterpret_cast<UnityRenderingExtTextureUpdateParamsV2 *>(data);
+
+        auto renderer = s_context->GetVideoRenderer(params->userData);
+        if (renderer == nullptr)
+        {
+            // DebugLog("VideoRenderer not found, rendererId:%d", params->userData);
+            return;
+        }
+        renderer->usedByRenderThread = false;
     }
 }
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -337,10 +337,13 @@ static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)
             // DebugLog("VideoRenderer not found, rendererId:%d", params->userData);
             return;
         }
-        renderer->usedByRenderThread = true;
         {
             ScopedProfiler profiler(*s_MarkerDecode);
             renderer->ConvertVideoFrameToTextureAndWriteToBuffer(params->width, params->height, ConvertTextureFormat(params->format));
+        }
+        if (!renderer->RenderTryLock())
+        {
+            return;
         }
         params->texData = renderer->tempBuffer.data();
     }
@@ -354,7 +357,7 @@ static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)
             // DebugLog("VideoRenderer not found, rendererId:%d", params->userData);
             return;
         }
-        renderer->usedByRenderThread = false;
+        renderer->RenderUnLock();
     }
 }
 

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -7,7 +7,6 @@ namespace webrtc {
 UnityVideoRenderer::UnityVideoRenderer(uint32_t id) : m_id(id)
 {
     DebugLog("Create UnityVideoRenderer Id:%d", id);
-    m_renderLock = std::unique_lock<std::mutex>(m_mutex, std::defer_lock);
 }
 
 UnityVideoRenderer::~UnityVideoRenderer()
@@ -33,24 +32,6 @@ void UnityVideoRenderer::OnFrame(const webrtc::VideoFrame &frame)
 uint32_t UnityVideoRenderer::GetId()
 {
     return m_id;
-}
-
-bool UnityVideoRenderer::RenderTryLock()
-{
-    if (m_renderLock.owns_lock())
-    {
-        return false;
-    }
-
-    return m_renderLock.try_lock();
-}
-
-void UnityVideoRenderer::RenderUnLock()
-{
-    if (m_renderLock.owns_lock())
-    {
-        m_renderLock.unlock();
-    }
 }
 
 rtc::scoped_refptr<webrtc::VideoFrameBuffer> UnityVideoRenderer::GetFrameBuffer()

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "UnityVideoRenderer.h"
+#include <thread>
+#include <chrono>
 
 namespace unity {
 namespace webrtc {
@@ -11,6 +13,10 @@ UnityVideoRenderer::UnityVideoRenderer(uint32_t id) : m_id(id)
 
 UnityVideoRenderer::~UnityVideoRenderer()
 {
+    while(usedByRenderThread)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
     DebugLog("Destory UnityVideoRenderer Id:%d", m_id);
     {
         std::unique_lock<std::mutex> lock(m_mutex);

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.h
@@ -17,17 +17,21 @@ namespace webrtc {
         void OnFrame(const webrtc::VideoFrame &frame) override;
 
         uint32_t GetId();
+        bool RenderTryLock();
+        void RenderUnLock();
         rtc::scoped_refptr<webrtc::VideoFrameBuffer> GetFrameBuffer();
         void SetFrameBuffer(rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer);
-        std::vector<uint8_t> tempBuffer;
-        bool usedByRenderThread;
 
+        // used in UnityRenderingExtEventUpdateTexture 
+        std::vector<uint8_t> tempBuffer;
+        // called on RenderThread
         void ConvertVideoFrameToTextureAndWriteToBuffer(int width, int height, libyuv::FourCC format);
 
     private:
         uint32_t m_id;
         std::mutex m_mutex;
         rtc::scoped_refptr<webrtc::VideoFrameBuffer> m_frameBuffer;
+        std::unique_lock<std::mutex> m_renderLock;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.h
@@ -20,6 +20,7 @@ namespace webrtc {
         rtc::scoped_refptr<webrtc::VideoFrameBuffer> GetFrameBuffer();
         void SetFrameBuffer(rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer);
         std::vector<uint8_t> tempBuffer;
+        bool usedByRenderThread;
 
         void ConvertVideoFrameToTextureAndWriteToBuffer(int width, int height, libyuv::FourCC format);
 

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.h
@@ -17,8 +17,6 @@ namespace webrtc {
         void OnFrame(const webrtc::VideoFrame &frame) override;
 
         uint32_t GetId();
-        bool RenderTryLock();
-        void RenderUnLock();
         rtc::scoped_refptr<webrtc::VideoFrameBuffer> GetFrameBuffer();
         void SetFrameBuffer(rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer);
 
@@ -31,7 +29,6 @@ namespace webrtc {
         uint32_t m_id;
         std::mutex m_mutex;
         rtc::scoped_refptr<webrtc::VideoFrameBuffer> m_frameBuffer;
-        std::unique_lock<std::mutex> m_renderLock;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -969,6 +969,11 @@ extern "C"
         obj->RegisterOnTrack(callback);
     }
 
+    UNITY_INTERFACE_EXPORT void PeerConnectionRegisterOnRemoveTrack(PeerConnectionObject* obj, DelegateOnRemoveTrack callback)
+    {
+        obj->RegisterOnRemoveTrack(callback);
+    }
+
     UNITY_INTERFACE_EXPORT bool TransceiverGetCurrentDirection(RtpTransceiverInterface* transceiver, RtpTransceiverDirection* direction)
     {
         if (transceiver->current_direction().has_value())

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -14,6 +14,7 @@ namespace Unity.WebRTC
 
         private IntPtr self;
         private bool disposed;
+        private HashSet<MediaStreamTrack> cacheTracks = new HashSet<MediaStreamTrack>();
 
         /// <summary>
         ///
@@ -85,10 +86,12 @@ namespace Unity.WebRTC
 
         public bool AddTrack(MediaStreamTrack track)
         {
+            cacheTracks.Add(track);
             return NativeMethods.MediaStreamAddTrack(GetSelfOrThrow(), track.GetSelfOrThrow());
         }
         public bool RemoveTrack(MediaStreamTrack track)
         {
+            cacheTracks.Remove(track);
             return NativeMethods.MediaStreamRemoveTrack(GetSelfOrThrow(), track.GetSelfOrThrow());
         }
 
@@ -115,25 +118,29 @@ namespace Unity.WebRTC
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeMediaStreamOnAddTrack))]
-        static void MediaStreamOnAddTrack(IntPtr ptr, IntPtr track)
+        static void MediaStreamOnAddTrack(IntPtr ptr, IntPtr trackPtr)
         {
             WebRTC.Sync(ptr, () =>
             {
                 if (WebRTC.Table[ptr] is MediaStream stream)
                 {
-                    stream.onAddTrack?.Invoke(new MediaStreamTrackEvent(track));
+                    var e = new MediaStreamTrackEvent(trackPtr);
+                    stream.onAddTrack?.Invoke(e);
+                    stream.cacheTracks.Add(e.Track);
                 }
             });
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeMediaStreamOnRemoveTrack))]
-        static void MediaStreamOnRemoveTrack(IntPtr ptr, IntPtr track)
+        static void MediaStreamOnRemoveTrack(IntPtr ptr, IntPtr trackPtr)
         {
             WebRTC.Sync(ptr, () =>
             {
                 if (WebRTC.Table[ptr] is MediaStream stream)
                 {
-                    stream.onRemoveTrack?.Invoke(new MediaStreamTrackEvent(track));
+                    var e = new MediaStreamTrackEvent(trackPtr);
+                    stream.onRemoveTrack?.Invoke(e);
+                    stream.cacheTracks.Remove(e.Track);
                 }
             });
         }

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -60,6 +60,7 @@ namespace Unity.WebRTC
 
         private RTCSessionDescriptionAsyncOperation m_opSessionDesc;
         private RTCSessionDescriptionAsyncOperation m_opSetRemoteDesc;
+        private HashSet<MediaStreamTrack> cacheTracks = new HashSet<MediaStreamTrack>();
 
         private bool disposed;
 
@@ -368,7 +369,23 @@ namespace Unity.WebRTC
             {
                 if (WebRTC.Table[ptr] is RTCPeerConnection connection)
                 {
-                    connection.OnTrack?.Invoke(new RTCTrackEvent(transceiver, connection));
+                    var e = new RTCTrackEvent(transceiver, connection);
+                    connection.OnTrack?.Invoke(e);
+                    connection.cacheTracks.Add(e.Track);
+                }
+            });
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(DelegateNativeOnRemoveTrack))]
+        static void PCOnRemoveTrack(IntPtr ptr, IntPtr receiverPtr)
+        {
+            WebRTC.Sync(ptr, () =>
+            {
+                if (WebRTC.Table[ptr] is RTCPeerConnection connection)
+                {
+                    var receiver = WebRTC.FindOrCreate(
+                        receiverPtr, ptr => new RTCRtpReceiver(ptr, connection));
+                    connection.cacheTracks.Remove(receiver.Track);
                 }
             });
         }
@@ -483,6 +500,7 @@ namespace Unity.WebRTC
             NativeMethods.PeerConnectionRegisterOnDataChannel(self, PCOnDataChannel);
             NativeMethods.PeerConnectionRegisterOnRenegotiationNeeded(self, PCOnNegotiationNeeded);
             NativeMethods.PeerConnectionRegisterOnTrack(self, PCOnTrack);
+            NativeMethods.PeerConnectionRegisterOnRemoveTrack(self, PCOnRemoveTrack);
             WebRTC.Context.PeerConnectionRegisterOnSetSessionDescSuccess(
                 self, OnSetSessionDescSuccess);
             WebRTC.Context.PeerConnectionRegisterOnSetSessionDescFailure(
@@ -520,6 +538,7 @@ namespace Unity.WebRTC
             var streamId = stream == null ? Guid.NewGuid().ToString() : stream.Id;
             IntPtr ptr = NativeMethods.PeerConnectionAddTrack(
                 GetSelfOrThrow(), track.GetSelfOrThrow(), streamId);
+            cacheTracks.Add(track);
             return CreateSender(ptr);
         }
 
@@ -532,6 +551,7 @@ namespace Unity.WebRTC
         {
             NativeMethods.PeerConnectionRemoveTrack(
                 GetSelfOrThrow(), sender.self);
+            cacheTracks.Remove(sender.Track);
         }
 
         /// <summary>

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -157,11 +157,6 @@ namespace Unity.WebRTC
             }
         }
 
-        ~VideoStreamTrack()
-        {
-            this.Dispose();
-        }
-
         public override void Dispose()
         {
             if (this.disposed)

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -407,8 +407,10 @@ namespace Unity.WebRTC
                 // Wait until all frame rendering is done
                 yield return new WaitForEndOfFrame();
                 {
-                    foreach(var track in VideoStreamTrack.tracks)
+                    foreach(var reference in VideoStreamTrack.s_tracks.Values)
                     {
+                        if (!reference.TryGetTarget(out var track))
+                            continue;
                         if (track.IsEncoderInitialized)
                         {
                             track.Update();
@@ -739,6 +741,8 @@ namespace Unity.WebRTC
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnTrack(IntPtr ptr, IntPtr transceiver);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void DelegateNativeOnRemoveTrack(IntPtr ptr, IntPtr receiver);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnDataChannel(IntPtr ptr, IntPtr ptrChannel);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateNativeOnMessage(IntPtr ptr, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] bytes, int size);
@@ -901,6 +905,8 @@ namespace Unity.WebRTC
         public static extern void PeerConnectionRegisterOnRenegotiationNeeded(IntPtr ptr, DelegateNativeOnNegotiationNeeded callback);
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterOnTrack(IntPtr ptr, DelegateNativeOnTrack callback);
+        [DllImport(WebRTC.Lib)]
+        public static extern void PeerConnectionRegisterOnRemoveTrack(IntPtr ptr, DelegateNativeOnRemoveTrack callback);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool TransceiverGetCurrentDirection(IntPtr transceiver, ref RTCRtpTransceiverDirection direction);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -407,17 +407,20 @@ namespace Unity.WebRTC
                 // Wait until all frame rendering is done
                 yield return new WaitForEndOfFrame();
                 {
-                    foreach(var reference in VideoStreamTrack.s_tracks.Values)
+                    lock (VideoStreamTrack.s_lockTracks)
                     {
-                        if (!reference.TryGetTarget(out var track))
-                            continue;
-                        if (track.IsEncoderInitialized)
+                        foreach (var reference in VideoStreamTrack.s_tracks.Values)
                         {
-                            track.Update();
-                        }
-                        else if (track.IsDecoderInitialized)
-                        {
-                            track.UpdateReceiveTexture();
+                            if (!reference.TryGetTarget(out var track))
+                                continue;
+                            if (track.IsEncoderInitialized)
+                            {
+                                track.Update();
+                            }
+                            else if (track.IsDecoderInitialized)
+                            {
+                                track.UpdateReceiveTexture();
+                            }
                         }
                     }
                 }

--- a/Samples~/VideoReceive/VideoReceive.unity
+++ b/Samples~/VideoReceive/VideoReceive.unity
@@ -1846,6 +1846,7 @@ MonoBehaviour:
   useWebCamToggle: {fileID: 260222989}
   webCamLListDropdown: {fileID: 652734888}
   cam: {fileID: 934963288}
+  streamSize: {x: 1280, y: 720}
   sourceImage: {fileID: 1839397354}
   receiveImage: {fileID: 2123783124}
   rotateObject: {fileID: 1823897046}

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -10,7 +10,7 @@ namespace Unity.WebRTC.RuntimeTest
         public const string UnsupportedReceiveVideoOnHardware = "IgnoreUnsupportedReceiveVideoOnHardware";
         public const string UnsupportedPlatformVideoDecoder = "IgnoreUnsupportedPlatformVideoDecoder";
 
-        [RuntimeInitializeOnLoadMethod]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static void OnLoad()
         {
             var ignoreHardwareEncoderTest = !NativeMethods.GetHardwareEncoderSupport();

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -77,9 +77,22 @@ namespace Unity.WebRTC.RuntimeTest
             var stream = new MediaStream();
             var track = new VideoStreamTrack(rt);
 
+            bool isCalledOnAddTrack = false;
+            bool isCalledOnRemoveTrack = false;
+
+            stream.OnAddTrack = e =>
+            {
+                Assert.That(e.Track, Is.EqualTo(track));
+                isCalledOnAddTrack = true;
+            };
+            stream.OnRemoveTrack = e =>
+            {
+                Assert.That(e.Track, Is.EqualTo(track));
+                isCalledOnRemoveTrack = true;
+            };
+
             // wait for the end of the initialization for encoder on the render thread.
             yield return 0;
-
             Assert.That(track.Kind, Is.EqualTo(TrackKind.Video));
             Assert.That(stream.GetVideoTracks(), Has.Count.EqualTo(0));
             Assert.That(stream.AddTrack(track), Is.True);
@@ -87,9 +100,13 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(stream.GetVideoTracks(), Has.All.Not.Null);
             Assert.That(stream.RemoveTrack(track), Is.True);
             Assert.That(stream.GetVideoTracks(), Has.Count.EqualTo(0));
+
+            var op1 = new WaitUntilWithTimeout(() => isCalledOnAddTrack, 5000);
+            yield return op1;
+            var op2 = new WaitUntilWithTimeout(() => isCalledOnRemoveTrack, 5000);
+            yield return op2;
+
             track.Dispose();
-            // wait for disposing video track.
-            yield return 0;
 
             stream.Dispose();
             Object.DestroyImmediate(rt);

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -90,7 +90,7 @@ namespace Unity.WebRTC.RuntimeTest
             new TestValue{width = 1920, height = 1080, count = 3}
         };
 
-        static int[] range = Enumerable.Range(0, 8).ToArray();
+        static int[] range = Enumerable.Range(0, 9).ToArray();
 
         // not supported TestCase attribute on UnityTest
         // refer to https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-tests-parameterized.html

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -70,14 +70,14 @@ namespace Unity.WebRTC.RuntimeTest
             Object.DestroyImmediate(rt);
         }
 
-        class TestValue
+        internal class TestValue
         {
             public int width;
             public int height;
             public int count;
         }
 
-        static TestValue[] testValues = new TestValue[]
+        internal static TestValue[] testValues = new TestValue[]
         {
             new TestValue{width = 256, height = 256, count = 1},
             new TestValue{width = 256, height = 256, count = 2},
@@ -87,7 +87,7 @@ namespace Unity.WebRTC.RuntimeTest
             new TestValue{width = 1280, height = 720, count = 3},
         };
 
-        static int[] range = Enumerable.Range(0, 6).ToArray();
+        internal static int[] range = Enumerable.Range(0, 6).ToArray();
 
         // not supported TestCase attribute on UnityTest
         // refer to https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-tests-parameterized.html

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -123,7 +123,7 @@ namespace Unity.WebRTC.RuntimeTest
             for (int i = 0; i < value.count; i++)
             {
                 yield return VideoReceive();
-                yield return new WaitForSeconds(0.1f);
+                yield return new WaitForSeconds(1);
             }
 
             Object.DestroyImmediate(test.gameObject);
@@ -206,10 +206,10 @@ namespace Unity.WebRTC.RuntimeTest
             SendVideoTrack = null;
 
             offerPc?.Close();
-            answerPc?.Close();
             offerPc?.Dispose();
-            answerPc?.Dispose();
             offerPc = null;
+            answerPc?.Close();
+            answerPc?.Dispose();
             answerPc = null;
             SendTexture = null;
             RecvTexture = null;

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -1,8 +1,10 @@
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using UnityEngine.UI;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -68,64 +70,178 @@ namespace Unity.WebRTC.RuntimeTest
             Object.DestroyImmediate(rt);
         }
 
+        class TestValue
+        {
+            public int width;
+            public int height;
+            public int count;
+        }
+
+        static TestValue[] testValues = new TestValue[]
+        {
+            new TestValue{width = 256, height = 256, count = 1},
+            new TestValue{width = 256, height = 256, count = 2},
+            new TestValue{width = 256, height = 256, count = 3},
+            new TestValue{width = 1280, height = 720, count = 1},
+            new TestValue{width = 1280, height = 720, count = 2},
+            new TestValue{width = 1280, height = 720, count = 3},
+            new TestValue{width = 1920, height = 1080, count = 1},
+            new TestValue{width = 1920, height = 1080, count = 2},
+            new TestValue{width = 1920, height = 1080, count = 3}
+        };
+
+        static int[] range = Enumerable.Range(0, 8).ToArray();
+
+        // not supported TestCase attribute on UnityTest
+        // refer to https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-tests-parameterized.html
         [UnityTest]
         [Timeout(5000)]
         [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoStreamTrack.UpdateReceiveTexture is not supported on Direct3D12")]
-        public IEnumerator VideoReceive()
+        public IEnumerator VideoReceive([ValueSource(nameof(range))]int index)
         {
-            const int width = 256;
-            const int height = 256;
+            var value = testValues[index];
+            var test = new MonoBehaviourTest<VideoReceivePeers>();
+            test.component.SetResolution(value.width, value.height);
+            yield return test;
+            test.component.CoroutineUpdate();
 
+            IEnumerator VideoReceive()
+            {
+                test.component.CreatePeers();
+                test.component.CreateVideoStreamTrack();
+                test.component.AddTrack();
+
+                yield return test.component.Signaling();
+
+                var receiveVideoTrack = test.component.RecvVideoTrack;
+                yield return new WaitUntil(() => receiveVideoTrack != null && receiveVideoTrack.IsDecoderInitialized);
+                Assert.That(test.component.RecvTexture, Is.Not.Null);
+
+                yield return new WaitForSeconds(0.1f);
+
+                test.component.Clear();
+            }
+
+            for (int i = 0; i < value.count; i++)
+            {
+                yield return VideoReceive();
+                yield return new WaitForSeconds(0.1f);
+            }
+
+            Object.DestroyImmediate(test.gameObject);
+        }
+    }
+
+    class VideoReceivePeers : MonoBehaviour, IMonoBehaviourTest
+    {
+        public bool IsTestFinished { get; private set; }
+
+        public VideoStreamTrack SendVideoTrack { get; private set; }
+        public VideoStreamTrack RecvVideoTrack { get; private set; }
+        public Texture SendTexture => sourceImage.texture;
+        public Texture RecvTexture => receiveImage.texture;
+
+        RTCPeerConnection offerPc;
+        RTCPeerConnection answerPc;
+        RTCRtpSender sender;
+        GameObject camObj;
+        Camera cam;
+        GameObject sourceObj;
+        RawImage sourceImage;
+        GameObject receiveObj;
+        RawImage receiveImage;
+
+        int width;
+        int height;
+
+        void Start()
+        {
+            camObj = new GameObject("Camera");
+            cam = camObj.AddComponent<Camera>();
+
+            sourceObj = new GameObject("Source");
+            sourceImage = sourceObj.AddComponent<RawImage>();
+            receiveObj = new GameObject("Receive");
+            receiveImage = receiveObj.AddComponent<RawImage>();
+
+            IsTestFinished = true;
+        }
+
+        public void SetResolution(int width, int height)
+        {
+            this.width = width;
+            this.height = height;
+        }
+
+        public void CreatePeers()
+        {
             var config = new RTCConfiguration
             {
-                iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}}
+                iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } }
             };
-            var pc1 = new RTCPeerConnection(ref config);
-            var pc2 = new RTCPeerConnection(ref config);
+            offerPc = new RTCPeerConnection(ref config);
+            answerPc = new RTCPeerConnection(ref config);
 
-            VideoStreamTrack receiveVideoTrack = null;
-            Texture receiveImage = null;
-
-            pc2.OnTrack = e =>
+            answerPc.OnTrack = e =>
             {
                 if (e.Track is VideoStreamTrack track && !track.IsDecoderInitialized)
                 {
-                    receiveVideoTrack = track;
-                    receiveImage = track.InitializeReceiver(width, height);
+                    RecvVideoTrack = track;
+                    receiveImage.texture = track.InitializeReceiver(width, height);
                 }
             };
-
-            var camObj = new GameObject("Camera");
-            var cam = camObj.AddComponent<Camera>();
-            cam.backgroundColor = Color.red;
-            var sendVideoTrack = cam.CaptureStreamTrack(width, height, 1000000);
-
-            yield return new WaitForSeconds(0.1f);
-
-            pc1.AddTrack(sendVideoTrack);
-
-            yield return SignalingPeers(pc1, pc2);
-
-            yield return new WaitUntil(() => receiveVideoTrack != null && receiveVideoTrack.IsDecoderInitialized);
-            Assert.That(receiveImage, Is.Not.Null);
-
-            sendVideoTrack.Update();
-            yield return new WaitForSeconds(0.1f);
-
-            receiveVideoTrack.UpdateReceiveTexture();
-            yield return new WaitForSeconds(0.1f);
-
-            receiveVideoTrack.Dispose();
-            sendVideoTrack.Dispose();
-            yield return 0;
-
-            pc2.Dispose();
-            pc1.Dispose();
-            Object.DestroyImmediate(camObj);
+        }
+        public void CreateVideoStreamTrack()
+        {
+            SendVideoTrack = cam.CaptureStreamTrack(width, height, 1000000);
+            sourceImage.texture = cam.targetTexture;
         }
 
-        private static IEnumerator SignalingPeers(RTCPeerConnection offerPc, RTCPeerConnection answerPc)
+        public void AddTrack()
+        {
+            sender = offerPc.AddTrack(SendVideoTrack);
+        }
+
+        public void RemoveTrack()
+        {
+            offerPc.RemoveTrack(sender);
+        }
+
+        public Coroutine CoroutineUpdate()
+        {
+            return StartCoroutine(WebRTC.Update());
+        }
+
+        public void Clear()
+        {
+            SendVideoTrack?.Dispose();
+            SendVideoTrack = null;
+
+            offerPc?.Close();
+            answerPc?.Close();
+            offerPc?.Dispose();
+            answerPc?.Dispose();
+            offerPc = null;
+            answerPc = null;
+            sourceImage.texture = null;
+            receiveImage.texture = null;
+        }
+
+        void OnDestroy()
+        {
+            Clear();
+            DestroyImmediate(sourceObj);
+            sourceObj = null;
+            DestroyImmediate(receiveObj);
+            receiveObj = null;
+            DestroyImmediate(camObj);
+            camObj = null;
+            sourceImage = null;
+            receiveImage = null;
+        }
+
+        public IEnumerator Signaling()
         {
             offerPc.OnIceCandidate = candidate => answerPc.AddIceCandidate(candidate);
             answerPc.OnIceCandidate = candidate => offerPc.AddIceCandidate(candidate);


### PR DESCRIPTION
The cause of the crash is that the texture data used by `UnityRenderingExtEventUpdateTexture` is null.

Changed `UnityVideoRenderer` to shared_ptr and add reference in `UnityRenderEvent`.