### PR TITLE
refactor: Add AudioStreamTrack SetData API 

### DIFF
--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -7,7 +7,7 @@ namespace Unity.WebRTC
     /// </summary>
     /// <param name="data"></param>
     /// <param name="channels"></param>
-    delegate void AudioReadEventHandler(float[] data, int channels);
+    delegate void AudioReadEventHandler(float[] data, int channels, int sampleRate);
 
     /// <summary>
     /// 
@@ -17,9 +17,16 @@ namespace Unity.WebRTC
     {
         public event AudioReadEventHandler onAudioRead;
 
+        private int sampleRate;
+
+        void OnEnable()
+        {
+            sampleRate = GetComponent<AudioSource>().clip.frequency;
+        }
+
         void OnAudioFilterRead(float[] data, int channels)
         {
-            onAudioRead?.Invoke(data, channels);
+            onAudioRead?.Invoke(data, channels, sampleRate);
         }
     }
 }

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -98,9 +99,6 @@ namespace Unity.WebRTC
             }
         }
 
-        internal static List<AudioStreamTrack> tracks = new List<AudioStreamTrack>();
-
-        readonly int _sampleRate = 0;
         readonly AudioSourceRead _audioSourceRead;
 
         private AudioStreamRenderer _streamRenderer;
@@ -126,8 +124,7 @@ namespace Unity.WebRTC
 
             _audioSourceRead = source.gameObject.AddComponent<AudioSourceRead>();
             _audioSourceRead.hideFlags = HideFlags.HideInHierarchy;
-            _audioSourceRead.onAudioRead += OnSendAudio;
-            _sampleRate = Source.clip.frequency;
+            _audioSourceRead.onAudioRead += SetData;
         }
 
         internal AudioStreamTrack(IntPtr ptr) : base(ptr)
@@ -162,9 +159,40 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
-        private void OnSendAudio(float[] data, int channels)
+        public void SetData(ref NativeArray<float>.ReadOnly nativeArray, int channels, int sampleRate)
         {
-            NativeMethods.ProcessAudio(self, data, _sampleRate, channels, data.Length);
+            unsafe
+            {
+                void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
+                NativeMethods.ProcessAudio(self, (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="nativeSlice"></param>
+        /// <param name="channels"></param>
+        public void SetData(NativeSlice<float> nativeSlice, int channels, int sampleRate)
+        {
+            unsafe
+            {
+                void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
+                NativeMethods.ProcessAudio(self, (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="array"></param>
+        /// <param name="channels"></param>
+        public void SetData(float[] array, int channels, int sampleRate)
+        {
+            NativeArray<float> nativeArray = new NativeArray<float>(array, Allocator.Temp);
+            var readonlyNativeArray = nativeArray.AsReadOnly();
+            SetData(ref readonlyNativeArray, channels, sampleRate);
+            nativeArray.Dispose();
         }
 
         private void OnAudioReceivedInternal(float[] audioData, int sampleRate, int channels, int numOfFrames)

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -177,7 +177,7 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="nativeSlice"></param>
         /// <param name="channels"></param>
-        public void SetData(NativeSlice<float> nativeSlice, int channels, int sampleRate)
+        public void SetData(ref NativeSlice<float> nativeSlice, int channels, int sampleRate)
         {
             unsafe
             {

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -157,6 +157,12 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="nativeArray"></param>
+        /// <param name="channels"></param>
+        /// <param name="sampleRate"></param>
         public void SetData(ref NativeArray<float>.ReadOnly nativeArray, int channels, int sampleRate)
         {
             unsafe

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -129,7 +129,6 @@ namespace Unity.WebRTC
 
         internal AudioStreamTrack(IntPtr ptr) : base(ptr)
         {
-            tracks.Add(this);
             WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
         }
 
@@ -145,7 +144,6 @@ namespace Unity.WebRTC
 
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
-                tracks.Remove(this);
                 if(_audioSourceRead != null)
                     Object.Destroy(_audioSourceRead);
                 _streamRenderer?.Dispose();

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -7,8 +7,6 @@ namespace Unity.WebRTC
     {
         protected IntPtr self;
         protected bool disposed;
-        private bool enabled;
-        private TrackState readyState;
 
         /// <summary>
         ///
@@ -56,20 +54,7 @@ namespace Unity.WebRTC
 
         public virtual void Dispose()
         {
-            if (this.disposed)
-            {
-                return;
-            }
-
-            if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
-            {
-                WebRTC.Context.DeleteMediaStreamTrack(self);
-                WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
-            }
-
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            throw new NotImplementedException("Must to implements on the inherited class");
         }
 
         //Disassociate track from its source(video or audio), not for destroying the track

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -175,8 +175,7 @@ namespace Unity.WebRTC
                     UnityEngine.Object.DestroyImmediate(m_sourceTexture);
                 }
 
-                if(!s_tracks.TryRemove(self, out var value))
-                    Debug.LogError("Invalid Operation");
+                s_tracks.TryRemove(self, out var value);
                 WebRTC.Context.DeleteMediaStreamTrack(self);
                 WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -407,20 +407,17 @@ namespace Unity.WebRTC
                 // Wait until all frame rendering is done
                 yield return new WaitForEndOfFrame();
                 {
-                    lock (VideoStreamTrack.s_lockTracks)
+                    foreach (var reference in VideoStreamTrack.s_tracks.Values)
                     {
-                        foreach (var reference in VideoStreamTrack.s_tracks.Values)
+                        if (!reference.TryGetTarget(out var track))
+                            continue;
+                        if (track.IsEncoderInitialized)
                         {
-                            if (!reference.TryGetTarget(out var track))
-                                continue;
-                            if (track.IsEncoderInitialized)
-                            {
-                                track.Update();
-                            }
-                            else if (track.IsDecoderInitialized)
-                            {
-                                track.UpdateReceiveTexture();
-                            }
+                            track.Update();
+                        }
+                        else if (track.IsDecoderInitialized)
+                        {
+                            track.UpdateReceiveTexture();
                         }
                     }
                 }
@@ -1029,7 +1026,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ProcessAudio(IntPtr track, float[] data, int sampleRate, int channels, int frames);
+        public static extern void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]

--- a/Samples~/Audio/AudioSpectrumView.cs
+++ b/Samples~/Audio/AudioSpectrumView.cs
@@ -78,6 +78,7 @@ namespace Unity.WebRTC.Samples
             {
                 if(lines.Count > 0)
                     ResetLines(0);
+                clip = null;
                 return;
             }
 

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -55,8 +55,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             for (int i = 0; i < 300; i++)
             {
-                float[] data = new float[2048];
-                renderer.SetData(data);
+                NativeArray<float> nativeArray = new NativeArray<float>(2048, Allocator.Temp);
+                renderer.SetData(ref nativeArray);
             }
             renderer.Dispose();
         }

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using Unity.Collections;
 using UnityEngine;
 
 namespace Unity.WebRTC.RuntimeTest

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Unity.Collections;
 using UnityEngine;
 
 namespace Unity.WebRTC.RuntimeTest
@@ -55,8 +56,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             for (int i = 0; i < 300; i++)
             {
-                NativeArray<float> nativeArray = new NativeArray<float>(2048, Allocator.Temp);
-                renderer.SetData(ref nativeArray);
+                float[] data = new float[2048];
+                renderer.SetData(data);
             }
             renderer.Dispose();
         }

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -41,7 +41,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void EqualIdWithAudioTrack()
         {
             var guid = Guid.NewGuid().ToString();
-            var track = new MediaStreamTrack(WebRTC.Context.CreateAudioTrack(guid));
+            var track = new AudioStreamTrack(WebRTC.Context.CreateAudioTrack(guid));
             Assert.That(track, Is.Not.Null);
             Assert.That(track.Id, Is.EqualTo(guid));
             track.Dispose();
@@ -51,7 +51,7 @@ namespace Unity.WebRTC.RuntimeTest
         public void EqualIdWithVideoTrack()
         {
             var guid = Guid.NewGuid().ToString();
-            var track = new MediaStreamTrack(WebRTC.Context.CreateVideoTrack(guid));
+            var track = new VideoStreamTrack(WebRTC.Context.CreateVideoTrack(guid));
             Assert.That(track, Is.Not.Null);
             Assert.That(track.Id, Is.EqualTo(guid));
             track.Dispose();

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -316,9 +316,6 @@ namespace Unity.WebRTC.RuntimeTest
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
-            float[] data = new float[2048];
-            NativeMethods.ProcessAudio(track, data,48000, 2, data.Length);
-
             NativeMethods.ContextDeleteMediaStreamTrack(context, track);
             NativeMethods.PeerConnectionRemoveTrack(peer, sender);
             NativeMethods.ContextDeleteMediaStream(context, stream);


### PR DESCRIPTION
This PR published APIs for setting audio binary data to tracks directly. Developers can set audio data to `AudioStreamTrack` without an `AudioSource` instance.

Other fixes below:

- Refactor `MediaStreamTrack` class
- Use `ConcurrentDictionary` in `VideoStreamTrack` instead of `lock` object