### PR TITLE
fix:  Change procedures of getting audio binary array

### DIFF
--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -47,8 +47,8 @@ namespace Unity.WebRTC
             var length = current - prev;
             var data = new float[length * channels];
             clip.GetData(data, prev);
-            NativeArray<float>.Copy(data, 0, nativeArray, prev, length);
-            var slice = new NativeSlice<float>(nativeArray, prev, length);
+            NativeArray<float>.Copy(data, 0, nativeArray, prev, data.Length);
+            var slice = new NativeSlice<float>(nativeArray, prev, data.Length);
             onAudioRead?.Invoke(ref slice, channels, sampleRate);
         }
 

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -3,14 +3,14 @@ using UnityEngine;
 namespace Unity.WebRTC
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="data"></param>
     /// <param name="channels"></param>
     delegate void AudioReadEventHandler(float[] data, int channels, int sampleRate);
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [RequireComponent(typeof(AudioSource))]
     internal class AudioSourceRead : MonoBehaviour
@@ -18,15 +18,54 @@ namespace Unity.WebRTC
         public event AudioReadEventHandler onAudioRead;
 
         private int sampleRate;
+        private int channels;
+        private int prevTimeSamples;
+
+        private AudioClip clip;
+        private AudioSource source;
 
         void OnEnable()
         {
-            sampleRate = GetComponent<AudioSource>().clip.frequency;
+            source = GetComponent<AudioSource>();
+            clip = source.clip;
+            channels = clip.channels;
+            sampleRate = clip.frequency;
+
+            Debug.Log("channels:" + channels);
+            Debug.Log("sampleRate:" + sampleRate);
+
         }
 
-        void OnAudioFilterRead(float[] data, int channels)
+        void Update()
         {
-            onAudioRead?.Invoke(data, channels, sampleRate);
-        }
+            Debug.Log("source.timeSamples:" + source.timeSamples);
+
+            if (source.timeSamples == prevTimeSamples)
+                return;
+
+            if (source.timeSamples < prevTimeSamples)
+            {
+                var length = clip.samples - prevTimeSamples;
+                var data = new float[length * channels];
+                clip.GetData(data, prevTimeSamples);
+                onAudioRead?.Invoke(data, channels, sampleRate);
+                prevTimeSamples = 0;
+            }
+
+            if (source.timeSamples == prevTimeSamples)
+                return;
+
+            {
+                var length = source.timeSamples - prevTimeSamples;
+                var data = new float[length * channels];
+                clip.GetData(data, prevTimeSamples);
+                onAudioRead?.Invoke(data, channels, sampleRate);
+                prevTimeSamples = source.timeSamples;
+            }
+    }
+        // void OnAudioFilterRead(float[] data, int channels)
+        // {
+        //     onAudioRead?.Invoke(data, channels, sampleRate);
+        // }
     }
 }

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using Unity.Collections;
 

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -38,12 +38,11 @@ namespace Unity.WebRTC
 
         void Update()
         {
-            Debug.Log("source.timeSamples:" + source.timeSamples);
-
-            if (source.timeSamples == prevTimeSamples)
+            var timeSamples= source.timeSamples;
+            if (timeSamples == prevTimeSamples)
                 return;
 
-            if (source.timeSamples < prevTimeSamples)
+            if (timeSamples < prevTimeSamples)
             {
                 var length = clip.samples - prevTimeSamples;
                 var data = new float[length * channels];
@@ -52,15 +51,15 @@ namespace Unity.WebRTC
                 prevTimeSamples = 0;
             }
 
-            if (source.timeSamples == prevTimeSamples)
+            if (timeSamples == prevTimeSamples)
                 return;
 
             {
-                var length = source.timeSamples - prevTimeSamples;
+                var length = timeSamples - prevTimeSamples;
                 var data = new float[length * channels];
                 clip.GetData(data, prevTimeSamples);
                 onAudioRead?.Invoke(data, channels, sampleRate);
-                prevTimeSamples = source.timeSamples;
+                prevTimeSamples = timeSamples;
             }
     }
         // void OnAudioFilterRead(float[] data, int channels)

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -7,28 +7,28 @@ using Object = UnityEngine.Object;
 namespace Unity.WebRTC
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="renderer"></param>
     public delegate void OnAudioReceived(AudioClip renderer);
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class AudioStreamTrack : MediaStreamTrack
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public event OnAudioReceived OnAudioReceived;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public AudioSource Source { get; private set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public AudioClip Renderer
         {
@@ -106,14 +106,14 @@ namespace Unity.WebRTC
         private AudioStreamRenderer _streamRenderer;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public AudioStreamTrack() : this(WebRTC.Context.CreateAudioTrack(Guid.NewGuid().ToString()))
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="source"></param>
         public AudioStreamTrack(AudioSource source) : this()
@@ -131,11 +131,11 @@ namespace Unity.WebRTC
 
         internal AudioStreamTrack(IntPtr ptr) : base(ptr)
         {
-            WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
+            //WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public override void Dispose()
         {
@@ -165,7 +165,7 @@ namespace Unity.WebRTC
 
 #if UNITY_2020_1_OR_NEWER
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="nativeArray"></param>
         /// <param name="channels"></param>
@@ -181,7 +181,7 @@ namespace Unity.WebRTC
 #endif
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="nativeArray"></param>
         /// <param name="channels"></param>
@@ -193,10 +193,11 @@ namespace Unity.WebRTC
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
                 NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
+            OnAudioReceive(self, nativeArray.ToArray(), nativeArray.Length, sampleRate, channels, sampleRate);
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="nativeSlice"></param>
         /// <param name="channels"></param>
@@ -210,7 +211,7 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="array"></param>
         /// <param name="channels"></param>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -2,7 +2,6 @@ using System;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace Unity.WebRTC
 {
@@ -131,7 +130,7 @@ namespace Unity.WebRTC
 
         internal AudioStreamTrack(IntPtr ptr) : base(ptr)
         {
-            //WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
+            WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
         }
 
         /// <summary>
@@ -207,8 +206,6 @@ namespace Unity.WebRTC
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
                 NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
-            //OnAudioReceive(self, nativeArray.ToArray(), nativeArray.Length, sampleRate, channels, sampleRate);
-            OnAudioReceivedInternal(nativeSlice.ToArray(), sampleRate, channels, sampleRate);
         }
 
         /// <summary>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -193,8 +193,6 @@ namespace Unity.WebRTC
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
                 NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
-            //OnAudioReceive(self, nativeArray.ToArray(), nativeArray.Length, sampleRate, channels, sampleRate);
-            OnAudioReceivedInternal(nativeArray.ToArray(), sampleRate, channels, sampleRate);
         }
 
         /// <summary>
@@ -209,6 +207,8 @@ namespace Unity.WebRTC
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
                 NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
+            //OnAudioReceive(self, nativeArray.ToArray(), nativeArray.Length, sampleRate, channels, sampleRate);
+            OnAudioReceivedInternal(nativeSlice.ToArray(), sampleRate, channels, sampleRate);
         }
 
         /// <summary>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -193,7 +193,8 @@ namespace Unity.WebRTC
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
                 NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
-            OnAudioReceive(self, nativeArray.ToArray(), nativeArray.Length, sampleRate, channels, sampleRate);
+            //OnAudioReceive(self, nativeArray.ToArray(), nativeArray.Length, sampleRate, channels, sampleRate);
+            OnAudioReceivedInternal(nativeArray.ToArray(), sampleRate, channels, sampleRate);
         }
 
         /// <summary>

--- a/Samples~/Audio/AudioSample.cs
+++ b/Samples~/Audio/AudioSample.cs
@@ -141,6 +141,7 @@ namespace Unity.WebRTC
             buttonCall.interactable = true;
             buttonHangup.interactable = true;
             dropdownSpeakerMode.interactable = false;
+            dropdownDSPBufferSize.interactable = false;
         }
 
         void OnEnableMicrophone(bool enable)
@@ -156,7 +157,7 @@ namespace Unity.WebRTC
             dropdownBandwidth.interactable = true;
 
             _receiveStream = new MediaStream();
-//            _receiveStream.OnAddTrack += OnAddTrack;
+            _receiveStream.OnAddTrack += OnAddTrack;
             _sendStream = new MediaStream();
 
             var configuration = GetSelectedSdpSemantics();
@@ -176,7 +177,6 @@ namespace Unity.WebRTC
             transceiver2.Direction = RTCRtpTransceiverDirection.RecvOnly;
 
             m_audioTrack = new AudioStreamTrack(inputAudioSource);
-            m_audioTrack.OnAudioReceived += OnAudioReceived;
             _pc1.AddTrack(m_audioTrack, _sendStream);
 
             var transceiver1 = _pc1.GetTransceivers().First();
@@ -254,6 +254,7 @@ namespace Unity.WebRTC
             buttonPause.gameObject.SetActive(true);
 
             dropdownSpeakerMode.interactable = true;
+            dropdownDSPBufferSize.interactable = true;
             dropdownBandwidth.interactable = false;
 
         }

--- a/Samples~/Audio/AudioSample.cs
+++ b/Samples~/Audio/AudioSample.cs
@@ -156,7 +156,7 @@ namespace Unity.WebRTC
             dropdownBandwidth.interactable = true;
 
             _receiveStream = new MediaStream();
-            _receiveStream.OnAddTrack += OnAddTrack;
+//            _receiveStream.OnAddTrack += OnAddTrack;
             _sendStream = new MediaStream();
 
             var configuration = GetSelectedSdpSemantics();
@@ -176,7 +176,7 @@ namespace Unity.WebRTC
             transceiver2.Direction = RTCRtpTransceiverDirection.RecvOnly;
 
             m_audioTrack = new AudioStreamTrack(inputAudioSource);
-
+            m_audioTrack.OnAudioReceived += OnAudioReceived;
             _pc1.AddTrack(m_audioTrack, _sendStream);
 
             var transceiver1 = _pc1.GetTransceivers().First();


### PR DESCRIPTION
This pull request fixes the issue that it is different pitches of audios between peers on iOS platform.
In detail, The change is using `AudioClip.GetData` instead of `MonoBehaviour.OnAudioFilterRead` to get the audio buffer from `AudioClip`.