### PR TITLE
fix: Manage lifespan of native objects using reference counter 

### DIFF
--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -106,6 +106,7 @@ if(Windows)
       Msdmo
       Dmoguids
       wmcodecdspuuid
+      Strmiids
   )
   target_include_directories(WebRTCLib
     PUBLIC

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -351,7 +351,7 @@ namespace webrtc
     {
         rtc::scoped_refptr<webrtc::MediaStreamInterface> stream =
             m_peerConnectionFactory->CreateLocalMediaStream(streamId);
-        m_mapRefPtr.try_emplace(stream.get(), stream);
+        m_mapRefPtr.emplace(stream.get(), stream);
 
         //m_mapLocalMediaStream[streamId] = stream.release();
         return stream.get();
@@ -416,7 +416,7 @@ namespace webrtc
         const rtc::scoped_refptr<AudioTrackInterface> track =
             m_peerConnectionFactory->CreateAudioTrack(label, source);
         //m_mediaSteamTrackList.push_back(track);
-        m_mapRefPtr.try_emplace(track.get(), track);
+        m_mapRefPtr.emplace(track.get(), track);
         return track;
     }
 

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -236,7 +236,6 @@ namespace webrtc
                 {
                     m_audioDevice = nullptr;
                 });
-            m_audioTrack = nullptr;
 
             m_mapIdAndEncoder.clear();
             //m_mediaSteamTrackList.clear();
@@ -249,7 +248,6 @@ namespace webrtc
             }
 
             m_mapRefPtr.clear();
-            //m_mapLocalMediaStream.clear();
             m_mapMediaStreamObserver.clear();
             m_mapSetSessionDescriptionObserver.clear();
             m_mapVideoEncoderParameter.clear();
@@ -357,16 +355,6 @@ namespace webrtc
         return stream.get();
     }
 
-    void Context::DeleteMediaStream(webrtc::MediaStreamInterface* stream)
-    {
-        m_mapRefPtr.erase(stream);
-        //if (m_mapLocalMediaStream.find(stream->id()) != m_mapLocalMediaStream.end())
-        //{
-        //    m_mapLocalMediaStream.erase(stream->id());
-        //    stream->Release();
-        //}
-    }
-
     void Context::RegisterMediaStreamObserver(webrtc::MediaStreamInterface* stream)
     {
         m_mapMediaStreamObserver[stream] = std::make_unique<MediaStreamObserver>(stream, this);
@@ -420,17 +408,6 @@ namespace webrtc
         return track;
     }
 
-    void Context::DeleteMediaStreamTrack(MediaStreamTrackInterface* track)
-    {
-        //const auto result = std::find_if(
-        //    m_mediaSteamTrackList.begin(), m_mediaSteamTrackList.end(),
-        //    [track](rtc::scoped_refptr<MediaStreamTrackInterface> x) { return x.get() == track; });
-        //if(result != m_mediaSteamTrackList.end())
-        //{
-        //    m_mediaSteamTrackList.erase(result);
-        //}
-        m_mapRefPtr.erase(track);
-    }
 
     void Context::RegisterAudioReceiveCallback(
         AudioTrackInterface* track, DelegateAudioReceive callback)

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -367,17 +367,22 @@ namespace webrtc
         return m_mapMediaStreamObserver[stream].get();
     }
 
-    webrtc::VideoTrackInterface* Context::CreateVideoTrack(
-        const std::string& label)
+    VideoTrackSourceInterface* Context::CreateVideoSource()
     {
-        const rtc::scoped_refptr<UnityVideoTrackSource> source =
+        rtc::scoped_refptr<UnityVideoTrackSource> source =
             new rtc::RefCountedObject<UnityVideoTrackSource>(false, nullptr);
 
+        AddRefPtr(source);
+        return source;
+    }
+
+    webrtc::VideoTrackInterface* Context::CreateVideoTrack(
+        const std::string& label, VideoTrackSourceInterface* source)
+    {
         const rtc::scoped_refptr<VideoTrackInterface> track =
             m_peerConnectionFactory->CreateVideoTrack(label, source);
 
         AddRefPtr(track);
-        AddRefPtr(source);
 
         return track;
     }

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -469,7 +469,7 @@ namespace webrtc
         return ptr;
     }
 
-    void Context::AddDataChannel(std::unique_ptr<DataChannelObject>& channel) {
+    void Context::AddDataChannel(std::unique_ptr<DataChannelObject> channel) {
         const auto ptr = channel.get();
         m_mapDataChannels[ptr] = std::move(channel);
     }

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -265,6 +265,12 @@ namespace webrtc
 
     UnityVideoTrackSource* Context::GetVideoSource(const MediaStreamTrackInterface* track)
     {
+        if (m_mapRefPtr.find(track) == m_mapRefPtr.end())
+        {
+            RTC_LOG(LS_INFO) << "track is not found";
+            return nullptr;
+        }
+
         const VideoTrackInterface* videoTrack = static_cast<const VideoTrackInterface*>(track);
         webrtc::VideoTrackSourceInterface* _source = videoTrack->GetSource();
         if (m_mapRefPtr.find(_source) == m_mapRefPtr.end())

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -383,7 +383,6 @@ namespace webrtc
             m_peerConnectionFactory->CreateVideoTrack(label, source);
 
         AddRefPtr(track);
-
         return track;
     }
 
@@ -404,7 +403,6 @@ namespace webrtc
             UnityAudioTrackSource::Create(audioOptions);
 
         AddRefPtr(source);
-
         return source;
     }
 
@@ -414,7 +412,6 @@ namespace webrtc
             m_peerConnectionFactory->CreateAudioTrack(label, source);
 
         AddRefPtr(track);
-
         return track;
     }
 

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -258,7 +258,7 @@ namespace webrtc
 
     UnityVideoTrackSource* Context::GetVideoSource(const MediaStreamTrackInterface* track)
     {
-        if (ExistsRefPtr(track))
+        if (!ExistsRefPtr(track))
         {
             RTC_LOG(LS_INFO) << "track is not found";
             return nullptr;
@@ -267,7 +267,7 @@ namespace webrtc
         const VideoTrackInterface* videoTrack = static_cast<const VideoTrackInterface*>(track);
         webrtc::VideoTrackSourceInterface* source = videoTrack->GetSource();
 
-        if (ExistsRefPtr(source))
+        if (!ExistsRefPtr(source))
         {
             RTC_LOG(LS_INFO) << "source is not found";
             return nullptr;
@@ -387,7 +387,7 @@ namespace webrtc
         // todo:(kazuki)
     }
 
-    AudioTrackInterface* Context::CreateAudioTrack(const std::string& label)
+    webrtc::AudioSourceInterface* Context::CreateAudioSource()
     {
         //avoid optimization specially for voice
         cricket::AudioOptions audioOptions;
@@ -396,13 +396,19 @@ namespace webrtc
         audioOptions.highpass_filter = false;
 
         const rtc::scoped_refptr<UnityAudioTrackSource> source =
-            UnityAudioTrackSource::Create(label, audioOptions);
+            UnityAudioTrackSource::Create(audioOptions);
 
+        AddRefPtr(source);
+
+        return source;
+    }
+
+    AudioTrackInterface* Context::CreateAudioTrack(const std::string& label, webrtc::AudioSourceInterface* source)
+    {
         const rtc::scoped_refptr<AudioTrackInterface> track =
             m_peerConnectionFactory->CreateAudioTrack(label, source);
 
         AddRefPtr(track);
-        AddRefPtr(source);
 
         return track;
     }

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -71,7 +71,7 @@ namespace webrtc
             return m_mapRefPtr.find(ptr) != m_mapRefPtr.end();
         }
         template <typename T>
-        void AddRefPtr(rtc::scoped_refptr<T>& refptr) {
+        void AddRefPtr(rtc::scoped_refptr<T> refptr) {
 //            std::lock_guard<std::mutex> lock(mutex);
             m_mapRefPtr.emplace(refptr.get(), refptr); }
         template <typename T>
@@ -116,7 +116,7 @@ namespace webrtc
     
         // DataChannel
         DataChannelObject* CreateDataChannel(PeerConnectionObject* obj, const char* label, const DataChannelInit& options);
-        void AddDataChannel(std::unique_ptr<DataChannelObject>& channel);
+        void AddDataChannel(std::unique_ptr<DataChannelObject> channel);
         void DeleteDataChannel(DataChannelObject* obj);
 
         // Renderer

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -66,27 +66,36 @@ namespace webrtc
         CodecInitializationResult GetInitializationResult(webrtc::MediaStreamTrackInterface* track);
 
         template <typename T>
-        rtc::scoped_refptr<T> GetRefPtr(T* ptr) { return *static_cast<rtc::scoped_refptr<T>*>((void*)(&m_mapRefPtr.find(ptr))); }
+        bool ExistsRefPtr(T* ptr) {
+//            std::lock_guard<std::mutex> lock(mutex);
+            return m_mapRefPtr.find(ptr) != m_mapRefPtr.end();
+        }
         template <typename T>
-        void AddRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.emplace(refptr.get(), refptr); }
+        void AddRefPtr(rtc::scoped_refptr<T>& refptr) {
+//            std::lock_guard<std::mutex> lock(mutex);
+            m_mapRefPtr.emplace(refptr.get(), refptr); }
         template <typename T>
-        void AddRefPtr(T* ptr) { m_mapRefPtr.emplace(ptr, ptr); }
+        void AddRefPtr(T* ptr) {
+//            std::lock_guard<std::mutex> lock(mutex);
+            m_mapRefPtr.emplace(ptr, ptr); }
         template <typename T>
-        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.erase(refptr.get()); }
+        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) {
+//                        std::lock_guard<std::mutex> lock(mutex);
+            m_mapRefPtr.erase(refptr.get()); }
         template <typename T>
-        void RemoveRefPtr(T* ptr) { m_mapRefPtr.erase(ptr); }
+        void RemoveRefPtr(T* ptr) {
+//                        std::lock_guard<std::mutex> lock(mutex);
+            m_mapRefPtr.erase(ptr); }
 
         // MediaStream
         webrtc::MediaStreamInterface* CreateMediaStream(const std::string& streamId);
         void RegisterMediaStreamObserver(webrtc::MediaStreamInterface* stream);
         void UnRegisterMediaStreamObserver(webrtc::MediaStreamInterface* stream);
-        void DeleteMediaStream(webrtc::MediaStreamInterface* stream);
         MediaStreamObserver* GetObserver(const webrtc::MediaStreamInterface* stream);
 
         // MediaStreamTrack
         webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label);
         webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label);
-        void DeleteMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         UnityVideoTrackSource* GetVideoSource(const MediaStreamTrackInterface* track);
 
@@ -141,7 +150,6 @@ namespace webrtc
         std::unique_ptr<rtc::Thread> m_signalingThread;
         rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
         rtc::scoped_refptr<DummyAudioDevice> m_audioDevice;
-        rtc::scoped_refptr<webrtc::AudioTrackInterface> m_audioTrack;
         //std::list<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> m_mediaSteamTrackList;
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
         std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -65,6 +65,17 @@ namespace webrtc
         UnityEncoderType GetEncoderType() const;
         CodecInitializationResult GetInitializationResult(webrtc::MediaStreamTrackInterface* track);
 
+        template <typename T>
+        rtc::scoped_refptr<T> GetRefPtr(T* ptr) { return *static_cast<rtc::scoped_refptr<T>*>((void*)(&m_mapRefPtr.find(ptr))); }
+        template <typename T>
+        void AddRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.try_emplace(refptr.get(), refptr); }
+        template <typename T>
+        void AddRefPtr(T* ptr) { m_mapRefPtr.try_emplace(ptr, ptr); }
+        template <typename T>
+        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.erase(refptr.get()); }
+        template <typename T>
+        void RemoveRefPtr(T* ptr) { m_mapRefPtr.erase(ptr); }
+
         // MediaStream
         webrtc::MediaStreamInterface* CreateMediaStream(const std::string& streamId);
         void RegisterMediaStreamObserver(webrtc::MediaStreamInterface* stream);
@@ -131,10 +142,10 @@ namespace webrtc
         rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
         rtc::scoped_refptr<DummyAudioDevice> m_audioDevice;
         rtc::scoped_refptr<webrtc::AudioTrackInterface> m_audioTrack;
-        std::list<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> m_mediaSteamTrackList;
+        //std::list<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> m_mediaSteamTrackList;
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
         std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;
-        std::map<const std::string, rtc::scoped_refptr<webrtc::MediaStreamInterface>> m_mapLocalMediaStream;
+        //std::map<const std::string, rtc::scoped_refptr<webrtc::MediaStreamInterface>> m_mapLocalMediaStream;
         std::map<const webrtc::MediaStreamInterface*, std::unique_ptr<MediaStreamObserver>> m_mapMediaStreamObserver;
         std::map<const webrtc::PeerConnectionInterface*, rtc::scoped_refptr<SetSessionDescriptionObserver>> m_mapSetSessionDescriptionObserver;
         std::map<const webrtc::MediaStreamTrackInterface*, std::unique_ptr<VideoEncoderParameter>> m_mapVideoEncoderParameter;
@@ -142,6 +153,11 @@ namespace webrtc
         std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
 
         std::map<webrtc::AudioTrackInterface*, std::unique_ptr<AudioTrackSinkAdapter>> m_mapAudioTrackAndSink;
+
+
+        std::map<const rtc::RefCountInterface*, rtc::scoped_refptr<rtc::RefCountInterface>> m_mapRefPtr;
+
+
 
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
         std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -150,6 +150,7 @@ namespace webrtc
         std::unique_ptr<rtc::Thread> m_signalingThread;
         rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
         rtc::scoped_refptr<DummyAudioDevice> m_audioDevice;
+        //rtc::scoped_refptr<webrtc::AudioTrackInterface> m_audioTrack;
         //std::list<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> m_mediaSteamTrackList;
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
         std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -68,9 +68,9 @@ namespace webrtc
         template <typename T>
         rtc::scoped_refptr<T> GetRefPtr(T* ptr) { return *static_cast<rtc::scoped_refptr<T>*>((void*)(&m_mapRefPtr.find(ptr))); }
         template <typename T>
-        void AddRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.try_emplace(refptr.get(), refptr); }
+        void AddRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.emplace(refptr.get(), refptr); }
         template <typename T>
-        void AddRefPtr(T* ptr) { m_mapRefPtr.try_emplace(ptr, ptr); }
+        void AddRefPtr(T* ptr) { m_mapRefPtr.emplace(ptr, ptr); }
         template <typename T>
         void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.erase(refptr.get()); }
         template <typename T>

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -72,9 +72,17 @@ namespace webrtc
         template <typename T>
         void AddRefPtr(T* ptr) { m_mapRefPtr.emplace(ptr, ptr); }
         template <typename T>
-        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.erase(refptr.get()); }
+        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr)
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            m_mapRefPtr.erase(refptr.get());
+        }
         template <typename T>
-        void RemoveRefPtr(T* ptr) { m_mapRefPtr.erase(ptr); }
+        void RemoveRefPtr(T* ptr)
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            m_mapRefPtr.erase(ptr);
+        }
 
         // MediaStream
         webrtc::MediaStreamInterface* CreateMediaStream(const std::string& streamId);

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -66,26 +66,15 @@ namespace webrtc
         CodecInitializationResult GetInitializationResult(webrtc::MediaStreamTrackInterface* track);
 
         template <typename T>
-        bool ExistsRefPtr(T* ptr) {
-//            std::lock_guard<std::mutex> lock(mutex);
-            return m_mapRefPtr.find(ptr) != m_mapRefPtr.end();
-        }
+        bool ExistsRefPtr(T* ptr) {  return m_mapRefPtr.find(ptr) != m_mapRefPtr.end(); }
         template <typename T>
-        void AddRefPtr(rtc::scoped_refptr<T> refptr) {
-//            std::lock_guard<std::mutex> lock(mutex);
-            m_mapRefPtr.emplace(refptr.get(), refptr); }
+        void AddRefPtr(rtc::scoped_refptr<T> refptr) { m_mapRefPtr.emplace(refptr.get(), refptr); }
         template <typename T>
-        void AddRefPtr(T* ptr) {
-//            std::lock_guard<std::mutex> lock(mutex);
-            m_mapRefPtr.emplace(ptr, ptr); }
+        void AddRefPtr(T* ptr) { m_mapRefPtr.emplace(ptr, ptr); }
         template <typename T>
-        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) {
-//                        std::lock_guard<std::mutex> lock(mutex);
-            m_mapRefPtr.erase(refptr.get()); }
+        void RemoveRefPtr(rtc::scoped_refptr<T>& refptr) { m_mapRefPtr.erase(refptr.get()); }
         template <typename T>
-        void RemoveRefPtr(T* ptr) {
-//                        std::lock_guard<std::mutex> lock(mutex);
-            m_mapRefPtr.erase(ptr); }
+        void RemoveRefPtr(T* ptr) { m_mapRefPtr.erase(ptr); }
 
         // MediaStream
         webrtc::MediaStreamInterface* CreateMediaStream(const std::string& streamId);
@@ -93,9 +82,15 @@ namespace webrtc
         void UnRegisterMediaStreamObserver(webrtc::MediaStreamInterface* stream);
         MediaStreamObserver* GetObserver(const webrtc::MediaStreamInterface* stream);
 
+        // Audio Source
+        webrtc::AudioSourceInterface* CreateAudioSource();
+
+        // Video Source
+        //CreateAudioSource();
+
         // MediaStreamTrack
         webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label);
-        webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label);
+        webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label, webrtc::AudioSourceInterface* source);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         UnityVideoTrackSource* GetVideoSource(const MediaStreamTrackInterface* track);
 

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -86,10 +86,10 @@ namespace webrtc
         webrtc::AudioSourceInterface* CreateAudioSource();
 
         // Video Source
-        //CreateAudioSource();
+        webrtc::VideoTrackSourceInterface* CreateVideoSource();
 
         // MediaStreamTrack
-        webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label);
+        webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label, webrtc::VideoTrackSourceInterface* source);
         webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label, webrtc::AudioSourceInterface* source);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
         UnityVideoTrackSource* GetVideoSource(const MediaStreamTrackInterface* track);

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -145,23 +145,15 @@ namespace webrtc
         std::unique_ptr<rtc::Thread> m_signalingThread;
         rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
         rtc::scoped_refptr<DummyAudioDevice> m_audioDevice;
-        //rtc::scoped_refptr<webrtc::AudioTrackInterface> m_audioTrack;
-        //std::list<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> m_mediaSteamTrackList;
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
         std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;
-        //std::map<const std::string, rtc::scoped_refptr<webrtc::MediaStreamInterface>> m_mapLocalMediaStream;
         std::map<const webrtc::MediaStreamInterface*, std::unique_ptr<MediaStreamObserver>> m_mapMediaStreamObserver;
         std::map<const webrtc::PeerConnectionInterface*, rtc::scoped_refptr<SetSessionDescriptionObserver>> m_mapSetSessionDescriptionObserver;
         std::map<const webrtc::MediaStreamTrackInterface*, std::unique_ptr<VideoEncoderParameter>> m_mapVideoEncoderParameter;
         std::map<const DataChannelObject*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
         std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
-
         std::map<webrtc::AudioTrackInterface*, std::unique_ptr<AudioTrackSinkAdapter>> m_mapAudioTrackAndSink;
-
-
         std::map<const rtc::RefCountInterface*, rtc::scoped_refptr<rtc::RefCountInterface>> m_mapRefPtr;
-
-
 
         // todo(kazuki): remove map after moving hardware encoder instance to DummyVideoEncoder.
         std::map<const uint32_t, IEncoder*> m_mapIdAndEncoder;

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
@@ -1,12 +1,14 @@
 #include "pch.h"
 #include "MediaStreamObserver.h"
-
+#include "Context.h"
 namespace unity
 {
 namespace webrtc
 {
 
-    MediaStreamObserver::MediaStreamObserver(webrtc::MediaStreamInterface* stream) : webrtc::MediaStreamObserver(stream)
+    MediaStreamObserver::MediaStreamObserver(webrtc::MediaStreamInterface* stream, Context* context)
+        : webrtc::MediaStreamObserver(stream)
+        , m_context(context)
     {
         this->SignalVideoTrackAdded.connect(this, &MediaStreamObserver::OnVideoTrackAdded);
         this->SignalAudioTrackAdded.connect(this, &MediaStreamObserver::OnAudioTrackAdded);
@@ -17,6 +19,7 @@ namespace webrtc
     void MediaStreamObserver::OnVideoTrackAdded(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
         DebugLog("OnVideoTrackAdded trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
+        m_context->AddRefPtr(track);
         for (auto callback : m_listOnAddTrack)
         {
             callback(stream, track);
@@ -26,6 +29,7 @@ namespace webrtc
     void MediaStreamObserver::OnAudioTrackAdded(webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
         DebugLog("OnAudioTrackAdded trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
+        m_context->AddRefPtr(track);
         for (auto callback : m_listOnAddTrack)
         {
             callback(stream, track);
@@ -35,6 +39,7 @@ namespace webrtc
     void MediaStreamObserver::OnVideoTrackRemoved(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
         DebugLog("OnVideoTrackRemoved trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
+        // m_context->RemoveRefPtr(track);
         for (auto callback : m_listOnRemoveTrack)
         {
             callback(stream, track);
@@ -44,6 +49,7 @@ namespace webrtc
     void MediaStreamObserver::OnAudioTrackRemoved(webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
         DebugLog("OnAudioTrackRemoved trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
+        // m_context->RemoveRefPtr(track);
         for (auto callback : m_listOnRemoveTrack)
         {
             callback(stream, track);

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
@@ -39,7 +39,6 @@ namespace webrtc
     void MediaStreamObserver::OnVideoTrackRemoved(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
         DebugLog("OnVideoTrackRemoved trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
-        // m_context->RemoveRefPtr(track);
         for (auto callback : m_listOnRemoveTrack)
         {
             callback(stream, track);
@@ -49,7 +48,6 @@ namespace webrtc
     void MediaStreamObserver::OnAudioTrackRemoved(webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
         DebugLog("OnAudioTrackRemoved trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
-        // m_context->RemoveRefPtr(track);
         for (auto callback : m_listOnRemoveTrack)
         {
             callback(stream, track);

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.h
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.h
@@ -9,7 +9,7 @@ namespace webrtc
     class MediaStreamObserver : public webrtc::MediaStreamObserver, public sigslot::has_slots<>
     {
     public:
-        explicit MediaStreamObserver(webrtc::MediaStreamInterface* stream);
+        explicit MediaStreamObserver(webrtc::MediaStreamInterface* stream, Context* context);
         void RegisterOnAddTrack(DelegateMediaStreamOnAddTrack callback);
         void RegisterOnRemoveTrack(DelegateMediaStreamOnRemoveTrack callback);
     private:
@@ -20,6 +20,7 @@ namespace webrtc
 
         std::list<DelegateMediaStreamOnAddTrack> m_listOnAddTrack;
         std::list<DelegateMediaStreamOnRemoveTrack> m_listOnRemoveTrack;
+        Context* m_context;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -86,6 +86,8 @@ namespace webrtc
 
     void PeerConnectionObject::OnTrack(rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
     {
+        context.AddRefPtr(transceiver);
+        context.AddRefPtr(transceiver->receiver());
         context.AddRefPtr(transceiver->receiver()->track());
 
         if (onTrack != nullptr)

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -56,7 +56,7 @@ namespace webrtc
     void PeerConnectionObject::OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> channel) {
         auto obj = std::make_unique<DataChannelObject>(channel, *this);
         const auto ptr = obj.get();
-        context.AddDataChannel(obj);
+        context.AddDataChannel(std::move(obj));
         if (onDataChannel != nullptr) {
             onDataChannel(this, ptr);
         }
@@ -86,6 +86,8 @@ namespace webrtc
 
     void PeerConnectionObject::OnTrack(rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
     {
+        context.AddRefPtr(transceiver->receiver()->track());
+
         if (onTrack != nullptr)
         {
             onTrack(this, transceiver.get());

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -6,18 +6,18 @@ namespace unity
 namespace webrtc
 {
 
-rtc::scoped_refptr<UnityAudioTrackSource> UnityAudioTrackSource::Create(const std::string& sTrackName)
+rtc::scoped_refptr<UnityAudioTrackSource> UnityAudioTrackSource::Create()
 {
     rtc::scoped_refptr<UnityAudioTrackSource> source(
-        new rtc::RefCountedObject<UnityAudioTrackSource>(sTrackName));
+        new rtc::RefCountedObject<UnityAudioTrackSource>());
     return source;
 }
 
 rtc::scoped_refptr<UnityAudioTrackSource> UnityAudioTrackSource::Create(
-    const std::string& sTrackName, const cricket::AudioOptions& audio_options)
+    const cricket::AudioOptions& audio_options)
 {
     rtc::scoped_refptr<UnityAudioTrackSource> source(
-        new rtc::RefCountedObject<UnityAudioTrackSource>(sTrackName, audio_options));
+        new rtc::RefCountedObject<UnityAudioTrackSource>(audio_options));
     return source;
 }
 
@@ -70,12 +70,10 @@ void UnityAudioTrackSource::OnData(const float* pAudioData, int nSampleRate, siz
         _convertedAudioData.begin() + nNumFramesFor10ms * nNumChannels * size);
 }
 
-UnityAudioTrackSource::UnityAudioTrackSource(const std::string& sTrackName)
-    : _sTrackName(sTrackName)
+UnityAudioTrackSource::UnityAudioTrackSource()
 {
 }
-UnityAudioTrackSource::UnityAudioTrackSource(const std::string& sTrackName, const cricket::AudioOptions& audio_options)
-    : _sTrackName(sTrackName)
+UnityAudioTrackSource::UnityAudioTrackSource(const cricket::AudioOptions& audio_options)
 {
 }
 

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -11,8 +11,8 @@ namespace webrtc
     class UnityAudioTrackSource : public LocalAudioSource
     {
     public:
-        static rtc::scoped_refptr<UnityAudioTrackSource> Create(const std::string& sTrackName);
-        static rtc::scoped_refptr<UnityAudioTrackSource> Create(const std::string& sTrackName, const cricket::AudioOptions& audio_options);
+        static rtc::scoped_refptr<UnityAudioTrackSource> Create();
+        static rtc::scoped_refptr<UnityAudioTrackSource> Create(const cricket::AudioOptions& audio_options);
 
         void AddSink(AudioTrackSinkInterface* sink) override;
         void RemoveSink(AudioTrackSinkInterface* sink) override;
@@ -20,13 +20,12 @@ namespace webrtc
         void OnData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames);
 
     protected:
-        UnityAudioTrackSource(const std::string& sTrackName);
-        UnityAudioTrackSource(const std::string& sTrackName, const cricket::AudioOptions& audio_options);
+        UnityAudioTrackSource();
+        UnityAudioTrackSource(const cricket::AudioOptions& audio_options);
 
         ~UnityAudioTrackSource() override;
 
     private:
-        std::string _sTrackName;
         std::vector<int16_t> _convertedAudioData;
         std::vector <AudioTrackSinkInterface*> _arrSink;
         std::mutex _mutex;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -269,6 +269,12 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
     const VideoStreamRenderEventID event =
         static_cast<VideoStreamRenderEventID>(eventID);
 
+    if (!s_context->ExistsRefPtr(track))
+    {
+        RTC_LOG(LS_INFO) << "OnRenderEvent:: track is not found";
+        return;
+    }
+
     switch(event)
     {
         case VideoStreamRenderEventID::Initialize:

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -19,14 +19,12 @@ UnityVideoTrackSource::UnityVideoTrackSource(
     encoder_(nullptr)
 {
 //  DETACH_FROM_THREAD(thread_checker_);
-    RTC_LOG(LS_INFO) << "UnityVideoTrackSource constructor";
 }
 
 UnityVideoTrackSource::~UnityVideoTrackSource()
 {
     {
         std::unique_lock<std::mutex> lock(m_mutex);
-        RTC_LOG(LS_INFO) << "UnityVideoTrackSource destructor";
     }
 }
 

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -19,12 +19,14 @@ UnityVideoTrackSource::UnityVideoTrackSource(
     encoder_(nullptr)
 {
 //  DETACH_FROM_THREAD(thread_checker_);
+    RTC_LOG(LS_INFO) << "UnityVideoTrackSource constructor";
 }
 
 UnityVideoTrackSource::~UnityVideoTrackSource()
 {
     {
         std::unique_lock<std::mutex> lock(m_mutex);
+        RTC_LOG(LS_INFO) << "UnityVideoTrackSource destructor";
     }
 }
 
@@ -50,6 +52,15 @@ bool UnityVideoTrackSource::is_screencast() const {
 absl::optional<bool> UnityVideoTrackSource::needs_denoising() const
 {
     return needs_denoising_;
+}
+
+CodecInitializationResult UnityVideoTrackSource::GetCodecInitializationResult() const
+{
+    if (encoder_ == nullptr)
+    {
+        return CodecInitializationResult::NotInitialized;
+    }
+    return encoder_->GetCodecInitializationResult();
 }
 
 void UnityVideoTrackSource::SetEncoder(IEncoder* encoder)

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -52,15 +52,7 @@ class UnityVideoTrackSource :
     void SetEncoder(IEncoder* encoder);
 
     // todo(kazuki)::
-    CodecInitializationResult GetCodecInitializationResult() const
-    {
-        if (encoder_ == nullptr)
-        {
-            return CodecInitializationResult::NotInitialized;
-        }
-        return encoder_->GetCodecInitializationResult();
-    }
-
+    CodecInitializationResult GetCodecInitializationResult() const;
     using ::webrtc::VideoTrackSourceInterface::AddOrUpdateSink;
     using ::webrtc::VideoTrackSourceInterface::RemoveSink;
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -280,15 +280,19 @@ extern "C"
     {
         context->StopMediaStreamTrack(track);
     }
-
-    UNITY_INTERFACE_EXPORT webrtc::MediaStreamTrackInterface* ContextCreateAudioTrack(Context* context, const char* label)
+    UNITY_INTERFACE_EXPORT webrtc::AudioSourceInterface* ContextCreateAudioTrackSource(Context* context)
     {
-        return context->CreateAudioTrack(label);
+        return context->CreateAudioSource();
+    }
+
+    UNITY_INTERFACE_EXPORT webrtc::MediaStreamTrackInterface* ContextCreateAudioTrack(
+        Context* context, const char* label, webrtc::AudioSourceInterface* source)
+    {
+        return context->CreateAudioTrack(label, source);
     }
 
     UNITY_INTERFACE_EXPORT void ContextDeleteRefPtr(Context* context, rtc::RefCountInterface* ptr)
     {
-        RTC_LOG(LS_INFO) << "ContextDeleteRefPtr";
         context->RemoveRefPtr(ptr);
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -271,15 +271,22 @@ extern "C"
         context->UnRegisterMediaStreamObserver(stream);
     }
 
-    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* ContextCreateVideoTrack(Context* context, const char* label)
+    UNITY_INTERFACE_EXPORT MediaStreamTrackInterface* ContextCreateVideoTrack(
+        Context* context, const char* label, webrtc::VideoTrackSourceInterface* source)
     {
-        return context->CreateVideoTrack(label);
+        return context->CreateVideoTrack(label, source);
     }
 
     UNITY_INTERFACE_EXPORT void ContextStopMediaStreamTrack(Context* context, ::webrtc::MediaStreamTrackInterface* track)
     {
         context->StopMediaStreamTrack(track);
     }
+
+    UNITY_INTERFACE_EXPORT webrtc::VideoTrackSourceInterface* ContextCreateVideoTrackSource(Context* context)
+    {
+        return context->CreateVideoSource();
+    }
+
     UNITY_INTERFACE_EXPORT webrtc::AudioSourceInterface* ContextCreateAudioTrackSource(Context* context)
     {
         return context->CreateAudioSource();

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -986,7 +986,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT void TransceiverStop(RtpTransceiverInterface* transceiver)
     {
-        transceiver->Stop();
+        transceiver->StopStandard();
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverDirection TransceiverGetDirection(RtpTransceiverInterface* transceiver)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -261,11 +261,6 @@ extern "C"
         return context->CreateMediaStream(streamId);
     }
 
-    UNITY_INTERFACE_EXPORT void ContextDeleteMediaStream(Context* context, MediaStreamInterface* stream)
-    {
-        context->DeleteMediaStream(stream);
-    }
-
     UNITY_INTERFACE_EXPORT void ContextRegisterMediaStreamObserver(Context* context, MediaStreamInterface* stream)
     {
         context->RegisterMediaStreamObserver(stream);
@@ -281,19 +276,19 @@ extern "C"
         return context->CreateVideoTrack(label);
     }
 
-    UNITY_INTERFACE_EXPORT void ContextDeleteMediaStreamTrack(Context* context, ::webrtc::MediaStreamTrackInterface* track)
-    {
-        context->DeleteMediaStreamTrack(track);
-    }
-
     UNITY_INTERFACE_EXPORT void ContextStopMediaStreamTrack(Context* context, ::webrtc::MediaStreamTrackInterface* track)
     {
         context->StopMediaStreamTrack(track);
     }
 
-    UNITY_INTERFACE_EXPORT::webrtc::MediaStreamTrackInterface* ContextCreateAudioTrack(Context* context, const char* label)
+    UNITY_INTERFACE_EXPORT webrtc::MediaStreamTrackInterface* ContextCreateAudioTrack(Context* context, const char* label)
     {
         return context->CreateAudioTrack(label);
+    }
+
+    UNITY_INTERFACE_EXPORT void ContextDeleteRefPtr(Context* context, rtc::RefCountInterface* ptr)
+    {
+        context->RemoveRefPtr(ptr);
     }
 
     UNITY_INTERFACE_EXPORT bool MediaStreamAddTrack(MediaStreamInterface* stream, MediaStreamTrackInterface* track)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -298,6 +298,11 @@ extern "C"
         return context->CreateAudioTrack(label, source);
     }
 
+    UNITY_INTERFACE_EXPORT void ContextAddRefPtr(Context* context, rtc::RefCountInterface* ptr)
+    {
+        context->AddRefPtr(ptr);
+    }
+
     UNITY_INTERFACE_EXPORT void ContextDeleteRefPtr(Context* context, rtc::RefCountInterface* ptr)
     {
         context->RemoveRefPtr(ptr);
@@ -494,10 +499,8 @@ extern "C"
         auto result = obj->connection->AddTransceiver(track);
         if (!result.ok())
             return nullptr;
-        rtc::scoped_refptr<RtpTransceiverInterface> transceiver = result.value();
-        context->AddRefPtr(transceiver);
 
-        return transceiver;
+        return result.value();
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface* PeerConnectionAddTransceiverWithInit(
@@ -506,10 +509,8 @@ extern "C"
         auto result = obj->connection->AddTransceiver(track, *init);
         if (!result.ok())
             return nullptr;
-        rtc::scoped_refptr<RtpTransceiverInterface> transceiver = result.value();
-        context->AddRefPtr(transceiver);
 
-        return transceiver;
+        return result.value();
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface* PeerConnectionAddTransceiverWithType(
@@ -518,10 +519,8 @@ extern "C"
         auto result = obj->connection->AddTransceiver(type);
         if (!result.ok())
             return nullptr;
-        rtc::scoped_refptr<RtpTransceiverInterface> transceiver = result.value();
-        context->AddRefPtr(transceiver);
 
-        return transceiver;
+        return result.value();
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface* PeerConnectionAddTransceiverWithTypeAndInit(
@@ -530,10 +529,8 @@ extern "C"
         auto result = obj->connection->AddTransceiver(type, *init);
         if (!result.ok())
             return nullptr;
-        rtc::scoped_refptr<RtpTransceiverInterface> transceiver = result.value();
-        context->AddRefPtr(transceiver);
 
-        return transceiver;
+        return result.value();
     }
 
     UNITY_INTERFACE_EXPORT RTCErrorType PeerConnectionRemoveTrack(PeerConnectionObject* obj, RtpSenderInterface* sender)
@@ -794,30 +791,18 @@ extern "C"
     UNITY_INTERFACE_EXPORT RtpReceiverInterface** PeerConnectionGetReceivers(Context* context, PeerConnectionObject* obj, size_t* length)
     {
         auto receivers = obj->connection->GetReceivers();
-        for (auto receiver : receivers)
-        {
-            context->AddRefPtr(receiver);
-        }
         return ConvertPtrArrayFromRefPtrArray<RtpReceiverInterface>(receivers, length);
     }
 
     UNITY_INTERFACE_EXPORT RtpSenderInterface** PeerConnectionGetSenders(Context* context, PeerConnectionObject* obj, size_t* length)
     {
         auto senders = obj->connection->GetSenders();
-        for (auto sender : senders)
-        {
-            context->AddRefPtr(sender);
-        }
         return ConvertPtrArrayFromRefPtrArray<RtpSenderInterface>(senders, length);
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface** PeerConnectionGetTransceivers(Context* context, PeerConnectionObject* obj, size_t* length)
     {
         auto transceivers = obj->connection->GetTransceivers();
-        for (auto transceiver : transceivers)
-        {
-            context->AddRefPtr(transceiver);
-        }
         return ConvertPtrArrayFromRefPtrArray<RtpTransceiverInterface>(transceivers, length);
     }
 

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -109,6 +109,7 @@ if(Windows)
       Dmoguids
       wmcodecdspuuid
       WebRTCLib
+      Strmiids
   )
   target_include_directories(WebRTCLibTest
     PRIVATE

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -128,49 +128,6 @@ TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
     context->DeleteVideoRenderer(renderer);
 }
 
-class RefCountTest : public rtc::RefCountInterface
-{
-public:
-    RefCountTest()
-    {
-        RTC_LOG(LS_INFO) << "constructor";
-    }
-
-protected:
-    ~RefCountTest() override
-    {
-        RTC_LOG(LS_INFO) << "destructor";
-    }
-};
-
-TEST_P(ContextTest, Test) {
-
-    RTC_LOG(LS_INFO) << "ContextTest::0";
-    {
-        rtc::scoped_refptr<RefCountTest> hoge3;
-        rtc::scoped_refptr<rtc::RefCountInterface> hoge2;
-        rtc::scoped_refptr<RefCountTest> hoge(new rtc::RefCountedObject<RefCountTest>());
-        hoge2 = hoge;
-        auto ptr = static_cast<rtc::scoped_refptr<RefCountTest>*>((void*)&hoge2);
-        hoge3 = *ptr;
-    }
-    RTC_LOG(LS_INFO) << "ContextTest::1";
-}
-
-TEST_P(ContextTest, Test2) {
-
-    RTC_LOG(LS_INFO) << "ContextTest::0";
-    std::vector<rtc::scoped_refptr<rtc::RefCountInterface>> vec;
-    {
-        rtc::scoped_refptr<RefCountTest> hoge(new rtc::RefCountedObject<RefCountTest>());
-        vec.push_back(hoge.get());
-    }
-    RTC_LOG(LS_INFO) << "ContextTest::1";
-    vec.clear();
-    RTC_LOG(LS_INFO) << "ContextTest::2";
-}
-
-
 INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, ContextTest, testing::ValuesIn(VALUES_TEST_ENV));
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -6,6 +6,8 @@
 #include "Codec/IEncoder.h"
 #include "Context.h"
 
+#include "rtc_base/ref_counted_object.h"
+
 namespace unity
 {
 namespace webrtc
@@ -119,6 +121,49 @@ TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
     track->RemoveSink(renderer);
     context->DeleteVideoRenderer(renderer);
 }
+
+class RefCountTest : public rtc::RefCountInterface
+{
+public:
+    RefCountTest()
+    {
+        RTC_LOG(LS_INFO) << "constructor";
+    }
+
+protected:
+    ~RefCountTest() override
+    {
+        RTC_LOG(LS_INFO) << "destructor";
+    }
+};
+
+TEST_P(ContextTest, Test) {
+
+    RTC_LOG(LS_INFO) << "ContextTest::0";
+    {
+        rtc::scoped_refptr<RefCountTest> hoge3;
+        rtc::scoped_refptr<rtc::RefCountInterface> hoge2;
+        rtc::scoped_refptr<RefCountTest> hoge(new rtc::RefCountedObject<RefCountTest>());
+        hoge2 = hoge;
+        auto ptr = static_cast<rtc::scoped_refptr<RefCountTest>*>((void*)&hoge2);
+        hoge3 = *ptr;
+    }
+    RTC_LOG(LS_INFO) << "ContextTest::1";
+}
+
+TEST_P(ContextTest, Test2) {
+
+    RTC_LOG(LS_INFO) << "ContextTest::0";
+    std::vector<rtc::scoped_refptr<rtc::RefCountInterface>> vec;
+    {
+        rtc::scoped_refptr<RefCountTest> hoge(new rtc::RefCountedObject<RefCountTest>());
+        vec.push_back(hoge.get());
+    }
+    RTC_LOG(LS_INFO) << "ContextTest::1";
+    vec.clear();
+    RTC_LOG(LS_INFO) << "ContextTest::2";
+}
+
 
 INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, ContextTest, testing::ValuesIn(VALUES_TEST_ENV));
 

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -40,6 +40,8 @@ TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
     const auto source = context->CreateVideoSource();
     const auto track = context->CreateVideoTrack("video", source);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
+    context->RemoveRefPtr(track);
+    context->RemoveRefPtr(source);
 }
 
 TEST_P(ContextTest, CreateAndDeleteMediaStream) {
@@ -56,12 +58,14 @@ TEST_P(ContextTest, CreateAndDeleteVideoTrack) {
     EXPECT_NE(nullptr, track);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
     context->RemoveRefPtr(track);
+    context->RemoveRefPtr(source);
 }
 
 TEST_P(ContextTest, CreateAndDeleteAudioTrack) {
     const auto source = context->CreateAudioSource();
     const auto track = context->CreateAudioTrack("audio", source);
     context->RemoveRefPtr(track);
+    context->RemoveRefPtr(source);
 }
 
 TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
@@ -73,6 +77,7 @@ TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
     stream->RemoveTrack(audiotrack);
     context->RemoveRefPtr(stream);
     context->RemoveRefPtr(track);
+    context->RemoveRefPtr(source);
 }
 
 TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
@@ -85,6 +90,7 @@ TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
     stream->RemoveTrack(videoTrack);
     context->RemoveRefPtr(stream);
     context->RemoveRefPtr(track);
+    context->RemoveRefPtr(source);
 }
 
 TEST_P(ContextTest, CreateAndDeletePeerConnection) {
@@ -126,6 +132,8 @@ TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
     track->AddOrUpdateSink(renderer, rtc::VideoSinkWants());
     track->RemoveSink(renderer);
     context->DeleteVideoRenderer(renderer);
+    context->RemoveRefPtr(track);
+    context->RemoveRefPtr(source);
 }
 
 INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, ContextTest, testing::ValuesIn(VALUES_TEST_ENV));

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -37,49 +37,54 @@ protected:
 TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_NE(nullptr, tex);
-    const auto track = context->CreateVideoTrack("video");
+    const auto source = context->CreateVideoSource();
+    const auto track = context->CreateVideoTrack("video", source);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
 }
 
 TEST_P(ContextTest, CreateAndDeleteMediaStream) {
     const auto stream = context->CreateMediaStream("test");
-    context->DeleteMediaStream(stream);
+    context->RemoveRefPtr(stream);
 }
 
 
 TEST_P(ContextTest, CreateAndDeleteVideoTrack) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     EXPECT_NE(nullptr, tex.get());
-    const auto track = context->CreateVideoTrack("video");
+    const auto source = context->CreateVideoSource();
+    const auto track = context->CreateVideoTrack("video", source);
     EXPECT_NE(nullptr, track);
     EXPECT_TRUE(context->InitializeEncoder(encoder_.get(), track));
-    context->DeleteMediaStreamTrack(track);
+    context->RemoveRefPtr(track);
 }
 
 TEST_P(ContextTest, CreateAndDeleteAudioTrack) {
-    const auto track = context->CreateAudioTrack("audio");
-    context->DeleteMediaStreamTrack(track);
+    const auto source = context->CreateAudioSource();
+    const auto track = context->CreateAudioTrack("audio", source);
+    context->RemoveRefPtr(track);
 }
 
 TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
     const auto stream = context->CreateMediaStream("audiostream");
-    const auto track = context->CreateAudioTrack("audio");
+    const auto source = context->CreateAudioSource();
+    const auto track = context->CreateAudioTrack("audio", source);
     const auto audiotrack = reinterpret_cast<webrtc::AudioTrackInterface*>(track);
     stream->AddTrack(audiotrack);
     stream->RemoveTrack(audiotrack);
-    context->DeleteMediaStream(stream);
-    context->DeleteMediaStreamTrack(track);
+    context->RemoveRefPtr(stream);
+    context->RemoveRefPtr(track);
 }
 
 TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
     const auto stream = context->CreateMediaStream("videostream");
-    const auto track = context->CreateVideoTrack("video");
+    const auto source = context->CreateVideoSource();
+    const auto track = context->CreateVideoTrack("video", source);
     const auto videoTrack = reinterpret_cast<webrtc::VideoTrackInterface*>(track);
     stream->AddTrack(videoTrack);
     stream->RemoveTrack(videoTrack);
-    context->DeleteMediaStream(stream);
-    context->DeleteMediaStreamTrack(track);
+    context->RemoveRefPtr(stream);
+    context->RemoveRefPtr(track);
 }
 
 TEST_P(ContextTest, CreateAndDeletePeerConnection) {
@@ -115,7 +120,8 @@ TEST_P(ContextTest, EqualRendererGetById) {
 
 TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
     const std::unique_ptr<ITexture2D> tex(m_device->CreateDefaultTextureV(width, height, m_textureFormat));
-    const auto track = context->CreateVideoTrack("video");
+    const auto source = context->CreateVideoSource();
+    const auto track = context->CreateVideoTrack("video", source);
     const auto renderer = context->CreateVideoRenderer();
     track->AddOrUpdateSink(renderer, rtc::VideoSinkWants());
     track->RemoveSink(renderer);

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -62,7 +62,7 @@ namespace Unity.WebRTC
 
             public void Dispose()
             {
-                if(m_clip != null)
+                if (m_clip != null)
                 {
                     WebRTC.DestroyOnMainThread(m_clip);
                 }
@@ -103,11 +103,14 @@ namespace Unity.WebRTC
         readonly AudioSourceRead _audioSourceRead;
 
         private AudioStreamRenderer _streamRenderer;
+        private AudioTrackSource _source;
+
 
         /// <summary>
         /// 
         /// </summary>
-        public AudioStreamTrack() : this(WebRTC.Context.CreateAudioTrack(Guid.NewGuid().ToString()))
+        public AudioStreamTrack()
+            : this(Guid.NewGuid().ToString(), new AudioTrackSource())
         {
         }
 
@@ -128,6 +131,13 @@ namespace Unity.WebRTC
             _audioSourceRead.onAudioRead += SetData;
         }
 
+        internal AudioStreamTrack(string label, AudioTrackSource source)
+            : this(WebRTC.Context.CreateAudioTrack(label, source.self))
+        {
+            _source = source;
+        }
+
+
         internal AudioStreamTrack(IntPtr ptr) : base(ptr)
         {
             WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
@@ -145,13 +155,14 @@ namespace Unity.WebRTC
 
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
-                if(_audioSourceRead != null)
+                if (_audioSourceRead != null)
                 {
                     // Unity API must be called from main thread.
                     _audioSourceRead.onAudioRead -= SetData;
                     WebRTC.DestroyOnMainThread(_audioSourceRead);
                 }
                 _streamRenderer?.Dispose();
+                _source?.Dispose();
                 WebRTC.Context.AudioTrackUnregisterAudioReceiveCallback(self);
             }
             base.Dispose();
@@ -237,6 +248,31 @@ namespace Unity.WebRTC
                     track.OnAudioReceivedInternal(audioData, sampleRate, numOfChannels, numOfFrames);
                 }
             });
+        }
+    }
+    internal class AudioTrackSource : RefCountedObject
+    {
+        public AudioTrackSource() : base(WebRTC.Context.CreateAudioTrackSource())
+        {
+        }
+
+        ~AudioTrackSource()
+        {
+            this.Dispose();
+        }
+
+        public override void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
+            {
+                WebRTC.Table.Remove(self);
+            }
+            base.Dispose();
         }
     }
 }

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -2,7 +2,6 @@ using System;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace Unity.WebRTC
 {
@@ -154,13 +153,8 @@ namespace Unity.WebRTC
                 }
                 _streamRenderer?.Dispose();
                 WebRTC.Context.AudioTrackUnregisterAudioReceiveCallback(self);
-                WebRTC.Context.DeleteMediaStreamTrack(self);
-                WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
             }
-
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            base.Dispose();
         }
 
 #if UNITY_2020_1_OR_NEWER

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -137,7 +137,6 @@ namespace Unity.WebRTC
             _source = source;
         }
 
-
         internal AudioStreamTrack(IntPtr ptr) : base(ptr)
         {
             WebRTC.Context.AudioTrackRegisterAudioReceiveCallback(self, OnAudioReceive);
@@ -254,6 +253,7 @@ namespace Unity.WebRTC
     {
         public AudioTrackSource() : base(WebRTC.Context.CreateAudioTrackSource())
         {
+            WebRTC.Table.Add(self, this);
         }
 
         ~AudioTrackSource()

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -67,6 +67,12 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
+        public void AddRefPtr(IntPtr ptr)
+        {
+            NativeMethods.ContextAddRefPtr(self, ptr);
+        }
+
+
         public void DeleteRefPtr(IntPtr ptr)
         {
             NativeMethods.ContextDeleteRefPtr(self, ptr);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -212,6 +212,11 @@ namespace Unity.WebRTC
             return NativeMethods.GetUpdateTextureFunc(self);
         }
 
+        public IntPtr CreateVideoTrackSource()
+        {
+            return NativeMethods.ContextCreateVideoTrackSource(self);
+        }
+
         public IntPtr CreateAudioTrackSource()
         {
             return NativeMethods.ContextCreateAudioTrackSource(self);
@@ -222,9 +227,9 @@ namespace Unity.WebRTC
             return NativeMethods.ContextCreateAudioTrack(self, label, trackSource);
         }
 
-        public IntPtr CreateVideoTrack(string label)
+        public IntPtr CreateVideoTrack(string label, IntPtr source)
         {
-            return NativeMethods.ContextCreateVideoTrack(self, label);
+            return NativeMethods.ContextCreateVideoTrack(self, label, source);
         }
 
         public void StopMediaStreamTrack(IntPtr track)

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -212,9 +212,14 @@ namespace Unity.WebRTC
             return NativeMethods.GetUpdateTextureFunc(self);
         }
 
-        public IntPtr CreateAudioTrack(string label)
+        public IntPtr CreateAudioTrackSource()
         {
-            return NativeMethods.ContextCreateAudioTrack(self, label);
+            return NativeMethods.ContextCreateAudioTrackSource(self);
+        }
+
+        public IntPtr CreateAudioTrack(string label, IntPtr trackSource)
+        {
+            return NativeMethods.ContextCreateAudioTrack(self, label, trackSource);
         }
 
         public IntPtr CreateVideoTrack(string label)

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -131,6 +131,31 @@ namespace Unity.WebRTC
             NativeMethods.PeerConnectionRegisterOnSetSessionDescFailure(self, ptr, callback);
         }
 
+        public IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track)
+        {
+            return NativeMethods.PeerConnectionAddTransceiver(self, pc, track);
+        }
+
+        public IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind)
+        {
+            return NativeMethods.PeerConnectionAddTransceiverWithType(self, pc, kind);
+        }
+
+        public IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length)
+        {
+            return NativeMethods.PeerConnectionGetReceivers(self, ptr, out length);
+        }
+
+        public IntPtr PeerConnectionGetSenders(IntPtr ptr, out ulong length)
+        {
+            return NativeMethods.PeerConnectionGetSenders(self, ptr, out length);
+        }
+
+        public IntPtr PeerConnectionGetTransceivers(IntPtr ptr, out ulong length)
+        {
+            return NativeMethods.PeerConnectionGetTransceivers(self, ptr, out length);
+        }
+
         public IntPtr CreateDataChannel(IntPtr ptr, string label, ref RTCDataChannelInitInternal options)
         {
             return NativeMethods.ContextCreateDataChannel(self, ptr, label, ref options);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -67,6 +67,11 @@ namespace Unity.WebRTC
             GC.SuppressFinalize(this);
         }
 
+        public void DeleteRefPtr(IntPtr ptr)
+        {
+            NativeMethods.ContextDeleteRefPtr(self, ptr);
+        }
+
         public EncoderType GetEncoderType()
         {
             return NativeMethods.ContextGetEncoderType(self);
@@ -94,7 +99,7 @@ namespace Unity.WebRTC
             RTCErrorType errorType = NativeMethods.PeerConnectionSetLocalDescription(
                 self, ptr, ref desc, ref ptrError);
             string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            return new RTCError { errorType =  errorType, message = message};
+            return new RTCError { errorType = errorType, message = message };
         }
 
         public RTCError PeerConnectionSetLocalDescription(IntPtr ptr)
@@ -103,7 +108,7 @@ namespace Unity.WebRTC
             RTCErrorType errorType =
                 NativeMethods.PeerConnectionSetLocalDescriptionWithoutDescription(self, ptr, ref ptrError);
             string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            return new RTCError {errorType = errorType, message = message};
+            return new RTCError { errorType = errorType, message = message };
         }
 
         public RTCError PeerConnectionSetRemoteDescription(
@@ -113,7 +118,7 @@ namespace Unity.WebRTC
             RTCErrorType errorType = NativeMethods.PeerConnectionSetRemoteDescription(
                 self, ptr, ref desc, ref ptrError);
             string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            return new RTCError { errorType =  errorType, message = message};
+            return new RTCError { errorType = errorType, message = message };
         }
 
         public void PeerConnectionRegisterOnSetSessionDescSuccess(IntPtr ptr, DelegateNativePeerConnectionSetSessionDescSuccess callback)
@@ -139,11 +144,6 @@ namespace Unity.WebRTC
         public IntPtr CreateMediaStream(string label)
         {
             return NativeMethods.ContextCreateMediaStream(self, label);
-        }
-
-        public void DeleteMediaStream(MediaStream stream)
-        {
-            NativeMethods.ContextDeleteMediaStream(self, stream.GetSelfOrThrow());
         }
 
         public void RegisterMediaStreamObserver(MediaStream stream)
@@ -202,10 +202,6 @@ namespace Unity.WebRTC
             NativeMethods.ContextStopMediaStreamTrack(self, track);
         }
 
-        public void DeleteMediaStreamTrack(IntPtr track)
-        {
-            NativeMethods.ContextDeleteMediaStreamTrack(self, track);
-        }
 
         public IntPtr CreateVideoRenderer()
         {

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -7,7 +7,7 @@ namespace Unity.WebRTC
     public delegate void DelegateOnAddTrack(MediaStreamTrackEvent e);
     public delegate void DelegateOnRemoveTrack(MediaStreamTrackEvent e);
 
-    public class MediaStream : RefCounterObject
+    public class MediaStream : RefCountedObject
     {
         private DelegateOnAddTrack onAddTrack;
         private DelegateOnRemoveTrack onRemoveTrack;

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -7,13 +7,11 @@ namespace Unity.WebRTC
     public delegate void DelegateOnAddTrack(MediaStreamTrackEvent e);
     public delegate void DelegateOnRemoveTrack(MediaStreamTrackEvent e);
 
-    public class MediaStream : IDisposable
+    public class MediaStream : RefCounterObject
     {
         private DelegateOnAddTrack onAddTrack;
         private DelegateOnRemoveTrack onRemoveTrack;
 
-        private IntPtr self;
-        private bool disposed;
         private HashSet<MediaStreamTrack> cacheTracks = new HashSet<MediaStreamTrack>();
 
         /// <summary>
@@ -36,12 +34,9 @@ namespace Unity.WebRTC
             if(self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Context.UnRegisterMediaStreamObserver(this);
-                WebRTC.Context.DeleteMediaStream(this);
                 WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
             }
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            base.Dispose();
         }
 
         public DelegateOnAddTrack OnAddTrack
@@ -108,9 +103,8 @@ namespace Unity.WebRTC
             return self;
         }
 
-        internal MediaStream(IntPtr ptr)
+        internal MediaStream(IntPtr ptr) :base(ptr)
         {
-            self = ptr;
             WebRTC.Table.Add(self, this);
             WebRTC.Context.RegisterMediaStreamObserver(this);
             WebRTC.Context.MediaStreamRegisterOnAddTrack(this, MediaStreamOnAddTrack);

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -25,7 +25,7 @@ namespace Unity.WebRTC
             this.Dispose();
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             if (this.disposed)
             {

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Unity.WebRTC
 {
-    public class MediaStreamTrack : RefCounterObject
+    public class MediaStreamTrack : RefCountedObject
     {
         /// <summary>
         ///

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -83,8 +83,6 @@ namespace Unity.WebRTC
             {
                 Close();
                 DisposeAllTransceivers();
-                //Debug.Log("RTCPeerConnection::Dispose");
-                //WebRTC.Context.DeletePeerConnection(self);
                 WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -82,9 +82,9 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 Close();
-                //DisposeAllTransceivers();
+                DisposeAllTransceivers();
                 //Debug.Log("RTCPeerConnection::Dispose");
-                WebRTC.Context.DeletePeerConnection(self);
+                //WebRTC.Context.DeletePeerConnection(self);
                 WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -82,7 +82,8 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 Close();
-                DisposeAllTransceivers();
+                //DisposeAllTransceivers();
+                //Debug.Log("RTCPeerConnection::Dispose");
                 WebRTC.Context.DeletePeerConnection(self);
                 WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
@@ -99,6 +100,7 @@ namespace Unity.WebRTC
             {
                 // Dispose of MediaStreamTrack when disposing of RTCRtpReceiver.
                 // On the other hand, do not dispose a track when disposing of RTCRtpSender.
+                transceiver.Stop();
                 transceiver.Receiver?.Track?.Dispose();
                 transceiver.Receiver?.Dispose();
                 transceiver.Sender?.Dispose();
@@ -166,7 +168,7 @@ namespace Unity.WebRTC
         /// <seealso cref="GetTransceivers()"/>
         public IEnumerable<RTCRtpReceiver> GetReceivers()
         {
-            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(GetSelfOrThrow(), out ulong length);
+            IntPtr buf = WebRTC.Context.PeerConnectionGetReceivers(GetSelfOrThrow(), out ulong length);
             return WebRTC.Deserialize(buf, (int)length, CreateReceiver);
         }
 
@@ -183,7 +185,7 @@ namespace Unity.WebRTC
         /// <seealso cref="GetTransceivers()"/>
         public IEnumerable<RTCRtpSender> GetSenders()
         {
-            var buf = NativeMethods.PeerConnectionGetSenders(GetSelfOrThrow(), out ulong length);
+            var buf = WebRTC.Context.PeerConnectionGetSenders(GetSelfOrThrow(), out ulong length);
             return WebRTC.Deserialize(buf, (int)length, CreateSender);
         }
 
@@ -200,7 +202,7 @@ namespace Unity.WebRTC
         /// <seealso cref="GetReceivers()"/>
         public IEnumerable<RTCRtpTransceiver> GetTransceivers()
         {
-            var buf = NativeMethods.PeerConnectionGetTransceivers(GetSelfOrThrow(), out ulong length);
+            var buf = WebRTC.Context.PeerConnectionGetTransceivers(GetSelfOrThrow(), out ulong length);
             return WebRTC.Deserialize(buf, (int)length, CreateTransceiver);
         }
 
@@ -546,10 +548,10 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="sender"></param>
         /// <seealso cref="AddTrack"/>
-        public void RemoveTrack(RTCRtpSender sender)
+        public RTCErrorType RemoveTrack(RTCRtpSender sender)
         {
             cacheTracks.Remove(sender.Track);
-            NativeMethods.PeerConnectionRemoveTrack(GetSelfOrThrow(), sender.self);
+            return NativeMethods.PeerConnectionRemoveTrack(GetSelfOrThrow(), sender.self);
         }
 
         /// <summary>
@@ -559,7 +561,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track)
         {
-            IntPtr ptr = NativeMethods.PeerConnectionAddTransceiver(
+            IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiver(
                 GetSelfOrThrow(), track.GetSelfOrThrow());
             return CreateTransceiver(ptr);
         }
@@ -571,7 +573,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(TrackKind kind)
         {
-            IntPtr ptr = NativeMethods.PeerConnectionAddTransceiverWithType(
+            IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiverWithType(
                 GetSelfOrThrow(), kind);
             return CreateTransceiver(ptr);
         }

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -384,7 +384,8 @@ namespace Unity.WebRTC
                 {
                     var receiver = WebRTC.FindOrCreate(
                         receiverPtr, _ptr => new RTCRtpReceiver(_ptr, connection));
-                    connection.cacheTracks.Remove(receiver.Track);
+                    if(receiver != null)
+                        connection.cacheTracks.Remove(receiver.Track);
                 }
             });
         }

--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -7,7 +7,7 @@ namespace Unity.WebRTC
     /// <summary>
     ///
     /// </summary>
-    public class RTCRtpReceiver : RefCounterObject
+    public class RTCRtpReceiver : RefCountedObject
     {
         private RTCPeerConnection peer;
 

--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -7,15 +7,12 @@ namespace Unity.WebRTC
     /// <summary>
     ///
     /// </summary>
-    public class RTCRtpReceiver : IDisposable
+    public class RTCRtpReceiver : RefCounterObject
     {
-        internal IntPtr self;
         private RTCPeerConnection peer;
-        private bool disposed;
 
-        internal RTCRtpReceiver(IntPtr ptr, RTCPeerConnection peer)
+        internal RTCRtpReceiver(IntPtr ptr, RTCPeerConnection peer) : base(ptr)
         {
-            self = ptr;
             WebRTC.Table.Add(self, this);
             this.peer = peer;
         }
@@ -34,7 +31,7 @@ namespace Unity.WebRTC
             this.Dispose();
         }
 
-        public virtual void Dispose()
+        public override void Dispose()
         {
             if (this.disposed)
             {
@@ -43,10 +40,8 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
             }
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            base.Dispose();
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -6,7 +6,7 @@ namespace Unity.WebRTC
     /// <summary>
     ///
     /// </summary>
-    public class RTCRtpSender : RefCounterObject
+    public class RTCRtpSender : RefCountedObject
     {
         private RTCPeerConnection peer;
 

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -6,16 +6,12 @@ namespace Unity.WebRTC
     /// <summary>
     ///
     /// </summary>
-    public class RTCRtpSender : IDisposable
+    public class RTCRtpSender : RefCounterObject
     {
-        internal IntPtr self;
         private RTCPeerConnection peer;
-        private bool disposed;
 
-
-        internal RTCRtpSender(IntPtr ptr, RTCPeerConnection peer)
+        internal RTCRtpSender(IntPtr ptr, RTCPeerConnection peer) : base(ptr)
         {
-            self = ptr;
             WebRTC.Table.Add(self, this);
             this.peer = peer;
         }
@@ -34,7 +30,7 @@ namespace Unity.WebRTC
             return self;
         }
 
-        public virtual void Dispose()
+        public override void Dispose()
         {
             if (this.disposed)
             {
@@ -43,10 +39,8 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
             }
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            base.Dispose();
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -1,17 +1,13 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace Unity.WebRTC
 {
-    public class RTCRtpTransceiver
+    public class RTCRtpTransceiver : RefCounterObject
     {
-        internal IntPtr self;
         private RTCPeerConnection peer;
-        private bool disposed;
 
-        internal RTCRtpTransceiver(IntPtr ptr, RTCPeerConnection peer)
+        internal RTCRtpTransceiver(IntPtr ptr, RTCPeerConnection peer) : base(ptr)
         {
-            self = ptr;
             WebRTC.Table.Add(self, this);
             this.peer = peer;
         }
@@ -21,7 +17,7 @@ namespace Unity.WebRTC
             this.Dispose();
         }
 
-        public virtual void Dispose()
+        public override void Dispose()
         {
             if (this.disposed)
             {
@@ -30,10 +26,17 @@ namespace Unity.WebRTC
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
                 WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
             }
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            base.Dispose();
+        }
+
+        internal IntPtr GetSelfOrThrow()
+        {
+            if (self == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("This instance has been disposed.");
+            }
+            return self;
         }
 
         /// <summary>
@@ -42,8 +45,8 @@ namespace Unity.WebRTC
         /// </summary>
         public RTCRtpTransceiverDirection Direction
         {
-            get { return NativeMethods.TransceiverGetDirection(self); }
-            set { NativeMethods.TransceiverSetDirection(self, value); }
+            get { return NativeMethods.TransceiverGetDirection(GetSelfOrThrow()); }
+            set { NativeMethods.TransceiverSetDirection(GetSelfOrThrow(), value); }
         }
 
         /// <summary>
@@ -56,7 +59,7 @@ namespace Unity.WebRTC
             get
             {
                 var direction = RTCRtpTransceiverDirection.RecvOnly;
-                if (NativeMethods.TransceiverGetCurrentDirection(self, ref direction))
+                if (NativeMethods.TransceiverGetCurrentDirection(GetSelfOrThrow(), ref direction))
                 {
                     return direction;
                 }
@@ -72,7 +75,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                IntPtr receiverPtr = NativeMethods.TransceiverGetReceiver(self);
+                IntPtr receiverPtr = NativeMethods.TransceiverGetReceiver(GetSelfOrThrow());
                 return WebRTC.FindOrCreate(receiverPtr, ptr => new RTCRtpReceiver(ptr, peer));
             }
         }
@@ -84,7 +87,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                IntPtr senderPtr = NativeMethods.TransceiverGetSender(self);
+                IntPtr senderPtr = NativeMethods.TransceiverGetSender(GetSelfOrThrow());
                 return WebRTC.FindOrCreate(senderPtr, ptr => new RTCRtpSender(ptr, peer));
             }
         }
@@ -93,7 +96,7 @@ namespace Unity.WebRTC
         {
             RTCRtpCodecCapabilityInternal[] array = Array.ConvertAll(codecs, v => v.Cast());
             MarshallingArray<RTCRtpCodecCapabilityInternal> instance = array;
-            RTCErrorType error = NativeMethods.TransceiverSetCodecPreferences(self, instance.ptr, instance.length);
+            RTCErrorType error = NativeMethods.TransceiverSetCodecPreferences(GetSelfOrThrow(), instance.ptr, instance.length);
             foreach (var v in array)
             {
                 v.Dispose();
@@ -104,7 +107,7 @@ namespace Unity.WebRTC
 
         public void Stop()
         {
-            NativeMethods.TransceiverStop(self);
+            NativeMethods.TransceiverStop(GetSelfOrThrow());
         }
     }
 }

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Unity.WebRTC
 {
-    public class RTCRtpTransceiver : RefCounterObject
+    public class RTCRtpTransceiver : RefCountedObject
     {
         private RTCPeerConnection peer;
 

--- a/Runtime/Scripts/RefCountedObject.cs
+++ b/Runtime/Scripts/RefCountedObject.cs
@@ -2,13 +2,13 @@ using System;
 
 namespace Unity.WebRTC
 {
-    public class RefCounterObject : IDisposable
+    public class RefCountedObject : IDisposable
     {
         internal IntPtr self;
 
         protected bool disposed;
 
-        internal RefCounterObject(IntPtr ptr)
+        internal RefCountedObject(IntPtr ptr)
         {
             self = ptr;
         }

--- a/Runtime/Scripts/RefCountedObject.cs
+++ b/Runtime/Scripts/RefCountedObject.cs
@@ -11,6 +11,7 @@ namespace Unity.WebRTC
         internal RefCountedObject(IntPtr ptr)
         {
             self = ptr;
+            WebRTC.Context.AddRefPtr(self);
         }
 
         public virtual void Dispose()

--- a/Runtime/Scripts/RefCountedObject.cs.meta
+++ b/Runtime/Scripts/RefCountedObject.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bcba9246fcf362b40b40a3d4fd88ab02
+guid: 60dacb94f51c0f04ba72616843c4e263
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Scripts/RefCounterObject.cs
+++ b/Runtime/Scripts/RefCounterObject.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Unity.WebRTC
+{
+    public class RefCounterObject : IDisposable
+    {
+        internal IntPtr self;
+
+        protected bool disposed;
+
+        internal RefCounterObject(IntPtr ptr)
+        {
+            self = ptr;
+        }
+
+        public virtual void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
+            {
+                WebRTC.Context.DeleteRefPtr(self);
+                self = IntPtr.Zero;
+            }
+
+            this.disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Runtime/Scripts/RefCounterObject.cs.meta
+++ b/Runtime/Scripts/RefCounterObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcba9246fcf362b40b40a3d4fd88ab02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.ComponentModel;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
@@ -180,13 +179,8 @@ namespace Unity.WebRTC
                 }
 
                 s_tracks.TryRemove(self, out var value);
-                WebRTC.Context.DeleteMediaStreamTrack(self);
-                WebRTC.Table.Remove(self);
-                self = IntPtr.Zero;
             }
-
-            this.disposed = true;
-            GC.SuppressFinalize(this);
+            base.Dispose();
         }
     }
 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -229,6 +229,7 @@ namespace Unity.WebRTC
     {
         public VideoTrackSource() : base(WebRTC.Context.CreateVideoTrackSource())
         {
+            WebRTC.Table.Add(self, this);
         }
 
         ~VideoTrackSource()

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -42,6 +42,7 @@ namespace Unity.WebRTC
         {
             get
             {
+                Debug.Log("IsEncoderInitialized");
                 return WebRTC.Context.GetInitializationResult(GetSelfOrThrow()) == CodecInitializationResult.Success;
             }
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -879,9 +879,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr PeerConnectionAddTrack(IntPtr pc, IntPtr track, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string streamId);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track);
+        public static extern IntPtr PeerConnectionAddTransceiver(IntPtr context, IntPtr pc, IntPtr track);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind);
+        public static extern IntPtr PeerConnectionAddTransceiverWithType(IntPtr context, IntPtr pc, TrackKind kind);
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType PeerConnectionRemoveTrack(IntPtr pc, IntPtr sender);
         [DllImport(WebRTC.Lib)]
@@ -904,11 +904,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern RTCPeerConnectionState PeerConnectionState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length);
+        public static extern IntPtr PeerConnectionGetReceivers(IntPtr context, IntPtr ptr, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionGetSenders(IntPtr ptr, out ulong length);
+        public static extern IntPtr PeerConnectionGetSenders(IntPtr context, IntPtr ptr, out ulong length);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionGetTransceivers(IntPtr ptr, out ulong length);
+        public static extern IntPtr PeerConnectionGetTransceivers(IntPtr context, IntPtr ptr, out ulong length);
         [DllImport(WebRTC.Lib)]
         public static extern RTCIceConnectionState PeerConnectionIceConditionState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -809,7 +809,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreateAudioTrackSource(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
+        public static extern IntPtr ContextCreateVideoTrackSource(IntPtr ptr);
+        [DllImport(WebRTC.Lib)]
+        public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label, IntPtr trackSource);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreateAudioTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label, IntPtr trackSource);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -654,6 +654,8 @@ namespace Unity.WebRTC
             var list = new List<T>();
             foreach (var ptr in array)
             {
+                if (ptr == IntPtr.Zero)
+                    UnityEngine.Debug.LogError("IntPtr is zero");
                 list.Add(FindOrCreate(ptr, constructor));
             }
             return list;
@@ -811,11 +813,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextStopMediaStreamTrack(IntPtr context, IntPtr track);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextDeleteMediaStreamTrack(IntPtr context, IntPtr track);
-        [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteStatsReport(IntPtr context, IntPtr report);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height, GraphicsFormat format, IntPtr texturePtr);
+        [DllImport(WebRTC.Lib)]
+        public static extern void ContextDeleteRefPtr(IntPtr context, IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern CodecInitializationResult GetInitializationResult(IntPtr context, IntPtr track);
         [DllImport(WebRTC.Lib)]
@@ -984,8 +986,6 @@ namespace Unity.WebRTC
         public static extern void DataChannelRegisterOnClose(IntPtr ptr, DelegateNativeOnClose callback);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreateMediaStream(IntPtr ctx, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
-        [DllImport(WebRTC.Lib)]
-        public static extern void ContextDeleteMediaStream(IntPtr ctx, IntPtr stream);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextRegisterMediaStreamObserver(IntPtr ctx, IntPtr stream);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -807,9 +807,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteDataChannel(IntPtr ptr, IntPtr ptrChannel);
         [DllImport(WebRTC.Lib)]
+        public static extern IntPtr ContextCreateAudioTrackSource(IntPtr ptr);
+        [DllImport(WebRTC.Lib)]
         public static extern IntPtr ContextCreateVideoTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr ContextCreateAudioTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label);
+        public static extern IntPtr ContextCreateAudioTrack(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string label, IntPtr trackSource);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextStopMediaStreamTrack(IntPtr context, IntPtr track);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -821,6 +821,8 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextSetVideoEncoderParameter(IntPtr context, IntPtr track, int width, int height, GraphicsFormat format, IntPtr texturePtr);
         [DllImport(WebRTC.Lib)]
+        public static extern void ContextAddRefPtr(IntPtr context, IntPtr ptr);
+        [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteRefPtr(IntPtr context, IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern CodecInitializationResult GetInitializationResult(IntPtr context, IntPtr track);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -883,7 +883,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionRemoveTrack(IntPtr pc, IntPtr sender);
+        public static extern RTCErrorType PeerConnectionRemoveTrack(IntPtr pc, IntPtr sender);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool PeerConnectionAddIceCandidate(IntPtr ptr, IntPtr candidate);

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Serialization;
 using UnityEngine;
 using Unity.WebRTC;
 using Unity.WebRTC.Samples;
@@ -27,13 +28,14 @@ class BandwidthSample : MonoBehaviour
 
     private RTCPeerConnection _pc1, _pc2;
     private List<RTCRtpSender> pc1Senders;
-    private VideoStreamTrack videoStreamTrack;
+    private MediaStream videoStream, receiveStream;
     private DelegateOnIceConnectionChange pc1OnIceConnectionChange;
     private DelegateOnIceConnectionChange pc2OnIceConnectionChange;
     private DelegateOnIceCandidate pc1OnIceCandidate;
     private DelegateOnIceCandidate pc2OnIceCandidate;
     private DelegateOnTrack pc2Ontrack;
     private DelegateOnNegotiationNeeded pc1OnNegotiationNeeded;
+    private bool videoUpdateStarted;
 
     private Dictionary<string, ulong?> bandwidthOptions = new Dictionary<string, ulong?>()
     {
@@ -58,6 +60,7 @@ class BandwidthSample : MonoBehaviour
         callButton.onClick.AddListener(Call);
         hangUpButton.onClick.AddListener(HangUp);
         copyClipboard.onClick.AddListener(CopyClipboard);
+        receiveStream = new MediaStream();
     }
 
     private void OnDestroy()
@@ -78,16 +81,18 @@ class BandwidthSample : MonoBehaviour
         pc2OnIceCandidate = candidate => { OnIceCandidate(_pc2, candidate); };
         pc2Ontrack = e =>
         {
-            if (e.Track is VideoStreamTrack track && !track.IsDecoderInitialized)
+            receiveStream.AddTrack(e.Track);
+        };
+        pc1OnNegotiationNeeded = () => { StartCoroutine(PeerNegotiationNeeded(_pc1)); };
+
+        receiveStream.OnAddTrack = e =>
+        {
+            if (e.Track is VideoStreamTrack track)
             {
                 receiveImage.texture = track.InitializeReceiver(width, height);
                 receiveImage.color = Color.white;
             }
         };
-        pc1OnNegotiationNeeded = () => { StartCoroutine(PeerNegotiationNeeded(_pc1)); };
-
-        StartCoroutine(WebRTC.Update());
-        StartCoroutine(LoopStatsCoroutine());
     }
 
     private void Update()
@@ -163,7 +168,18 @@ class BandwidthSample : MonoBehaviour
 
     private void AddTracks()
     {
-        pc1Senders.Add(_pc1.AddTrack(videoStreamTrack));
+        foreach (var track in videoStream.GetTracks())
+        {
+            pc1Senders.Add(_pc1.AddTrack(track, videoStream));
+        }
+
+        if (!videoUpdateStarted)
+        {
+            StartCoroutine(WebRTC.Update());
+            StartCoroutine(LoopStatsCoroutine());
+            videoUpdateStarted = true;
+        }
+
         bandwidthSelector.interactable = false;
     }
 
@@ -174,6 +190,13 @@ class BandwidthSample : MonoBehaviour
             _pc1.RemoveTrack(sender);
         }
         pc1Senders.Clear();
+
+        MediaStreamTrack[] tracks = receiveStream.GetTracks().ToArray();
+        foreach (var track in tracks)
+        {
+            receiveStream.RemoveTrack(track);
+            track.Dispose();
+        }
     }
 
     private void Call()
@@ -195,9 +218,9 @@ class BandwidthSample : MonoBehaviour
         _pc2.OnIceConnectionChange = pc2OnIceConnectionChange;
         _pc2.OnTrack = pc2Ontrack;
 
-        if (videoStreamTrack == null)
+        if (videoStream == null)
         {
-            videoStreamTrack = cam.CaptureStreamTrack(width, height, 0);
+            videoStream = cam.CaptureStream(width, height, 1000000);
         }
         sourceImage.texture = cam.targetTexture;
         sourceImage.color = Color.white;

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -79,7 +79,7 @@ namespace Unity.WebRTC.RuntimeTest
             var context = Context.Create(
                 encoderType: value ? EncoderType.Hardware : EncoderType.Software);
             var track = context.CreateAudioTrack("audio");
-            context.DeleteMediaStreamTrack(track);
+            context.DeleteRefPtr(track);
             context.Dispose();
         }
 
@@ -96,7 +96,7 @@ namespace Unity.WebRTC.RuntimeTest
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
             var track = context.CreateVideoTrack("video");
-            context.DeleteMediaStreamTrack(track);
+            context.DeleteRefPtr(track);
             context.Dispose();
             UnityEngine.Object.DestroyImmediate(rt);
         }

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -78,8 +78,10 @@ namespace Unity.WebRTC.RuntimeTest
             var value = NativeMethods.GetHardwareEncoderSupport();
             var context = Context.Create(
                 encoderType: value ? EncoderType.Hardware : EncoderType.Software);
-            var track = context.CreateAudioTrack("audio");
+            var source = context.CreateAudioTrackSource();
+            var track = context.CreateAudioTrack("audio", source);
             context.DeleteRefPtr(track);
+            context.DeleteRefPtr(source);
             context.Dispose();
         }
 

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -97,8 +97,10 @@ namespace Unity.WebRTC.RuntimeTest
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
             var rt = new UnityEngine.RenderTexture(width, height, 0, format);
             rt.Create();
-            var track = context.CreateVideoTrack("video");
+            var source = context.CreateVideoTrackSource();
+            var track = context.CreateVideoTrack("video", source);
             context.DeleteRefPtr(track);
+            context.DeleteRefPtr(source);
             context.Dispose();
             UnityEngine.Object.DestroyImmediate(rt);
         }

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -53,10 +53,12 @@ namespace Unity.WebRTC.RuntimeTest
         public void EqualIdWithVideoTrack()
         {
             var guid = Guid.NewGuid().ToString();
-            var track = new VideoStreamTrack(WebRTC.Context.CreateVideoTrack(guid));
+            var source = new VideoTrackSource();
+            var track = new VideoStreamTrack(WebRTC.Context.CreateVideoTrack(guid, source.self));
             Assert.That(track, Is.Not.Null);
             Assert.That(track.Id, Is.EqualTo(guid));
             track.Dispose();
+            source.Dispose();
         }
 
         [Test]

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -41,10 +41,12 @@ namespace Unity.WebRTC.RuntimeTest
         public void EqualIdWithAudioTrack()
         {
             var guid = Guid.NewGuid().ToString();
-            var track = new AudioStreamTrack(WebRTC.Context.CreateAudioTrack(guid));
+            var source = new AudioTrackSource();
+            var track = new AudioStreamTrack(WebRTC.Context.CreateAudioTrack(guid, source.self));
             Assert.That(track, Is.Not.Null);
             Assert.That(track.Id, Is.EqualTo(guid));
             track.Dispose();
+            source.Dispose();
         }
 
         [Test]

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -128,7 +128,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var context = NativeMethods.ContextCreate(0, encoderType, true);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
-            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(context, connection, out ulong length);
+            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(connection, out ulong length);
             Assert.AreEqual(0, length);
             NativeMethods.ContextDeletePeerConnection(context, connection);
             NativeMethods.ContextDestroy(0);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -184,8 +184,10 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
@@ -201,13 +203,15 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
             var track2 = NativeMethods.SenderGetTrack(sender);
             Assert.AreEqual(track, track2);
             Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
@@ -224,7 +228,8 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             NativeMethods.SenderGetParameters(sender, out var ptr);
@@ -237,6 +242,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
         }
@@ -251,7 +257,8 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             NativeMethods.MediaStreamAddTrack(stream, track);
 
             IntPtr buf = NativeMethods.MediaStreamGetVideoTracks(stream, out ulong length);
@@ -269,6 +276,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.MediaStreamRemoveTrack(stream, track);
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
@@ -303,6 +311,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.MediaStreamRemoveTrack(stream, track);
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDestroy(0);
         }
 
@@ -319,6 +328,7 @@ namespace Unity.WebRTC.RuntimeTest
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
             NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
@@ -341,12 +351,14 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             var renderer = NativeMethods.CreateVideoRenderer(context);
             NativeMethods.VideoTrackAddOrUpdateSink(track, renderer);
             NativeMethods.VideoTrackRemoveSink(track, renderer);
             NativeMethods.DeleteVideoRenderer(context, renderer);
             NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
@@ -400,7 +412,8 @@ namespace Unity.WebRTC.RuntimeTest
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             var callback = NativeMethods.GetRenderEventFunc(context);
@@ -423,6 +436,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
@@ -455,7 +469,8 @@ namespace Unity.WebRTC.RuntimeTest
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
             var receiveTexture = CreateRenderTexture(width, height);
-            var track = NativeMethods.ContextCreateVideoTrack(context, "video");
+            var source = NativeMethods.ContextCreateVideoTrackSource(context);
+            var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             var renderer = NativeMethods.CreateVideoRenderer(context);
             var rendererId = NativeMethods.GetVideoRendererId(renderer);
             NativeMethods.VideoTrackAddOrUpdateSink(track, renderer);
@@ -480,6 +495,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.VideoTrackRemoveSink(track, renderer);
             NativeMethods.DeleteVideoRenderer(context, renderer);
             NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
             UnityEngine.Object.DestroyImmediate(receiveTexture);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -128,7 +128,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var context = NativeMethods.ContextCreate(0, encoderType, true);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
-            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(connection, out ulong length);
+            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(context, connection, out ulong length);
             Assert.AreEqual(0, length);
             NativeMethods.ContextDeletePeerConnection(context, connection);
             NativeMethods.ContextDestroy(0);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -280,7 +280,8 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var context = NativeMethods.ContextCreate(0, encoderType, true);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
+            var source = NativeMethods.ContextCreateAudioTrackSource(context);
+            var track = NativeMethods.ContextCreateAudioTrack(context, "audio", source);
             NativeMethods.MediaStreamAddTrack(stream, track);
 
             var trackNativePtr = NativeMethods.MediaStreamGetAudioTracks(stream, out ulong trackSize);
@@ -313,7 +314,8 @@ namespace Unity.WebRTC.RuntimeTest
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
             Assert.IsNotEmpty(streamId);
-            var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
+            var source = NativeMethods.ContextCreateAudioTrackSource(context);
+            var track = NativeMethods.ContextCreateAudioTrack(context, "audio", source);
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
             NativeMethods.ContextDeleteRefPtr(context, track);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -128,7 +128,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var context = NativeMethods.ContextCreate(0, encoderType, true);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
-            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(connection, out ulong length);
+            IntPtr buf = NativeMethods.PeerConnectionGetReceivers(context, connection, out ulong length);
             Assert.AreEqual(0, length);
             NativeMethods.ContextDeletePeerConnection(context, connection);
             NativeMethods.ContextDestroy(0);
@@ -152,7 +152,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var context = NativeMethods.ContextCreate(0, encoderType, true);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDestroy(0);
         }
 
@@ -173,7 +173,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.MediaStreamRegisterOnRemoveTrack(context, stream, MediaStreamOnRemoveTrack);
 
             NativeMethods.ContextUnRegisterMediaStreamObserver(context, stream);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDestroy(0);
         }
 
@@ -185,7 +185,7 @@ namespace Unity.WebRTC.RuntimeTest
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
             var track = NativeMethods.ContextCreateVideoTrack(context, "video");
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
@@ -205,9 +205,9 @@ namespace Unity.WebRTC.RuntimeTest
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
             var track2 = NativeMethods.SenderGetTrack(sender);
             Assert.AreEqual(track, track2);
-            NativeMethods.PeerConnectionRemoveTrack(peer, sender);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
+            NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
@@ -234,9 +234,9 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreNotEqual(IntPtr.Zero, parameters.encodings);
             Assert.AreNotEqual(IntPtr.Zero, parameters.transactionId);
 
-            NativeMethods.PeerConnectionRemoveTrack(peer, sender);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
+            NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
         }
@@ -267,8 +267,8 @@ namespace Unity.WebRTC.RuntimeTest
             #endif
 
             NativeMethods.MediaStreamRemoveTrack(stream, track);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
@@ -300,8 +300,8 @@ namespace Unity.WebRTC.RuntimeTest
             #endif
 
             NativeMethods.MediaStreamRemoveTrack(stream, track);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDestroy(0);
         }
 
@@ -316,9 +316,9 @@ namespace Unity.WebRTC.RuntimeTest
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio");
             var sender = NativeMethods.PeerConnectionAddTrack(peer, track, streamId);
 
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
-            NativeMethods.PeerConnectionRemoveTrack(peer, sender);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            NativeMethods.ContextDeleteRefPtr(context, track);
+            Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
         }
@@ -344,7 +344,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.VideoTrackAddOrUpdateSink(track, renderer);
             NativeMethods.VideoTrackRemoveSink(track, renderer);
             NativeMethods.DeleteVideoRenderer(context, renderer);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
@@ -418,9 +418,9 @@ namespace Unity.WebRTC.RuntimeTest
             VideoEncoderMethods.FinalizeEncoder(callback, track);
             yield return new WaitForSeconds(1.0f);
 
-            NativeMethods.PeerConnectionRemoveTrack(peer, sender);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
-            NativeMethods.ContextDeleteMediaStream(context, stream);
+            Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
+            NativeMethods.ContextDeleteRefPtr(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
@@ -477,7 +477,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             NativeMethods.VideoTrackRemoveSink(track, renderer);
             NativeMethods.DeleteVideoRenderer(context, renderer);
-            NativeMethods.ContextDeleteMediaStreamTrack(context, track);
+            NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
             UnityEngine.Object.DestroyImmediate(receiveTexture);


### PR DESCRIPTION
This pull request is for generalizing the PR below.
https://github.com/Unity-Technologies/com.unity.webrtc/pull/496

- To dispose of the native object safely, manage the lifespan of the native object from C# code
- Use `rtc::RefCountedObject` class to manage timing of disposing objects 
- Define **RefCountedObject** class in C# code which has the native pointer relating the `rtc::RefCountedObject` and decrement the reference count when the object is disposed of.