### PR TITLE
fix: Resource leak in VideoReceiver sample

### DIFF
--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1020,9 +1020,10 @@ extern "C"
         return false;
     }
 
-    UNITY_INTERFACE_EXPORT void TransceiverStop(RtpTransceiverInterface* transceiver)
+    UNITY_INTERFACE_EXPORT RTCErrorType TransceiverStop(RtpTransceiverInterface* transceiver)
     {
-        transceiver->StopStandard();
+        auto error = transceiver->StopStandard();
+        return error.type();
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverDirection TransceiverGetDirection(RtpTransceiverInterface* transceiver)

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -105,9 +105,9 @@ namespace Unity.WebRTC
             return error;
         }
 
-        public void Stop()
+        public RTCErrorType Stop()
         {
-            NativeMethods.TransceiverStop(GetSelfOrThrow());
+            return NativeMethods.TransceiverStop(self);
         }
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -665,7 +665,9 @@ namespace Unity.WebRTC
         {
             if (Context.table.ContainsKey(ptr))
             {
-                return Context.table[ptr] as T;
+                if(Context.table[ptr] is T value)
+                    return value;
+                throw new InvalidCastException($"{ptr} is not {typeof(T).Name}");
             }
             else
             {
@@ -934,7 +936,7 @@ namespace Unity.WebRTC
         public static extern bool TransceiverGetCurrentDirection(IntPtr transceiver, ref RTCRtpTransceiverDirection direction);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool TransceiverStop(IntPtr transceiver);
+        public static extern RTCErrorType TransceiverStop(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
         public static extern RTCRtpTransceiverDirection TransceiverGetDirection(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -190,9 +190,14 @@ namespace Unity.WebRTC.Samples
 
         private void RemoveTracks()
         {
-            foreach (var sender in pc1Senders)
+            var transceivers = _pc1.GetTransceivers();
+            foreach (var transceiver in transceivers)
             {
-                _pc1.RemoveTrack(sender);
+                if(transceiver.Sender != null)
+                {
+                    transceiver.Stop();
+                    _pc1.RemoveTrack(transceiver.Sender);
+                }
             }
 
             pc1Senders.Clear();

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -1,5 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
+using System.Collections;
+using UnityEngine.TestTools;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -16,6 +18,20 @@ namespace Unity.WebRTC.RuntimeTest
         public void TearDown()
         {
             WebRTC.Dispose();
+        }
+
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator AddAndRemoveAudioTrack()
+        {
+            var audioTrack = new AudioStreamTrack();
+            var test = new MonoBehaviourTest<SignalingPeers>();
+            var sender = test.component.AddTrack(0, audioTrack);
+            yield return test;
+            Assert.That(test.component.RemoveTrack(0, sender), Is.EqualTo(RTCErrorType.None));
+            yield return new WaitUntil(() => test.component.NegotiationCompleted());
+            test.component.Dispose();
+            Object.DestroyImmediate(test.gameObject);
         }
 
         [Test]

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -10,8 +10,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -11,8 +11,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -94,8 +94,8 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator SendThrowsExceptionAfterClose()
         {
             var test = new MonoBehaviourTest<SignalingPeers>();
-            yield return test;
             RTCDataChannel channel = test.component.CreateDataChannel(0, "test");
+            yield return test;
             byte[] message1 = { 1, 2, 3 };
             string message2 = "123";
 

--- a/Tests/Runtime/IceCandidateTest.cs
+++ b/Tests/Runtime/IceCandidateTest.cs
@@ -8,8 +8,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -113,7 +113,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void AddAndRemoveAudioStreamTrack()
+        public void AddAndRemoveAudioTrack()
         {
             var stream = new MediaStream();
             var track = new AudioStreamTrack();
@@ -152,42 +152,14 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
-        public IEnumerator AddAndRemoveAudioMediaTrack()
-        {
-            RTCConfiguration config = default;
-            config.iceServers = new[]
-            {
-                new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}
-            };
-            var audioTrack = new AudioStreamTrack();
-            var audioStream = new MediaStream();
-            audioStream.AddTrack(audioTrack);
-
-            var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(audioStream);
-            yield return test;
-            test.component.Dispose();
-            Assert.That(audioStream.GetTracks().ToList(),
-                Has.Count.EqualTo(1).And.All.InstanceOf<AudioStreamTrack>());
-            foreach (var track in audioStream.GetTracks())
-            {
-                track.Dispose();
-            }
-            audioStream.Dispose();
-            Object.DestroyImmediate(test.gameObject);
-        }
-
-        [UnityTest]
-        [Timeout(5000)]
         public IEnumerator CaptureStream()
         {
             var camObj = new GameObject("Camera");
             var cam = camObj.AddComponent<Camera>();
             var videoStream = cam.CaptureStream(1280, 720, 1000000);
-            yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(videoStream);
+            test.component.AddStream(0, videoStream);
             yield return test;
             yield return new WaitForSeconds(0.1f);
             test.component.Dispose();
@@ -218,7 +190,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(videoStream);
+            test.component.AddStream(0, videoStream);
             yield return test;
             test.component.CoroutineUpdate();
             yield return new WaitForSeconds(0.1f);
@@ -263,7 +235,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(videoStream);
+            test.component.AddStream(0, videoStream);
             yield return test;
             test.component.CoroutineUpdate();
             yield return new WaitForSeconds(0.1f);
@@ -306,7 +278,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(videoStream);
+            test.component.AddStream(0, videoStream);
             yield return test;
             test.component.CoroutineUpdate();
             yield return new WaitForSeconds(0.1f);
@@ -351,7 +323,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(videoStream);
+            test.component.AddStream(0, videoStream);
             yield return test;
             test.component.CoroutineUpdate();
             yield return new WaitForSeconds(0.1f);
@@ -410,7 +382,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return 0;
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(stream);
+            test.component.AddStream(0, stream);
             yield return test;
 
             foreach (var receiver in test.component.GetPeerReceivers(1))

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -13,8 +13,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -316,15 +316,11 @@ namespace Unity.WebRTC.RuntimeTest
             if (SystemInfo.processorType == "Apple M1")
                 Assert.Ignore("todo:: This test will hang up on Apple M1");
 
-            //var stream = new MediaStream();
-
             var go = new GameObject("Test");
             var cam = go.AddComponent<Camera>();
-            //stream.AddTrack(cam.CaptureStreamTrack(1280, 720, 0));
 
             var test = new MonoBehaviourTest<SignalingPeers>();
             test.component.AddTransceiver(0, cam.CaptureStreamTrack(1280, 720, 0));
-            //test.component.SetStream(stream);
             yield return test;
             test.component.CoroutineUpdate();
 
@@ -844,7 +840,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(0.1f);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.SetStream(stream);
+            test.component.AddStream(0, stream);
             yield return test;
             test.component.CoroutineUpdate();
             yield return new WaitForSeconds(0.1f);

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -25,9 +25,9 @@ namespace Unity.WebRTC.RuntimeTest
             }
         }
 
-        public void AddTransceiver(int indexPeer, MediaStreamTrack track)
+        public RTCRtpTransceiver AddTransceiver(int indexPeer, MediaStreamTrack track)
         {
-            peers[indexPeer].AddTransceiver(track);
+            return peers[indexPeer].AddTransceiver(track);
         }
 
         public RTCRtpSender AddTrack(int indexPeer, MediaStreamTrack track)

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -16,9 +16,16 @@ namespace Unity.WebRTC.RuntimeTest
 
         public bool IsTestFinished { get; private set; }
 
+        bool negotiating = false;
+
         public void SetStream(MediaStream stream)
         {
             m_stream = stream;
+        }
+
+        public void AddTransceiver(int indexPeer, MediaStreamTrack track)
+        {
+            peers[indexPeer].AddTransceiver(track);
         }
 
         public RTCDataChannel CreateDataChannel(int indexPeer, string label, RTCDataChannelInit option = null)
@@ -58,12 +65,18 @@ namespace Unity.WebRTC.RuntimeTest
             return peers[indexPeer].GetReceivers();
         }
 
+        public IEnumerable<RTCRtpTransceiver> GetPeerTransceivers(int indexPeer)
+        {
+            return peers[indexPeer].GetTransceivers();
+        }
+
+
         public Coroutine CoroutineUpdate()
         {
             return StartCoroutine(WebRTC.Update());
         }
 
-        IEnumerator Start()
+        void Awake()
         {
             RTCConfiguration config = default;
             config.iceServers = new[]
@@ -75,9 +88,6 @@ namespace Unity.WebRTC.RuntimeTest
             peers[1] = new RTCPeerConnection(ref config);
             dataChannels[peers[0]] = new List<RTCDataChannel>();
             dataChannels[peers[1]] = new List<RTCDataChannel>();
-
-            RTCDataChannel channel = peers[0].CreateDataChannel("data");
-            dataChannels[peers[0]].Add(channel);
 
             peers[0].OnIceCandidate = candidate =>
             {
@@ -97,7 +107,7 @@ namespace Unity.WebRTC.RuntimeTest
                 Assert.That(e.Track, Is.Not.Null);
                 Assert.That(e.Receiver, Is.Not.Null);
                 Assert.That(e.Transceiver, Is.Not.Null);
-                peers[1].AddTrack(e.Track);
+                //peers[1].AddTrack(e.Track);
             };
             peers[0].OnDataChannel = e =>
             {
@@ -106,58 +116,84 @@ namespace Unity.WebRTC.RuntimeTest
             };
             peers[1].OnDataChannel = e =>
             {
-                if(peers[1].ConnectionState == RTCPeerConnectionState.Connected)
+                if (peers[1].ConnectionState == RTCPeerConnectionState.Connected)
                     dataChannels[peers[1]].Add(e);
             };
-
-            if (m_stream != null)
+            peers[0].OnNegotiationNeeded = () =>
             {
-                foreach (var track in m_stream.GetTracks())
-                {
-                    peers[0].AddTrack(track, m_stream);
-                }
-            }
+//                Debug.Log("OnNegotiationNeeded ");
+                IsTestFinished = false;
+                StartCoroutine(Negotiate(peers[0], peers[1]));
+            };
 
-            // Because some platform can't accept H264 codec for receive.
-            foreach (var transceiver in peers[0].GetTransceivers())
+            peers[1].OnNegotiationNeeded = () =>
             {
-                transceiver.Direction = RTCRtpTransceiverDirection.SendOnly;
-            }
+//                Debug.Log("OnNegotiationNeeded ");
+                IsTestFinished = false;
+                StartCoroutine(Negotiate(peers[1], peers[0]));
+            };
+        }
 
-            var op1 = peers[0].CreateOffer();
+        IEnumerator Start()
+        {
+
+            //RTCDataChannel channel = peers[0].CreateDataChannel("data");
+            //dataChannels[peers[0]].Add(channel);
+
+            //if (m_stream != null)
+            //{
+            //    foreach (var track in m_stream.GetTracks())
+            //    {
+            //        peers[0].AddTrack(track, m_stream);
+            //    }
+            //}
+
+            //// Because some platform can't accept H264 codec for receive.
+            //foreach (var transceiver in peers[0].GetTransceivers())
+            //{
+            //    transceiver.Direction = RTCRtpTransceiverDirection.SendOnly;
+            //}
+
+            //yield return StartCoroutine(Negotiate(peers[0], peers[1]));
+            yield return new WaitUntil(() => NegotiationCompleted());
+        }
+
+        IEnumerator Negotiate(RTCPeerConnection peer1, RTCPeerConnection peer2)
+        {
+            if (negotiating)
+            {
+                Debug.LogError("Negotiating");
+                yield break;
+            }
+            negotiating = true;
+            var op1 = peer1.CreateOffer();
             yield return op1;
             Assert.That(op1.IsError, Is.False, op1.Error.message);
             var desc = op1.Desc;
-            var op2 = peers[0].SetLocalDescription(ref desc);
+            var op2 = peer1.SetLocalDescription(ref desc);
             yield return op2;
             Assert.That(op2.IsError, Is.False, op2.Error.message);
 
-            var op3 = peers[1].SetRemoteDescription(ref desc);
+            var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
             Assert.That(op3.IsError, Is.False, op3.Error.message);
-            var op4 = peers[1].CreateAnswer();
+            var op4 = peer2.CreateAnswer();
             yield return op4;
             Assert.That(op4.IsError, Is.False, op4.Error.message);
             desc = op4.Desc;
-            var op5 = peers[1].SetLocalDescription(ref desc);
+            var op5 = peer2.SetLocalDescription(ref desc);
             yield return op5;
             Assert.That(op5.IsError, Is.False, op5.Error.message);
 
-            var op6 = peers[0].SetRemoteDescription(ref desc);
+            var op6 = peer1.SetRemoteDescription(ref desc);
             yield return op6;
             Assert.That(op6.IsError, Is.False, op6.Error.message);
 
             var op7 = new WaitUntilWithTimeout(() =>
-                peers[0].IceConnectionState == RTCIceConnectionState.Connected ||
-                peers[0].IceConnectionState == RTCIceConnectionState.Completed, 5000);
+                peers[0].SignalingState == RTCSignalingState.Stable &&
+                peers[1].SignalingState == RTCSignalingState.Stable, 5000);
             yield return op7;
             Assert.That(op7.IsCompleted, Is.True);
-
-            var op8 = new WaitUntilWithTimeout(() =>
-                peers[1].IceConnectionState == RTCIceConnectionState.Connected ||
-                peers[1].IceConnectionState == RTCIceConnectionState.Completed, 5000);
-            yield return op8;
-            Assert.That(op8.IsCompleted, Is.True);
 
             if (m_stream != null)
             {
@@ -166,6 +202,13 @@ namespace Unity.WebRTC.RuntimeTest
                 Assert.That(op9.IsCompleted, Is.True);
             }
             IsTestFinished = true;
+            negotiating = false;
+        }
+
+        public bool NegotiationCompleted()
+        {
+            return !negotiating &&
+                peers[0].SignalingState == RTCSignalingState.Stable && peers[1].SignalingState == RTCSignalingState.Stable;
         }
 
         public void Dispose()

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -11,8 +11,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -1,4 +1,8 @@
+using UnityEngine;
+using UnityEngine.TestTools;
 using NUnit.Framework;
+using System.Collections;
+using System.Linq;
 
 namespace Unity.WebRTC.RuntimeTest
 {
@@ -175,6 +179,45 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(sender.Track, Is.Null);
 
             peer.Dispose();
+        }
+
+
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator TransceiverStop()
+        {
+            if (SystemInfo.processorType == "Apple M1")
+                Assert.Ignore("todo:: This test will hang up on Apple M1");
+
+            var go = new GameObject("Test");
+            var cam = go.AddComponent<Camera>();
+
+            var test = new MonoBehaviourTest<SignalingPeers>();
+            test.component.AddTransceiver(0, cam.CaptureStreamTrack(1280, 720, 0));
+            yield return test;
+            test.component.CoroutineUpdate();
+
+            var senderTransceivers = test.component.GetPeerTransceivers(0);
+            Assert.That(senderTransceivers.Count(), Is.EqualTo(1));
+            var transceiver1 = senderTransceivers.First();
+
+            var receiverTransceivers = test.component.GetPeerTransceivers(1);
+            Assert.That(receiverTransceivers.Count(), Is.EqualTo(1));
+            var transceiver2 = receiverTransceivers.First();
+
+            Assert.That(transceiver1.Stop(), Is.EqualTo(RTCErrorType.None));
+
+            // wait for OnNegotiationNeeded callback in SignalingPeers class
+            yield return 0;
+            yield return new WaitUntil(() => test.component.NegotiationCompleted());
+
+            Assert.That(transceiver1.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+            Assert.That(transceiver1.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+            Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+            Assert.That(transceiver2.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+
+            Object.DestroyImmediate(go);
+            Object.DestroyImmediate(test.gameObject);
         }
     }
 }

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -31,7 +31,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            WebRTC.Initialize(encoderType);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -10,8 +10,8 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            var value = TestHelper.HardwareCodecSupport();
-            WebRTC.Initialize(value ? EncoderType.Hardware : EncoderType.Software);
+            var type = TestHelper.HardwareCodecSupport() ? EncoderType.Hardware : EncoderType.Software;
+            WebRTC.Initialize(type: type, limitTextureSize: true, forTest: true);
         }
 
         [TearDown]


### PR DESCRIPTION
This change is for fixing the resource leak in the **VideoReceiver** sample.
Need to call `RTCRtpTransceiver.Stop` method explicitly to dispose of the encoder.