### PR TITLE
fix: Workaround for testing with H.264 codec

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -177,7 +177,7 @@ namespace webrtc
     }
 #pragma warning(pop)
 
-    Context::Context(int uid, UnityEncoderType encoderType)
+    Context::Context(int uid, UnityEncoderType encoderType, bool forTest)
         : m_uid(uid)
         , m_encoderType(encoderType)
     {
@@ -197,7 +197,7 @@ namespace webrtc
 
         std::unique_ptr<webrtc::VideoDecoderFactory> videoDecoderFactory =
             m_encoderType == UnityEncoderType::UnityEncoderHardware ?
-            std::make_unique<UnityVideoDecoderFactory>() :
+            std::make_unique<UnityVideoDecoderFactory>(forTest) :
             webrtc::CreateBuiltinVideoDecoderFactory();
 
         m_peerConnectionFactory = CreatePeerConnectionFactory(

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -33,14 +33,14 @@ namespace webrtc
         return nullptr;
     }
 
-    Context* ContextManager::CreateContext(int uid, UnityEncoderType encoderType)
+    Context* ContextManager::CreateContext(int uid, UnityEncoderType encoderType, bool forTest)
     {
         auto it = s_instance.m_contexts.find(uid);
         if (it != s_instance.m_contexts.end()) {
             DebugLog("Using already created context with ID %d", uid);
             return nullptr;
         }
-        auto ctx = new Context(uid, encoderType);
+        auto ctx = new Context(uid, encoderType, forTest);
         s_instance.m_contexts[uid].reset(ctx);
         return ctx;
     }

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -26,7 +26,7 @@ namespace webrtc
         static ContextManager* GetInstance() { return &s_instance; }
      
         Context* GetContext(int uid) const;
-        Context* CreateContext(int uid, UnityEncoderType encoderType);
+        Context* CreateContext(int uid, UnityEncoderType encoderType, bool forTest);
         void DestroyContext(int uid);
         void SetCurContext(Context*);
         bool Exists(Context* context);
@@ -58,7 +58,7 @@ namespace webrtc
     {
     public:
         
-        explicit Context(int uid = -1, UnityEncoderType encoderType = UnityEncoderHardware);
+        explicit Context(int uid = -1, UnityEncoderType encoderType = UnityEncoderHardware, bool forTest = false);
         ~Context();
 
         // Utility

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -25,14 +25,31 @@ namespace webrtc
 #endif
     }
 
-    UnityVideoDecoderFactory::UnityVideoDecoderFactory()
+    UnityVideoDecoderFactory::UnityVideoDecoderFactory(bool forTest)
     : internal_decoder_factory_(CreateDecoderFactory())
+    , forTest_(forTest)
     {
     }
 
     std::vector<webrtc::SdpVideoFormat> UnityVideoDecoderFactory::GetSupportedFormats() const
     {
+#if CUDA_PLATFORM
+        // todo(kazuki):: Support H.264 hardware decoder for CUDA platforms (Linux and Windows)
+        // This is a workaround to generate SDPs contains H.264 codec for unit testing.
+        // The workaround will be removed if CUDA HW decoder is supported.
+        if(forTest_)
+        {
+            return { webrtc::CreateH264Format(
+                webrtc::H264::kProfileConstrainedBaseline,
+                webrtc::H264::kLevel5_1, "1") };
+        }
+        else
+        {
+            return internal_decoder_factory_->GetSupportedFormats();
+        }
+#else
         return internal_decoder_factory_->GetSupportedFormats();
+#endif
     }
 
     std::unique_ptr<webrtc::VideoDecoder> UnityVideoDecoderFactory::CreateVideoDecoder(const webrtc::SdpVideoFormat & format)

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
@@ -12,9 +12,10 @@ namespace webrtc
     public:
         std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
         std::unique_ptr<webrtc::VideoDecoder> CreateVideoDecoder(const webrtc::SdpVideoFormat& format) override;
-        UnityVideoDecoderFactory();
+        UnityVideoDecoderFactory(bool forTest);
     private:
         const std::unique_ptr<VideoDecoderFactory> internal_decoder_factory_;
+        bool forTest_;
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -412,7 +412,7 @@ extern "C"
         delegateSetResolution = func;
     }
 
-    UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid, UnityEncoderType encoderType)
+    UNITY_INTERFACE_EXPORT Context* ContextCreate(int uid, UnityEncoderType encoderType, bool forTest)
     {
         auto ctx = ContextManager::GetInstance()->GetContext(uid);
         if (ctx != nullptr)
@@ -420,7 +420,7 @@ extern "C"
             DebugLog("Already created context with ID %d", uid);
             return ctx;
         }
-        ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType);
+        ctx = ContextManager::GetInstance()->CreateContext(uid, encoderType, forTest);
         return ctx;
     }
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -15,14 +15,14 @@ namespace Unity.WebRTC
         private IntPtr renderFunction;
         private IntPtr textureUpdateFunction;
 
-        public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware)
+        public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware, bool forTest = false)
         {
             if (encoderType == EncoderType.Hardware && !NativeMethods.GetHardwareEncoderSupport())
             {
                 throw new ArgumentException("Hardware encoder is not supported");
             }
 
-            var ptr = NativeMethods.ContextCreate(id, encoderType);
+            var ptr = NativeMethods.ContextCreate(id, encoderType, forTest);
             return new Context(ptr, id);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -347,7 +347,13 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="type"></param>
         /// <param name="limitTextureSize"></param>
-        public static void Initialize(EncoderType type = EncoderType.Hardware, bool limitTextureSize = true, bool forTest = false)
+        public static void Initialize(EncoderType type = EncoderType.Hardware, bool limitTextureSize = true)
+        {
+            Initialize(type, limitTextureSize, false);
+        }
+
+
+        internal static void Initialize(EncoderType type, bool limitTextureSize, bool forTest)
         {
             // todo(kazuki): Add this event to avoid crash caused by hot-reload.
             // Dispose of all before reloading assembly.

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -347,7 +347,7 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="type"></param>
         /// <param name="limitTextureSize"></param>
-        public static void Initialize(EncoderType type = EncoderType.Hardware, bool limitTextureSize = true)
+        public static void Initialize(EncoderType type = EncoderType.Hardware, bool limitTextureSize = true, bool forTest = false)
         {
             // todo(kazuki): Add this event to avoid crash caused by hot-reload.
             // Dispose of all before reloading assembly.
@@ -378,7 +378,7 @@ namespace Unity.WebRTC
 #if UNITY_IOS && !UNITY_EDITOR
             NativeMethods.RegisterRenderingWebRTCPlugin();
 #endif
-            s_context = Context.Create(encoderType:type);
+            s_context = Context.Create(encoderType:type, forTest:forTest);
             NativeMethods.SetCurrentContext(s_context.self);
             s_syncContext = SynchronizationContext.Current;
             var flipShader = Resources.Load<Shader>("Flip");
@@ -761,7 +761,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void RegisterDebugLog(DelegateDebugLog func);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreate(int uid, EncoderType encoderType);
+        public static extern IntPtr ContextCreate(int uid, EncoderType encoderType, [MarshalAs(UnmanagedType.U1)] bool forTest);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDestroy(int uid);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -13,8 +13,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, forTest:true);
         }
 
         [TearDown]

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -14,7 +14,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void SetUp()
         {
             var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
-            WebRTC.Initialize(type: type, forTest:true);
+            WebRTC.Initialize(type: type, limitTextureSize:true, forTest:true);
         }
 
         [TearDown]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -68,14 +68,14 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CreateAndDestroyContext()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             NativeMethods.ContextDestroy(0);
         }
 
         [Test]
         public void GetEncoderType()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             Assert.AreEqual(encoderType, NativeMethods.ContextGetEncoderType(context));
             NativeMethods.ContextDestroy(0);
         }
@@ -83,7 +83,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CreateAndDeletePeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
@@ -92,7 +92,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void RestartIcePeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             NativeMethods.PeerConnectionRestartIce(peer);
             NativeMethods.ContextDeletePeerConnection(context, peer);
@@ -112,7 +112,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void RegisterDelegateToPeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
 
             NativeMethods.PeerConnectionRegisterOnSetSessionDescSuccess(context, connection, PeerConnectionSetSessionDescSuccess);
@@ -126,7 +126,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void PeerConnectionGetReceivers()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
             IntPtr buf = NativeMethods.PeerConnectionGetReceivers(connection, out ulong length);
             Assert.AreEqual(0, length);
@@ -137,7 +137,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CreateAndDeleteDataChannel()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
 
             var init = (RTCDataChannelInitInternal)new RTCDataChannelInit();
@@ -150,7 +150,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CreateAndDeleteMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             NativeMethods.ContextDeleteMediaStream(context, stream);
             NativeMethods.ContextDestroy(0);
@@ -165,7 +165,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void RegisterDelegateToMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             NativeMethods.ContextRegisterMediaStreamObserver(context, stream);
 
@@ -180,7 +180,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void AddAndRemoveVideoTrack()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
@@ -193,7 +193,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void AddAndRemoveVideoTrackToPeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -216,7 +216,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void SenderGetParameter()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -246,7 +246,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void AddAndRemoveVideoTrackToMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             const int width = 1280;
             const int height = 720;
@@ -278,7 +278,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void AddAndRemoveAudioTrackToMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
             NativeMethods.MediaStreamAddTrack(stream, track);
@@ -308,7 +308,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void AddAndRemoveAudioTrack()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -329,7 +329,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CreateAndDeleteVideoRenderer()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var renderer = NativeMethods.CreateVideoRenderer(context);
             NativeMethods.DeleteVideoRenderer(context, renderer);
             NativeMethods.ContextDestroy(0);
@@ -338,7 +338,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void AddAndRemoveVideoRendererToVideoTrack()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
@@ -355,7 +355,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CallGetRenderEventFunc()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var callback = NativeMethods.GetRenderEventFunc(context);
             Assert.AreNotEqual(callback, IntPtr.Zero);
             NativeMethods.ContextDestroy(0);
@@ -393,7 +393,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Ignore("todo::GetInitializationResult returns NotInitialized")]
         public IEnumerator CallVideoEncoderMethods()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -432,7 +432,7 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CallGetUpdateTextureFunc()
         {
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             var callback = NativeMethods.GetUpdateTextureFunc(context);
             Assert.AreNotEqual(callback, IntPtr.Zero);
             NativeMethods.ContextDestroy(0);
@@ -451,7 +451,7 @@ namespace Unity.WebRTC.RuntimeTest
                 yield break;
             }
 
-            var context = NativeMethods.ContextCreate(0, encoderType);
+            var context = NativeMethods.ContextCreate(0, encoderType, true);
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -33,8 +33,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -34,7 +34,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void SetUp()
         {
             var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
-            WebRTC.Initialize(type: type, forTest: true);
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -133,7 +132,6 @@ namespace Unity.WebRTC.RuntimeTest
             yield return op2;
             Assert.That(op2.IsError, Is.False, op2.Error.message);
 
-            desc.sdp = ReplaceOfferSdpForHardwareEncodeTest(desc.sdp);
             var op3 = peers[1].SetRemoteDescription(ref desc);
             yield return op3;
             Assert.That(op3.IsError, Is.False, op3.Error.message);
@@ -144,8 +142,6 @@ namespace Unity.WebRTC.RuntimeTest
             var op5 = peers[1].SetLocalDescription(ref desc);
             yield return op5;
             Assert.That(op5.IsError, Is.False, op5.Error.message);
-
-            desc.sdp = ReplaceAnswerSdpForHardwareEncodeTest(desc.sdp);
 
             var op6 = peers[0].SetRemoteDescription(ref desc);
             yield return op6;
@@ -170,85 +166,6 @@ namespace Unity.WebRTC.RuntimeTest
                 Assert.That(op9.IsCompleted, Is.True);
             }
             IsTestFinished = true;
-        }
-
-        private static string ReplaceAnswerSdpForHardwareEncodeTest(string originalSdp)
-        {
-            if (WebRTC.GetEncoderType() == EncoderType.Software)
-            {
-                return originalSdp;
-            }
-
-            return originalSdp
-                .Replace("m=video 9 UDP/TLS/RTP/SAVPF 96 98 100 104 105 106",
-                    "m=video 9 UDP/TLS/RTP/SAVPF 96 98 100 102 104 105 106")
-                .Replace("a=rtpmap:104 red/90000", @"a=rtpmap:102 H264/90000
-a=rtcp-fb:102 goog-remb
-a=rtcp-fb:102 transport-cc
-a=rtcp-fb:102 ccm fir
-a=rtcp-fb:102 nack
-a=rtcp-fb:102 nack pli
-a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e033
-a=rtpmap:104 red/90000");
-        }
-
-        private static string ReplaceOfferSdpForHardwareEncodeTest(string originalSdp)
-        {
-            if (WebRTC.GetEncoderType() == EncoderType.Software)
-            {
-                return originalSdp;
-            }
-
-            var result = originalSdp
-                .Replace("m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100",
-                    "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 103 104 105 106");
-
-            var matchedObject = Regex.Match(originalSdp, @"(a=rtpmap:96.*)a=ssrc-group", RegexOptions.Singleline);
-            if (!string.IsNullOrEmpty(matchedObject.Value))
-            {
-                result = result.Replace(matchedObject.Value, @"a=rtpmap:96 VP8/90000
-a=rtcp-fb:96 goog-remb
-a=rtcp-fb:96 transport-cc
-a=rtcp-fb:96 ccm fir
-a=rtcp-fb:96 nack
-a=rtcp-fb:96 nack pli
-a=rtpmap:97 rtx/90000
-a=fmtp:97 apt=96
-a=rtpmap:98 VP9/90000
-a=rtcp-fb:98 goog-remb
-a=rtcp-fb:98 transport-cc
-a=rtcp-fb:98 ccm fir
-a=rtcp-fb:98 nack
-a=rtcp-fb:98 nack pli
-a=fmtp:98 profile-id=0
-a=rtpmap:99 rtx/90000
-a=fmtp:99 apt=98
-a=rtpmap:100 VP9/90000
-a=rtcp-fb:100 goog-remb
-a=rtcp-fb:100 transport-cc
-a=rtcp-fb:100 ccm fir
-a=rtcp-fb:100 nack
-a=rtcp-fb:100 nack pli
-a=fmtp:100 profile-id=2
-a=rtpmap:101 rtx/90000
-a=fmtp:101 apt=100
-a=rtpmap:102 H264/90000
-a=rtcp-fb:102 goog-remb
-a=rtcp-fb:102 transport-cc
-a=rtcp-fb:102 ccm fir
-a=rtcp-fb:102 nack
-a=rtcp-fb:102 nack pli
-a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e033
-a=rtpmap:103 rtx/90000
-a=fmtp:103 apt=102
-a=rtpmap:104 red/90000
-a=rtpmap:105 rtx/90000
-a=fmtp:105 apt=104
-a=rtpmap:106 ulpfec/90000
-a=ssrc-group");
-            }
-
-            return result;
         }
 
         public void Dispose()


### PR DESCRIPTION
This is a workaround to generate SDPs contains H.264 codec for unit testing.
The previous method is unstable because it is premised on the fixed contents of SDPs.
The workaround will be removed if CUDA HW decoder is supported.