### PR TITLE
fix: Fix compile error on Unity2019

### DIFF
--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -157,6 +157,7 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
+#if UNITY_2020_1_OR_NEWER
         /// <summary>
         /// 
         /// </summary>
@@ -164,6 +165,22 @@ namespace Unity.WebRTC
         /// <param name="channels"></param>
         /// <param name="sampleRate"></param>
         public void SetData(ref NativeArray<float>.ReadOnly nativeArray, int channels, int sampleRate)
+        {
+            unsafe
+            {
+                void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
+                NativeMethods.ProcessAudio(self, (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+            }
+        }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="nativeArray"></param>
+        /// <param name="channels"></param>
+        /// <param name="sampleRate"></param>
+        public void SetData(ref NativeArray<float> nativeArray, int channels, int sampleRate)
         {
             unsafe
             {
@@ -194,8 +211,7 @@ namespace Unity.WebRTC
         public void SetData(float[] array, int channels, int sampleRate)
         {
             NativeArray<float> nativeArray = new NativeArray<float>(array, Allocator.Temp);
-            var readonlyNativeArray = nativeArray.AsReadOnly();
-            SetData(ref readonlyNativeArray, channels, sampleRate);
+            SetData(ref nativeArray, channels, sampleRate);
             nativeArray.Dispose();
         }
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -384,7 +384,7 @@ namespace Unity.WebRTC
                 if (WebRTC.Table[ptr] is RTCPeerConnection connection)
                 {
                     var receiver = WebRTC.FindOrCreate(
-                        receiverPtr, ptr => new RTCRtpReceiver(ptr, connection));
+                        receiverPtr, _ptr => new RTCRtpReceiver(_ptr, connection));
                     connection.cacheTracks.Remove(receiver.Track);
                 }
             });

--- a/Samples~/Audio/AudioSpectrumView.cs
+++ b/Samples~/Audio/AudioSpectrumView.cs
@@ -19,7 +19,7 @@ namespace Unity.WebRTC.Samples
         float[] spectrum = new float[2048];
         private AudioClip clip;
 
-        NativeArray<Vector3> array;
+        Vector3[] array;
         List<LineRenderer> lines = new List<LineRenderer>();
 
         private Dictionary<AudioSpeakerMode, int> SpeakerModeToChannel = new Dictionary<AudioSpeakerMode, int>()
@@ -34,7 +34,7 @@ namespace Unity.WebRTC.Samples
 
         void Start()
         {
-            array = new NativeArray<Vector3>(positionCount, Allocator.Persistent);
+            array = new Vector3[positionCount];
 
             // This line object is used as a template.
             if(line.gameObject.activeInHierarchy)
@@ -47,11 +47,6 @@ namespace Unity.WebRTC.Samples
         {
             // reset lines;
             clip = null;
-        }
-
-        void OnDestroy()
-        {
-            array.Dispose();
         }
 
         void ResetLines(int channelCount)

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -413,7 +413,7 @@ namespace Unity.WebRTC.RuntimeTest
             test.component.SetStream(stream);
             yield return test;
 
-            foreach (var receiver in test.component.GetReceivers(1))
+            foreach (var receiver in test.component.GetPeerReceivers(1))
             {
                 Assert.That(receiver.Streams, Has.Count.EqualTo(1));
             }

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -45,7 +45,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         public RTCStatsReportAsyncOperation GetReceiverStats(int indexPeer, int indexReceiver)
         {
-            return GetReceivers(indexPeer).ElementAt(indexReceiver).GetStats();
+            return GetPeerReceivers(indexPeer).ElementAt(indexReceiver).GetStats();
         }
 
         public IEnumerable<RTCRtpSender> GetPeerSenders(int indexPeer)
@@ -53,7 +53,7 @@ namespace Unity.WebRTC.RuntimeTest
             return peers[indexPeer].GetSenders();
         }
 
-        public IEnumerable<RTCRtpReceiver> GetReceivers(int indexPeer)
+        public IEnumerable<RTCRtpReceiver> GetPeerReceivers(int indexPeer)
         {
             return peers[indexPeer].GetReceivers();
         }
@@ -87,16 +87,16 @@ namespace Unity.WebRTC.RuntimeTest
             };
             peers[1].OnIceCandidate = candidate =>
             {
-                Assert.NotNull(candidate);
-                Assert.NotNull(candidate.Candidate);
+                Assert.That(candidate, Is.Not.Null);
+                Assert.That(candidate.Candidate, Is.Not.Null);
                 peers[0].AddIceCandidate(candidate);
             };
             peers[1].OnTrack = e =>
             {
-                Assert.NotNull(e);
-                Assert.NotNull(e.Track);
-                Assert.NotNull(e.Receiver);
-                Assert.NotNull(e.Transceiver);
+                Assert.That(e, Is.Not.Null);
+                Assert.That(e.Track, Is.Not.Null);
+                Assert.That(e.Receiver, Is.Not.Null);
+                Assert.That(e.Transceiver, Is.Not.Null);
                 peers[1].AddTrack(e.Track);
             };
             peers[0].OnDataChannel = e =>
@@ -161,7 +161,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             if (m_stream != null)
             {
-                var op9 = new WaitUntilWithTimeout(() => GetPeerSenders(0).Any(), 5000);
+                var op9 = new WaitUntilWithTimeout(() => GetPeerSenders(0).Any() && GetPeerReceivers(1).Any(), 5000);
                 yield return op9;
                 Assert.That(op9.IsCompleted, Is.True);
             }


### PR DESCRIPTION
`NativeArray<T>.ReadOnly` type is not supported on Unity2019, so I add an override method to fix it.