### PR TITLE
fix: Fix a bug of AudioStreamTrack.SetData method

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -39,6 +39,11 @@ void UnityAudioTrackSource::RemoveSink(AudioTrackSinkInterface* sink)
 
 void UnityAudioTrackSource::OnData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames)
 {
+    RTC_DCHECK(pAudioData);
+    RTC_DCHECK(nSampleRate);
+    RTC_DCHECK(nNumChannels);
+    RTC_DCHECK(nNumFrames);
+
     std::lock_guard<std::mutex> lock(_mutex);
 
     if (_arrSink.empty())

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -186,7 +186,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 #endif
@@ -202,7 +202,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 
@@ -216,8 +216,18 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
-                NativeMethods.ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
+        }
+
+        static void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
+        {
+            if (sampleRate == 0 || channels == 0 || frames == 0)
+                throw new ArgumentException($"arguments are invalid values " +
+                    $"sampleRate={sampleRate}, " +
+                    $"channels={channels}" +
+                    $"frames={frames}");
+            NativeMethods.ProcessAudio(track, array, sampleRate, channels, frames);
         }
 
         /// <summary>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -225,7 +225,7 @@ namespace Unity.WebRTC
             if (sampleRate == 0 || channels == 0 || frames == 0)
                 throw new ArgumentException($"arguments are invalid values " +
                     $"sampleRate={sampleRate}, " +
-                    $"channels={channels}" +
+                    $"channels={channels}, " +
                     $"frames={frames}");
             NativeMethods.ProcessAudio(track, array, sampleRate, channels, frames);
         }

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -237,6 +237,8 @@ namespace Unity.WebRTC
         /// <param name="channels"></param>
         public void SetData(float[] array, int channels, int sampleRate)
         {
+            if (array == null)
+                throw new ArgumentNullException("array is null");
             NativeArray<float> nativeArray = new NativeArray<float>(array, Allocator.Temp);
             SetData(ref nativeArray, channels, sampleRate);
             nativeArray.Dispose();

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -106,6 +106,21 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void AudioStreamTrackSetData()
+        {
+            var track = new AudioStreamTrack();
+            Assert.That(() => track.SetData(null, 0, 0), Throws.ArgumentNullException);
+
+            float[] data = new float[2048];
+            Assert.That(() => track.SetData(data, 0, 0), Throws.ArgumentException);
+
+            Assert.That(() => track.SetData(data, 1, 0), Throws.ArgumentException);
+            Assert.That(() => track.SetData(data, 0, 48000), Throws.ArgumentException);
+            Assert.That(() => track.SetData(data, 1, 48000), Throws.Nothing);
+            track.Dispose();
+        }
+
+        [Test]
         public void AudioStreamTrackPlayAudio()
         {
             GameObject obj = new GameObject("audio");


### PR DESCRIPTION
`AudioStreamTrack.SetData` method had bugs that it occurs crashes when pass invalid arguments like zero or null. 