### PR TITLE
fix: crash when call WebRTC.Initialize twice

### DIFF
--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -336,7 +336,7 @@ namespace Unity.WebRTC
         private static bool s_limitTextureSize;
 
 #if UNITY_EDITOR
-        static public void OnBeforeAssemblyReload()
+        public static void OnBeforeAssemblyReload()
         {
             Dispose();
         }
@@ -349,6 +349,9 @@ namespace Unity.WebRTC
         /// <param name="limitTextureSize"></param>
         public static void Initialize(EncoderType type = EncoderType.Hardware, bool limitTextureSize = true)
         {
+            if (s_context != null)
+                throw new InvalidOperationException("Already initialized WebRTC.");
+
             Initialize(type, limitTextureSize, false);
         }
 

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -21,6 +21,12 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void InitializeTwiceThrowException()
+        {
+            Assert.That(() => WebRTC.Initialize(), Throws.InvalidOperationException);
+        }
+
+        [Test]
         public void GraphicsFormat()
         {
             var graphicsFormat = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);


### PR DESCRIPTION
- throw exception when call WebRTC.Initialize twice