### PR TITLE
fix: dispose receive track on OnRemoveTrack

### DIFF
--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -100,7 +100,6 @@ namespace Unity.WebRTC
                 // Dispose of MediaStreamTrack when disposing of RTCRtpReceiver.
                 // On the other hand, do not dispose a track when disposing of RTCRtpSender.
                 transceiver.Receiver?.Track?.Dispose();
-
                 transceiver.Receiver?.Dispose();
                 transceiver.Sender?.Dispose();
                 transceiver.Dispose();
@@ -549,9 +548,8 @@ namespace Unity.WebRTC
         /// <seealso cref="AddTrack"/>
         public void RemoveTrack(RTCRtpSender sender)
         {
-            NativeMethods.PeerConnectionRemoveTrack(
-                GetSelfOrThrow(), sender.self);
             cacheTracks.Remove(sender.Track);
+            NativeMethods.PeerConnectionRemoveTrack(GetSelfOrThrow(), sender.self);
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -20,6 +20,15 @@ namespace Unity.WebRTC
             this.peer = peer;
         }
 
+        internal IntPtr GetSelfOrThrow()
+        {
+            if (self == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("This instance has been disposed.");
+            }
+            return self;
+        }
+
         ~RTCRtpReceiver()
         {
             this.Dispose();
@@ -64,7 +73,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                IntPtr ptr = NativeMethods.ReceiverGetTrack(self);
+                IntPtr ptr = NativeMethods.ReceiverGetTrack(GetSelfOrThrow());
                 if (ptr == IntPtr.Zero)
                     return null;
                 return WebRTC.FindOrCreate(ptr, MediaStreamTrack.Create);
@@ -75,7 +84,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                IntPtr ptrStreams = NativeMethods.ReceiverGetStreams(self, out ulong length);
+                IntPtr ptrStreams = NativeMethods.ReceiverGetStreams(GetSelfOrThrow(), out ulong length);
                 return WebRTC.Deserialize(ptrStreams, (int)length, ptr => new MediaStream(ptr));
             }
         }

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -25,6 +25,15 @@ namespace Unity.WebRTC
             this.Dispose();
         }
 
+        internal IntPtr GetSelfOrThrow()
+        {
+            if (self == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("This instance has been disposed.");
+            }
+            return self;
+        }
+
         public virtual void Dispose()
         {
             if (this.disposed)
@@ -71,7 +80,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                IntPtr ptr = NativeMethods.SenderGetTrack(self);
+                IntPtr ptr = NativeMethods.SenderGetTrack(GetSelfOrThrow());
                 if (ptr == IntPtr.Zero)
                     return null;
                 return WebRTC.FindOrCreate(ptr, MediaStreamTrack.Create);
@@ -84,7 +93,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpSendParameters GetParameters()
         {
-            NativeMethods.SenderGetParameters(self, out var ptr);
+            NativeMethods.SenderGetParameters(GetSelfOrThrow(), out var ptr);
             RTCRtpSendParametersInternal parametersInternal = Marshal.PtrToStructure<RTCRtpSendParametersInternal>(ptr);
             RTCRtpSendParameters parameters = new RTCRtpSendParameters(ref parametersInternal);
             Marshal.FreeHGlobal(ptr);
@@ -101,7 +110,7 @@ namespace Unity.WebRTC
             parameters.CreateInstance(out RTCRtpSendParametersInternal instance);
             IntPtr ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf(instance));
             Marshal.StructureToPtr(instance, ptr, false);
-            RTCErrorType error = NativeMethods.SenderSetParameters(self, ptr);
+            RTCErrorType error = NativeMethods.SenderSetParameters(GetSelfOrThrow(), ptr);
             Marshal.FreeCoTaskMem(ptr);
             return error;
         }
@@ -114,7 +123,7 @@ namespace Unity.WebRTC
         public bool ReplaceTrack(MediaStreamTrack track)
         {
             IntPtr trackPtr = track?.GetSelfOrThrow() ?? IntPtr.Zero;
-            return NativeMethods.SenderReplaceTrack(self, trackPtr);
+            return NativeMethods.SenderReplaceTrack(GetSelfOrThrow(), trackPtr);
         }
     }
 }


### PR DESCRIPTION
By disposing the track, the rendering process of the received video is stopped.

