### PR TITLE
Improve audio playback stability using streaming AudioClip

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -143,6 +143,9 @@ namespace webrtc
         void SetEncoderParameter(const MediaStreamTrackInterface* track, int width, int height,
             UnityRenderingExtTextureFormat format, void* textureHandle);
 
+        // AudioDevice
+        rtc::scoped_refptr<DummyAudioDevice> GetAudioDevice() const { return m_audioDevice; }
+
         // mutex;
         std::mutex mutex;
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -12,8 +12,6 @@ namespace webrtc
         int64_t currentTime = rtc::TimeMillis();
 
         {
-            std::lock_guard<std::mutex> lock(mutex_);
-
             if (audio_transport_ == nullptr) {
                 return false;
             }
@@ -38,7 +36,7 @@ namespace webrtc
                 int64_t ntp_time_ms = -1;
                 char data[kBytesPerSample * kChannels * kSamplesPerFrame];
 
-                audio_transport_->PullRenderData(kBytesPerSample * 8, kSamplingRate,
+                (*audio_transport_).PullRenderData(kBytesPerSample * 8, kSamplingRate,
                     kChannels, kSamplesPerFrame, data,
                     &elapsed_time_ms, &ntp_time_ms);
             }
@@ -46,9 +44,72 @@ namespace webrtc
 
         int64_t deltaTimeMillis = rtc::TimeMillis() - currentTime;
         if (deltaTimeMillis < 10) {
-            SleepMs(10 - deltaTimeMillis);
+            SleepMs(10 - (deltaTimeMillis + 1));
         }
         return true;
+    }
+
+    void DummyAudioDevice::RecodingThread() {
+        bool buffer_init = false;
+
+        while (recording_) {
+            const int64_t bgnTime = rtc::TimeMillis();
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                if (sampleRate_ > 0 && channels_ > 0) {
+                    const size_t samplesFor10ms = sampleRate_ * channels_ / 100;
+
+                    if (buffer_init == false && audioBuffer_.size() > samplesFor10ms * 10) {
+                        audioBuffer_.erase(
+                            audioBuffer_.begin(),
+                            audioBuffer_.begin() + (audioBuffer_.size() - samplesFor10ms));
+                        buffer_init = true;
+                    }
+
+                    if (buffer_init) {
+                        if (audioBuffer_.size() >= samplesFor10ms) {
+                            constexpr int bytePerSample = sizeof(decltype(audioBuffer_)::value_type);
+
+                            uint32_t newMicLev = 0;
+                            if (audio_transport_) {
+                                (*audio_transport_).RecordedDataIsAvailable(audioBuffer_.data(),
+                                    sampleRate_ / 100, bytePerSample, channels_, sampleRate_,
+                                    0, 0, 0, false, newMicLev);
+                            }
+
+                            audioBuffer_.erase(audioBuffer_.begin(), audioBuffer_.begin() + samplesFor10ms);
+                        }
+                    }
+                }
+            }
+            if (recording_) {
+                const int64_t elapsed = rtc::TimeMillis() - bgnTime;
+                if (elapsed < 10) {
+                    SleepMs(10 - (elapsed + 1));
+                }
+            }
+        }
+    }
+
+    void DummyAudioDevice::InitLocalAudio(int sampleRate, int channels) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        sampleRate_ = sampleRate;
+        channels_ = channels;
+    }
+    
+    void DummyAudioDevice::PushLocalAudio(const float* audioData, int sampleRate, int channels, int numFrames) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        if (sampleRate_ == 0 || channels_ == 0)
+            return;
+
+        audioBuffer_.reserve(audioBuffer_.size() + numFrames);
+        for (size_t i = 0; i < numFrames; i++)
+        {
+            audioBuffer_.push_back(audioData[i] >= 0 ? audioData[i] * SHRT_MAX : audioData[i] * -SHRT_MIN);
+        }
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -51,8 +51,6 @@ namespace webrtc
     }
 
     void DummyAudioDevice::RecordingThread() {
-        bool buffer_init = false;
-
         while (recording_) {
             const int64_t bgnTime = rtc::TimeMillis();
             {

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "DummyAudioDevice.h"
+#include "UnityAudioTrackSource.h"
 #include "system_wrappers/include/sleep.h"
 
 namespace unity
@@ -56,31 +57,8 @@ namespace webrtc
             const int64_t bgnTime = rtc::TimeMillis();
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-
-                if (sampleRate_ > 0 && channels_ > 0) {
-                    const size_t samplesFor10ms = sampleRate_ * channels_ / 100;
-
-                    if (buffer_init == false && audioBuffer_.size() > samplesFor10ms * 10) {
-                        audioBuffer_.erase(
-                            audioBuffer_.begin(),
-                            audioBuffer_.begin() + (audioBuffer_.size() - samplesFor10ms));
-                        buffer_init = true;
-                    }
-
-                    if (buffer_init) {
-                        if (audioBuffer_.size() >= samplesFor10ms) {
-                            constexpr int bytePerSample = sizeof(decltype(audioBuffer_)::value_type);
-
-                            uint32_t newMicLev = 0;
-                            if (audio_transport_) {
-                                (*audio_transport_).RecordedDataIsAvailable(audioBuffer_.data(),
-                                    sampleRate_ / 100, bytePerSample, channels_, sampleRate_,
-                                    0, 0, 0, false, newMicLev);
-                            }
-
-                            audioBuffer_.erase(audioBuffer_.begin(), audioBuffer_.begin() + samplesFor10ms);
-                        }
-                    }
+                for (const auto &pair : callbacks_) {
+                    pair.second();
                 }
             }
             if (recording_) {
@@ -92,23 +70,11 @@ namespace webrtc
         }
     }
 
-    void DummyAudioDevice::InitLocalAudio(int sampleRate, int channels) {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        sampleRate_ = sampleRate;
-        channels_ = channels;
-    }
-    
-    void DummyAudioDevice::PushLocalAudio(const float* audioData, int sampleRate, int channels, int numFrames) {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        if (sampleRate_ == 0 || channels_ == 0)
-            return;
-
-        audioBuffer_.reserve(audioBuffer_.size() + numFrames);
-        for (size_t i = 0; i < numFrames; i++)
-        {
-            audioBuffer_.push_back(audioData[i] >= 0 ? audioData[i] * SHRT_MAX : audioData[i] * -SHRT_MIN);
+    void DummyAudioDevice::RegisterSendAudioCallback(UnityAudioTrackSource* source, int sampleRate, int channels) {
+        if (callbacks_.find(source) == callbacks_.end()) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            callbacks_.emplace(source, [source, sampleRate, channels]() {
+                source->SendAudioData(sampleRate, channels); });
         }
     }
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -50,7 +50,7 @@ namespace webrtc
         return true;
     }
 
-    void DummyAudioDevice::RecodingThread() {
+    void DummyAudioDevice::RecordingThread() {
         bool buffer_init = false;
 
         while (recording_) {

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -69,10 +69,17 @@ namespace webrtc
     }
 
     void DummyAudioDevice::RegisterSendAudioCallback(UnityAudioTrackSource* source, int sampleRate, int channels) {
+        std::lock_guard<std::mutex> lock(mutex_);
         if (callbacks_.find(source) == callbacks_.end()) {
-            std::lock_guard<std::mutex> lock(mutex_);
             callbacks_.emplace(source, [source, sampleRate, channels]() {
                 source->SendAudioData(sampleRate, channels); });
+        }
+    }
+
+    void DummyAudioDevice::UnregisterSendAudioCallback(UnityAudioTrackSource* source) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (callbacks_.find(source) != callbacks_.end()) {
+            callbacks_.erase(source);
         }
     }
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -323,6 +323,7 @@ namespace webrtc
         }
 #endif
         void RegisterSendAudioCallback(UnityAudioTrackSource* source, int sampleRate, int channels);
+        void UnregisterSendAudioCallback(UnityAudioTrackSource* source);
 
     private:
         bool PlayoutThreadProcess();

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <unordered_map>
 
 #include "WebRTCPlugin.h"
 #include "api/task_queue/default_task_queue_factory.h"
@@ -11,6 +12,8 @@ namespace unity
 namespace webrtc
 {
     using namespace ::webrtc;
+
+    class UnityAudioTrackSource;
 
     class DummyAudioDevice : public webrtc::AudioDeviceModule
     {
@@ -319,8 +322,7 @@ namespace webrtc
             return 0;
         }
 #endif
-        void InitLocalAudio(int sampleRate, int channels);
-        void PushLocalAudio(const float* audioData, int sampleRate, int channels, int numFrames);
+        void RegisterSendAudioCallback(UnityAudioTrackSource* source, int sampleRate, int channels);
 
     private:
         bool PlayoutThreadProcess();
@@ -336,9 +338,8 @@ namespace webrtc
 
         std::atomic<webrtc::AudioTransport*> audio_transport_{ nullptr };
 
-        int sampleRate_ = 0;
-        int channels_ = 0;
-        std::vector<int16_t> audioBuffer_;
+        using callback_t = std::function<void()>;
+        std::unordered_map<UnityAudioTrackSource*, callback_t> callbacks_;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -142,7 +142,7 @@ namespace webrtc
         {
             recording_ = true;
             recordAudioThread_.reset(new rtc::PlatformThread(
-                [](void *pThis) { static_cast<DummyAudioDevice*>(pThis)->RecodingThread(); },
+                [](void *pThis) { static_cast<DummyAudioDevice*>(pThis)->RecordingThread(); },
                 this, "webrtc_audio_module_recording_thread", rtc::kRealtimePriority));
             recordAudioThread_->Start();
             return 0;
@@ -326,7 +326,7 @@ namespace webrtc
 
     private:
         bool PlayoutThreadProcess();
-        void RecodingThread();
+        void RecordingThread();
 
         std::atomic<bool> initialized_ {false};
         std::atomic<bool> playing_ {false};

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -37,44 +37,6 @@ void UnityAudioTrackSource::RemoveSink(AudioTrackSinkInterface* sink)
         _arrSink.erase(i);
 }
 
-void UnityAudioTrackSource::OnData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames)
-{
-    RTC_DCHECK(pAudioData);
-    RTC_DCHECK(nSampleRate);
-    RTC_DCHECK(nNumChannels);
-    RTC_DCHECK(nNumFrames);
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    if (_arrSink.empty())
-        return;
-
-    for (size_t i = 0; i < nNumFrames; i++)
-    {
-        _convertedAudioData.push_back(pAudioData[i] >= 0 ? pAudioData[i] * SHRT_MAX : pAudioData[i] * -SHRT_MIN);
-    }
-
-    // eg.  80 for 8KHz and 160 for 16kHz
-    size_t nNumFramesFor10ms = nSampleRate / 100;
-    size_t size = _convertedAudioData.size() / (nNumFramesFor10ms * nNumChannels);
-    size_t nBitPerSample = sizeof(int16_t) * 8;
-
-    for(auto sink : _arrSink)
-    {
-        for (size_t i = 0; i < size; i++)
-        {
-            sink->OnData(
-                &_convertedAudioData.data()[i * nNumFramesFor10ms * nNumChannels],
-                nBitPerSample, nSampleRate, nNumChannels, nNumFramesFor10ms);
-        }
-    }
-
-    // pop processed buffer, remained buffer will be processed the next time.
-    _convertedAudioData.erase(
-        _convertedAudioData.begin(),
-        _convertedAudioData.begin() + nNumFramesFor10ms * nNumChannels * size);
-}
-
 UnityAudioTrackSource::UnityAudioTrackSource()
 {
 }

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -37,6 +37,56 @@ void UnityAudioTrackSource::RemoveSink(AudioTrackSinkInterface* sink)
         _arrSink.erase(i);
 }
 
+void UnityAudioTrackSource::PushAudioData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames)
+{
+    RTC_DCHECK(pAudioData);
+    RTC_DCHECK(nSampleRate);
+    RTC_DCHECK(nNumChannels);
+    RTC_DCHECK(nNumFrames);
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_arrSink.empty())
+        return;
+
+    for (size_t i = 0; i < nNumFrames; i++)
+    {
+        _convertedAudioData.push_back(pAudioData[i] >= 0 ? pAudioData[i] * SHRT_MAX : pAudioData[i] * -SHRT_MIN);
+    }
+}
+
+void UnityAudioTrackSource::SendAudioData(int nSampleRate, size_t nNumChannels) {
+    RTC_DCHECK(nSampleRate);
+    RTC_DCHECK(nNumChannels);
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    // eg.  80 for 8KHz and 160 for 16kHz
+    size_t nNumFramesFor10ms = nSampleRate / 100;
+    size_t nNumSamplesFor10ms = nNumFramesFor10ms * nNumChannels;
+    size_t nBitPerSample = sizeof(int16_t) * 8;
+
+    if (_bufferInit == false && _convertedAudioData.size() > nNumSamplesFor10ms * 8) {
+        _convertedAudioData.erase(
+            _convertedAudioData.begin(),
+            _convertedAudioData.begin() + (_convertedAudioData.size() - nNumSamplesFor10ms * 8));
+        _bufferInit = true;
+    }
+
+    if (_bufferInit) {
+        for (auto sink : _arrSink)
+        {
+            sink->OnData(_convertedAudioData.data(),
+                nBitPerSample, nSampleRate, nNumChannels, nNumFramesFor10ms);
+        }
+    }
+
+    // pop processed buffer, remained buffer will be processed the next time.
+    _convertedAudioData.erase(
+        _convertedAudioData.begin(),
+        _convertedAudioData.begin() + nNumSamplesFor10ms);
+}
+
 UnityAudioTrackSource::UnityAudioTrackSource()
 {
 }

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -18,8 +18,6 @@ namespace webrtc
         void AddSink(AudioTrackSinkInterface* sink) override;
         void RemoveSink(AudioTrackSinkInterface* sink) override;
 
-        void OnData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames);
-
     protected:
         UnityAudioTrackSource();
         UnityAudioTrackSource(const cricket::AudioOptions& audio_options);

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -18,6 +18,9 @@ namespace webrtc
         void AddSink(AudioTrackSinkInterface* sink) override;
         void RemoveSink(AudioTrackSinkInterface* sink) override;
 
+        void PushAudioData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames);
+        void SendAudioData(int nSampleRate, size_t nNumChannels);
+
     protected:
         UnityAudioTrackSource();
         UnityAudioTrackSource(const cricket::AudioOptions& audio_options);
@@ -29,6 +32,7 @@ namespace webrtc
         std::vector <AudioTrackSinkInterface*> _arrSink;
         std::mutex _mutex;
         cricket::AudioOptions _options;
+        bool _bufferInit = false;
     };
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1376,6 +1376,34 @@ extern "C"
         ContextManager::GetInstance()->curContext = context;
     }
 
+    UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
+        Context* context,
+        AudioTrackInterface* track,
+        int32 sample_rate,
+        int32 number_of_channels)
+    {
+        UnityAudioTrackSource* source =
+            static_cast<UnityAudioTrackSource*>(track->GetSource());
+        auto adm = context->GetAudioDevice();
+        if (source != nullptr && adm != nullptr)
+        {
+            adm->RegisterSendAudioCallback(source, sample_rate, number_of_channels);
+        }
+    }
+
+    UNITY_INTERFACE_EXPORT void ContextUninitLocalAudio(
+        Context* context,
+        AudioTrackInterface* track)
+    {
+        UnityAudioTrackSource* source =
+            static_cast<UnityAudioTrackSource*>(track->GetSource());
+        auto adm = context->GetAudioDevice();
+        if (source != nullptr && adm != nullptr)
+        {
+            adm->UnregisterSendAudioCallback(source);
+        }
+    }
+
     UNITY_INTERFACE_EXPORT void ContextProcessLocalAudio(
         Context* context,
         AudioTrackInterface* track,
@@ -1386,16 +1414,13 @@ extern "C"
     {
         UnityAudioTrackSource* source =
             static_cast<UnityAudioTrackSource*>(track->GetSource());
-
-        source->PushAudioData(
-            audio_data,
-            sample_rate,
-            number_of_channels,
-            number_of_frames);
-
-        auto adm = context->GetAudioDevice();
-        if (adm != nullptr) {
-            adm->RegisterSendAudioCallback(source, sample_rate, number_of_channels);
+        if (source != nullptr)
+        {
+            source->PushAudioData(
+                audio_data,
+                sample_rate,
+                number_of_channels,
+                number_of_frames);
         }
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1376,27 +1376,26 @@ extern "C"
         ContextManager::GetInstance()->curContext = context;
     }
 
-    UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
-        Context* context,
-        int32 sample_rate,
-        int32 number_of_channels)
-    {
-        auto adm = context->GetAudioDevice();
-        if (adm != nullptr) {
-            adm->InitLocalAudio(sample_rate, number_of_channels);
-        }
-    }
-
     UNITY_INTERFACE_EXPORT void ContextProcessLocalAudio(
         Context* context,
+        AudioTrackInterface* track,
         float* audio_data,
         int32 sample_rate,
         int32 number_of_channels,
         int32 number_of_frames)
     {
+        UnityAudioTrackSource* source =
+            static_cast<UnityAudioTrackSource*>(track->GetSource());
+
+        source->PushAudioData(
+            audio_data,
+            sample_rate,
+            number_of_channels,
+            number_of_frames);
+
         auto adm = context->GetAudioDevice();
         if (adm != nullptr) {
-            adm->PushLocalAudio(audio_data, sample_rate, number_of_channels, number_of_frames);
+            adm->RegisterSendAudioCallback(source, sample_rate, number_of_channels);
         }
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1376,22 +1376,29 @@ extern "C"
         ContextManager::GetInstance()->curContext = context;
     }
 
-    UNITY_INTERFACE_EXPORT void ProcessAudio(
-        AudioTrackInterface* track,
+    UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
+        Context* context,
+        int32 sample_rate,
+        int32 number_of_channels)
+    {
+        auto adm = context->GetAudioDevice();
+        if (adm != nullptr) {
+            adm->InitLocalAudio(sample_rate, number_of_channels);
+        }
+    }
+
+    UNITY_INTERFACE_EXPORT void ContextProcessLocalAudio(
+        Context* context,
         float* audio_data,
         int32 sample_rate,
         int32 number_of_channels,
         int32 number_of_frames)
     {
-        UnityAudioTrackSource* source =
-            static_cast<UnityAudioTrackSource*>(track->GetSource());
-
-        source->OnData(audio_data,
-            sample_rate,
-            number_of_channels,
-            number_of_frames);
+        auto adm = context->GetAudioDevice();
+        if (adm != nullptr) {
+            adm->PushLocalAudio(audio_data, sample_rate, number_of_channels, number_of_frames);
+        }
     }
-
 
     UNITY_INTERFACE_EXPORT void ContextRegisterAudioReceiveCallback(
         Context* context, AudioTrackInterface* track, DelegateAudioReceive callback)

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -34,6 +34,7 @@ namespace Unity.WebRTC
             sampleRate = clip.frequency;
             nativeArray = new NativeArray<float>(
                 clip.channels * clip.samples, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            WebRTC.Context.InitLocalAudio(sampleRate, channels);
         }
 
         private void OnDestroy()

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -34,7 +34,6 @@ namespace Unity.WebRTC
             sampleRate = clip.frequency;
             nativeArray = new NativeArray<float>(
                 clip.channels * clip.samples, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-            WebRTC.Context.InitLocalAudio(sampleRate, channels);
         }
 
         private void OnDestroy()

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -129,6 +129,7 @@ namespace Unity.WebRTC
                 throw new ArgumentException("AudioClip must to be attached on AudioSource");
             Source = source;
 
+            WebRTC.Context.InitLocalAudio(self, source.clip.frequency, source.clip.channels);
             _audioSourceRead = source.gameObject.AddComponent<AudioSourceRead>();
             _audioSourceRead.hideFlags = HideFlags.HideInHierarchy;
             _audioSourceRead.onAudioRead += SetData;
@@ -162,6 +163,7 @@ namespace Unity.WebRTC
                     // Unity API must be called from main thread.
                     _audioSourceRead.onAudioRead -= SetData;
                     WebRTC.DestroyOnMainThread(_audioSourceRead);
+                    WebRTC.Context.UninitLocalAudio(self);
                 }
                 _streamRenderer?.Dispose();
                 _source?.Dispose();

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -84,7 +84,7 @@ namespace Unity.WebRTC
                 int remain = data.Length;
                 while (remain > 0)
                 {
-                    if (m_recvBufs.TryTake(out float[] src) == false)
+                    if (!m_recvBufs.TryTake(out float[] src))
                     {
                         return;
                     }

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -182,7 +182,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 #endif
@@ -198,7 +198,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 
@@ -212,18 +212,18 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
-                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
         }
 
-        static void ProcessAudio(IntPtr array, int sampleRate, int channels, int frames)
+        static void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
         {
             if (sampleRate == 0 || channels == 0 || frames == 0)
                 throw new ArgumentException($"arguments are invalid values " +
                     $"sampleRate={sampleRate}, " +
                     $"channels={channels}, " +
                     $"frames={frames}");
-            WebRTC.Context.ProcessLocalAudio(array, sampleRate, channels, frames);
+            WebRTC.Context.ProcessLocalAudio(track, array, sampleRate, channels, frames);
         }
 
         /// <summary>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -182,7 +182,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 #endif
@@ -198,7 +198,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 
@@ -212,18 +212,18 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
-                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
         }
 
-        static void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
+        static void ProcessAudio(IntPtr array, int sampleRate, int channels, int frames)
         {
             if (sampleRate == 0 || channels == 0 || frames == 0)
                 throw new ArgumentException($"arguments are invalid values " +
                     $"sampleRate={sampleRate}, " +
                     $"channels={channels}, " +
                     $"frames={frames}");
-            NativeMethods.ProcessAudio(track, array, sampleRate, channels, frames);
+            WebRTC.Context.ProcessLocalAudio(array, sampleRate, channels, frames);
         }
 
         /// <summary>

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -303,5 +303,15 @@ namespace Unity.WebRTC
             textureUpdateFunction = textureUpdateFunction == IntPtr.Zero ? GetUpdateTextureFunc() : textureUpdateFunction;
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
+
+        internal void InitLocalAudio(int sampleRate, int channels)
+        {
+            NativeMethods.ContextInitLocalAudio(self, sampleRate, channels);
+        }
+
+        internal void ProcessLocalAudio(IntPtr array, int sampleRate, int channels, int frames)
+        {
+            NativeMethods.ContextProcessLocalAudio(self, array, sampleRate, channels, frames);
+        }
     }
 }

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -304,14 +304,9 @@ namespace Unity.WebRTC
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
 
-        internal void InitLocalAudio(int sampleRate, int channels)
+        internal void ProcessLocalAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
         {
-            NativeMethods.ContextInitLocalAudio(self, sampleRate, channels);
-        }
-
-        internal void ProcessLocalAudio(IntPtr array, int sampleRate, int channels, int frames)
-        {
-            NativeMethods.ContextProcessLocalAudio(self, array, sampleRate, channels, frames);
+            NativeMethods.ContextProcessLocalAudio(self, track, array, sampleRate, channels, frames);
         }
     }
 }

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -304,6 +304,16 @@ namespace Unity.WebRTC
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
 
+        internal void InitLocalAudio(IntPtr track, int sampleRate, int channels)
+        {
+            NativeMethods.ContextInitLocalAudio(self, track, sampleRate, channels);
+        }
+
+        internal void UninitLocalAudio(IntPtr track)
+        {
+            NativeMethods.ContextUninitLocalAudio(self, track);
+        }
+
         internal void ProcessLocalAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
         {
             NativeMethods.ContextProcessLocalAudio(self, track, array, sampleRate, channels, frames);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1085,9 +1085,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextInitLocalAudio(IntPtr context, int sampleRate, int channels);
-        [DllImport(WebRTC.Lib)]
-        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr array, int sampleRate, int channels, int frames);
+        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1085,6 +1085,10 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
+        public static extern void ContextInitLocalAudio(IntPtr context, IntPtr track, int sampleRate, int channels);
+        [DllImport(WebRTC.Lib)]
+        public static extern void ContextUninitLocalAudio(IntPtr context, IntPtr track);
+        [DllImport(WebRTC.Lib)]
         public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1085,7 +1085,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
+        public static extern void ContextInitLocalAudio(IntPtr context, int sampleRate, int channels);
+        [DllImport(WebRTC.Lib)]
+        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]


### PR DESCRIPTION
Hello.

As commented in #525, current audio playback is often unstable and has very high latency.
In order to reduce latency and improve playback quality, I tried to change to work `AudioClip` of `AudioStreamRenderer` as streaming mode  and reduce sample length of `AudioClip`.
I think it works better than current implementation, has lower latency and less frequently glitch.

Thank you in advance for your review.