### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Plugin~/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/Plugin~/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
@@ -349,7 +349,7 @@ int NvDecoder::ReconfigureDecoder(CUVIDEOFORMAT *pVideoFormat)
     // If external reconfigure is called along with resolution change even if post processing params is not changed,
     // do full reconfigure params update
     if ((m_bReconfigExternal && bDecodeResChange) || m_bReconfigExtPPChange) {
-        // update display rect and target resolution if requested explicitely
+        // update display rect and target resolution if requested explicitly
         m_bReconfigExternal = false;
         m_bReconfigExtPPChange = false;
         m_videoFormat = *pVideoFormat;

--- a/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
+++ b/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
@@ -40,7 +40,7 @@ void NvEncoderCuda::AllocateInputBuffers(int32_t numInputBuffers)
         NVENC_THROW_ERROR("Encoder intialization failed", NV_ENC_ERR_ENCODER_NOT_INITIALIZED);
     }
 
-    // for MEOnly mode we need to allocate seperate set of buffers for reference frame
+    // for MEOnly mode we need to allocate separate set of buffers for reference frame
     int numCount = m_bMotionEstimationOnly ? 2 : 1;
 
     for (int count = 0; count < numCount; count++)

--- a/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
+++ b/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
@@ -62,7 +62,7 @@ public:
 
     /**
     *  @brief This is a static function to copy input data from host memory to device memory.
-    *  Application must pass a seperate device pointer for each YUV plane.
+    *  Application must pass a separate device pointer for each YUV plane.
     */
     static void CopyToDeviceFrame(CUcontext device,
         void* pSrcFrame,

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -290,7 +290,7 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
                 param->width, param->height, s_gfxDevice.get(), encoderType, param->textureFormat);
             if (!s_context->InitializeEncoder(s_mapEncoder[track].get(), track))
             {
-                // DebugLog("Encoder initialization faild.");
+                // DebugLog("Encoder initialization failed.");
             }
             return;
         }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -196,7 +196,7 @@ namespace webrtc
     }
 
     ///
-    /// avoid compile erorr for vector<bool>
+    /// avoid compile error for vector<bool>
     /// https://en.cppreference.com/w/cpp/container/vector_bool
     bool* ConvertArray(std::vector<bool> vec, size_t* length)
     {

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Please read this if you have an interest to customize native code in this projec
 | `2.0.0-preview` | [M79](https://groups.google.com/d/msg/discuss-webrtc/Ozvbd0p7Q1Y/M4WN2cRKCwAJ) | - Multi camera <br>- DirectX12 (DXR) Support | Apr 2020 |
 | `2.1.0-preview` | [M84](https://groups.google.com/g/discuss-webrtc/c/MRAV4jgHYV0/m/A5X253_ZAQAJ) | - Profiler tool <br>- Bitrate control | Aug 2020 |
 | `2.2.0-preview` | [M85](https://groups.google.com/g/discuss-webrtc/c/Qq3nsR2w2HU/m/7WGLPscPBwAJ) | - Video decoder (VP8, VP9 only) <br>- Vulkan HW encoder support <br>- MacOS HW encoder support | Oct 2020 |
-| `2.3.0-preview` | [M85](https://groups.google.com/g/discuss-webrtc/c/Qq3nsR2w2HU/m/7WGLPscPBwAJ) | - iOS platform suppport | Dec 2020 |
-| `2.4.0-exp.1` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | - Android platform suppport | Apr 2021 |
+| `2.3.0-preview` | [M85](https://groups.google.com/g/discuss-webrtc/c/Qq3nsR2w2HU/m/7WGLPscPBwAJ) | - iOS platform support | Dec 2020 |
+| `2.4.0-exp.1` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | - Android platform support | Apr 2021 |
 | `2.4.0-exp.2` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | | May 2021 |
 | `2.4.0-exp.3` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | | Jun 2021 |
 | `2.4.0-exp.4` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | - Audio renderer support - <br>- Apple Silicon support | Aug 2021 |

--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -414,7 +414,7 @@ record keeping.)
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from 
  *    the apps directory (application code) you must include an acknowledgement:


### PR DESCRIPTION
There are small typos in:
- Plugin~/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
- Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
- Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
- Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
- Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
- README.md
- Third Party Notices.md

Fixes:
- Should read `separate` rather than `seperate`.
- Should read `support` rather than `suppport`.
- Should read `routines` rather than `rouines`.
- Should read `failed` rather than `faild`.
- Should read `explicitly` rather than `explicitely`.
- Should read `error` rather than `erorr`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md