### PR TITLE
Fix audio options not working correctly

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -74,7 +74,7 @@ UnityAudioTrackSource::UnityAudioTrackSource()
 {
 }
 UnityAudioTrackSource::UnityAudioTrackSource(const cricket::AudioOptions& audio_options)
-{
+    : _options(audio_options) {
 }
 
 UnityAudioTrackSource::~UnityAudioTrackSource()

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -14,6 +14,7 @@ namespace webrtc
         static rtc::scoped_refptr<UnityAudioTrackSource> Create();
         static rtc::scoped_refptr<UnityAudioTrackSource> Create(const cricket::AudioOptions& audio_options);
 
+        const cricket::AudioOptions options() const override { return _options; }
         void AddSink(AudioTrackSinkInterface* sink) override;
         void RemoveSink(AudioTrackSinkInterface* sink) override;
 
@@ -29,6 +30,7 @@ namespace webrtc
         std::vector<int16_t> _convertedAudioData;
         std::vector <AudioTrackSinkInterface*> _arrSink;
         std::mutex _mutex;
+        cricket::AudioOptions _options;
     };
 } // end namespace webrtc
 } // end namespace unity


### PR DESCRIPTION
Hello.

I found current implementations as below are not working due to missing member initialize.
https://github.com/Unity-Technologies/com.unity.webrtc/blob/8bf0f084ec8c58b69b29f0c7e50f41243f835796/Plugin~/WebRTCPlugin/Context.cpp#L396-L400

In order to fix it without modifying libwebrtc, I added the `cricket::AudioOptions` member and `options()` overrided function to `LocalAudioSource` itself to enable accessing `_options` member correctly.