### PR TITLE
fix: Call the method UnityEngine.Object.DestroyImmediate on main thread

### DIFF
--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -64,7 +64,9 @@ namespace Unity.WebRTC
             public void Dispose()
             {
                 if(m_clip != null)
-                    Object.Destroy(m_clip);
+                {
+                    WebRTC.DestroyOnMainThread(m_clip);
+                }
                 m_clip = null;
             }
 
@@ -145,7 +147,11 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 if(_audioSourceRead != null)
-                    Object.Destroy(_audioSourceRead);
+                {
+                    // Unity API must be called from main thread.
+                    _audioSourceRead.onAudioRead -= SetData;
+                    WebRTC.DestroyOnMainThread(_audioSourceRead);
+                }
                 _streamRenderer?.Dispose();
                 WebRTC.Context.AudioTrackUnregisterAudioReceiveCallback(self);
                 WebRTC.Context.DeleteMediaStreamTrack(self);
@@ -169,7 +175,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                NativeMethods.ProcessAudio(self, (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 #endif
@@ -185,7 +191,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                NativeMethods.ProcessAudio(self, (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 
@@ -199,7 +205,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
-                NativeMethods.ProcessAudio(self, (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+                NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
         }
 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -166,13 +166,17 @@ namespace Unity.WebRTC
                     WebRTC.Context.FinalizeEncoder(self);
                     if (RenderTexture.active == m_destTexture)
                         RenderTexture.active = null;
-                    UnityEngine.Object.DestroyImmediate(m_destTexture);
+
+                    // Unity API must be called from main thread.
+                    WebRTC.DestroyOnMainThread(m_destTexture);
                 }
 
                 if (IsDecoderInitialized)
                 {
                     m_renderer.Dispose();
-                    UnityEngine.Object.DestroyImmediate(m_sourceTexture);
+
+                    // Unity API must be called from main thread.
+                    WebRTC.DestroyOnMainThread(m_destTexture);
                 }
 
                 s_tracks.TryRemove(self, out var value);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -614,6 +614,10 @@ namespace Unity.WebRTC
             }
             return false;
         }
+        internal static void DestroyOnMainThread(UnityEngine.Object obj)
+        {
+            s_syncContext.Post(DestroyImmediate, obj);
+        }
 
         internal static void Sync(IntPtr ptr, Action callback)
         {
@@ -633,6 +637,13 @@ namespace Unity.WebRTC
             }
             obj.callback();
         }
+
+        static void DestroyImmediate(object state)
+        {
+            var obj = state as UnityEngine.Object;
+            UnityEngine.Object.DestroyImmediate(obj);
+        }
+
 
         internal static IEnumerable<T> Deserialize<T>(IntPtr buf, int length, Func<IntPtr, T> constructor) where T : class
         {


### PR DESCRIPTION
Fix the crash bug in the `PerfectNegotiation` sample scene.

```
[impolite-Peer] SRD Offer SignalingState Stable
0x00007FFC9C17538E (UnityPlayer) UnityMain
0x00007FFC9C179FC7 (UnityPlayer) UnityMain
0x00007FFC9C076883 (UnityPlayer) UnityMain
0x00007FFC9C074BD6 (UnityPlayer) UnityMain
0x00007FFC9C24E4D3 (UnityPlayer) UnityMain
0x00007FFC9C24E244 (UnityPlayer) UnityMain
0x00007FFC9C3C487C (UnityPlayer) UnityMain
0x00007FFC9C429D0C (UnityPlayer) UnityMain
0x000001CEE243ED10 (Mono JIT Code) (wrapper managed-to-native) UnityEngine.Object:DestroyImmediate (UnityEngine.Object,bool)
0x000001CEE243EC53 (Mono JIT Code) UnityEngine.Object:DestroyImmediate (UnityEngine.Object)
0x000001CEE243E143 (Mono JIT Code) Unity.WebRTC.VideoStreamTrack:Dispose ()
0x000001CEE243DF89 (Mono JIT Code) Unity.WebRTC.MediaStreamTrack:Finalize ()
0x000001CEE243BED0 (Mono JIT Code) (wrapper runtime-invoke) object:runtime_invoke_void__this__ (object,intptr,intptr,intptr)
0x00007FFCB271E630 (mono-2.0-bdwgc) mono_get_runtime_build_info
0x00007FFCB26A2AC2 (mono-2.0-bdwgc) mono_perfcounters_init
0x00007FFCB2704E16 (mono-2.0-bdwgc) mono_gc_reference_queue_new
0x00007FFCB2900132 (mono-2.0-bdwgc) GC_gcj_malloc
0x00007FFCB2703D89 (mono-2.0-bdwgc) mono_callspec_parse
0x00007FFCB26C6BB8 (mono-2.0-bdwgc) mono_unity_managed_callstack
0x00007FFCB26C6946 (mono-2.0-bdwgc) mono_unity_managed_callstack
0x00007FFD6A7E7034 (KERNEL32) BaseThreadInitThunk
0x00007FFD6A922651 (ntdll) RtlUserThreadStart
```