### PR TITLE
Add Support for Sending Basic Native Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added the ability to execute pending native tasks manually from the main thread.
+- Added the ability to execute pending native tasks manually from the main thread
+- Added support for sending basic native collections (`NativeArray<T>`, `NativeSlice<T>` and `NativeArray<T>.ReadOnly`) to `RTCDataChannel`
 
 ## [2.4.0-exp.4] - 2021-08-19
 
@@ -23,9 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add the audio waveform graph to `MultiplePeerConnections` scene in the sample
 
-### Fixed 
+### Fixed
 
-- Fix the crash on Windows with Vulkan API on `VideoReceieSample` 
+- Fix the crash on Windows with Vulkan API on `VideoReceieSample`
 - Fix the crash when calling `WebRTC.Initialize` twice
 - Fix the error in the build process on `Unity2021.2`
 
@@ -51,7 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Add the validation of the streaming texture size on Android
-- Add the validation of the  streaming when using NvCodec 
+- Add the validation of the  streaming when using NvCodec
 - Use the software video decoder when disabling hardware acceleration
 
 ## [2.4.0-exp.1] - 2021-04-23
@@ -61,7 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Android ARM64 platform support
 - Added a sample scene "Menu" which developers can go back and forth between sample scenes
 - Added a sample scene "PerfectNegotiation"
-- Added the software encoder on Linux support when using OpenGL Core graphics API 
+- Added the software encoder on Linux support when using OpenGL Core graphics API
 - Added the `RestartIce` method to the `RTCPeerConnection` class
 - Added the `Streams` property to the `RTCRtpReceiver` class
 
@@ -107,7 +108,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.0-preview] - 2020-12-28
 
-### Added 
+### Added
 
 - Supported iOS platform
 - Supported H.264 HW decoder (VideoToolbox) on macOS
@@ -166,7 +167,7 @@ public RTCDataChannel CreateDataChannel(string label RTCDataChannelInit options 
 
 - Upgrade libwebrtc m85
 - Upgrade NVIDIA Codec SDK 9.1
-- Changed `RTCPeerConnection` behaviour to throw exceptions when pass invalid arguments to `SetLocalDescription`, `SetRemoteDescription` 
+- Changed `RTCPeerConnection` behaviour to throw exceptions when pass invalid arguments to `SetLocalDescription`, `SetRemoteDescription`
 
 ## [2.1.3-preview] - 2020-09-28
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1348,7 +1348,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT void DataChannelSendPtr(DataChannelObject* dataChannelObj, const byte* msg, int len)
     {
-        dataChannelObj->Send(ptr, len);
+        dataChannelObj->Send(msg, len);
     }
 
     UNITY_INTERFACE_EXPORT void DataChannelSendBinary(DataChannelObject* dataChannelObj, const byte* msg, int len)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1346,11 +1346,6 @@ extern "C"
         dataChannelObj->Send(msg);
     }
 
-    UNITY_INTERFACE_EXPORT void DataChannelSendPtr(DataChannelObject* dataChannelObj, const byte* msg, int len)
-    {
-        dataChannelObj->Send(msg, len);
-    }
-
     UNITY_INTERFACE_EXPORT void DataChannelSendBinary(DataChannelObject* dataChannelObj, const byte* msg, int len)
     {
         dataChannelObj->Send(msg, len);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -874,7 +874,7 @@ extern "C"
         obj->RegisterConnectionStateChange(callback);
     }
 
-    
+
     UNITY_INTERFACE_EXPORT void PeerConnectionRegisterOnIceCandidate(PeerConnectionObject*obj, DelegateIceCandidate callback)
     {
         obj->RegisterIceCandidate(callback);
@@ -1067,7 +1067,7 @@ extern "C"
             return *this;
         }
     };
-     
+
     UNITY_INTERFACE_EXPORT RTCErrorType TransceiverSetCodecPreferences(RtpTransceiverInterface* transceiver, RTCRtpCodecCapability* codecs, size_t length)
     {
         std::vector<RtpCodecCapability> _codecs(length);
@@ -1344,6 +1344,11 @@ extern "C"
     UNITY_INTERFACE_EXPORT void DataChannelSend(DataChannelObject* dataChannelObj, const char* msg)
     {
         dataChannelObj->Send(msg);
+    }
+
+    UNITY_INTERFACE_EXPORT void DataChannelSendPtr(DataChannelObject* dataChannelObj, const byte* msg, int len)
+    {
+        dataChannelObj->Send(ptr, len);
     }
 
     UNITY_INTERFACE_EXPORT void DataChannelSendBinary(DataChannelObject* dataChannelObj, const byte* msg, int len)

--- a/Runtime/Scripts/Internal/ExecutableUnitySynchronizationContext.cs
+++ b/Runtime/Scripts/Internal/ExecutableUnitySynchronizationContext.cs
@@ -101,16 +101,14 @@ namespace Unity.WebRTC
 
             while (HasPendingTasks())
             {
+                // To prevent work from posting more work indefinitely, stop processing after timeout.
+                // Does not prevent a given work queue from going over the time allotment
                 if (stopwatch.ElapsedMilliseconds > millisecondsTimeout)
                 {
                     break;
                 }
 
-                if (HasPendingTasks())
-                {
-                    Execute();
-                }
-
+                Execute();
                 Thread.Sleep(1);
             }
 
@@ -179,7 +177,7 @@ namespace Unity.WebRTC
             }
         }
 
-        struct WorkRequest
+        readonly struct WorkRequest
         {
             readonly SendOrPostCallback m_DelegateCallback;
             readonly object m_DelegateState;

--- a/Runtime/Scripts/RTCDataChannel.cs
+++ b/Runtime/Scripts/RTCDataChannel.cs
@@ -312,6 +312,7 @@ namespace Unity.WebRTC
             NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), new IntPtr(msg.GetUnsafeReadOnlyPtr()), msg.Length * UnsafeUtility.SizeOf<T>());
         }
 
+#if UNITY_2020_1_OR_NEWER // ReadOnly support was introduced in 2020.1
         public unsafe void Send<T>(NativeArray<T>.ReadOnly msg)
             where T : struct
         {
@@ -321,6 +322,7 @@ namespace Unity.WebRTC
             }
             NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), new IntPtr(msg.GetUnsafeReadOnlyPtr()), msg.Length * UnsafeUtility.SizeOf<T>());
         }
+#endif
 
         public unsafe void Send(void* msgPtr, int length)
         {

--- a/Runtime/Scripts/RTCDataChannel.cs
+++ b/Runtime/Scripts/RTCDataChannel.cs
@@ -1,20 +1,22 @@
 using System.Runtime.InteropServices;
 using System;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.WebRTC
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <seealso cref="RTCPeerConnection.CreateDataChannel(string, RTCDataChannelInit)"/>
     public class RTCDataChannelInit
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public bool? ordered;
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>
         /// Cannot be set along with <see cref="RTCDataChannelInit.maxRetransmits"/>.
@@ -22,7 +24,7 @@ namespace Unity.WebRTC
         /// <seealso cref="RTCDataChannelInit.maxRetransmits"/>
         public int? maxPacketLifeTime;
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <remarks>
         /// Cannot be set along with <see cref="RTCDataChannelInit.maxPacketLifeTime"/>.
@@ -30,15 +32,15 @@ namespace Unity.WebRTC
         /// <seealso cref="RTCDataChannelInit.maxPacketLifeTime"/>
         public int? maxRetransmits;
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public string protocol;
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public bool? negotiated;
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public int? id;
     }
@@ -75,7 +77,7 @@ namespace Unity.WebRTC
     public delegate void DelegateOnDataChannel(RTCDataChannel channel);
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <seealso cref="RTCPeerConnection.CreateDataChannel(string, RTCDataChannelInit)"/>
     public class RTCDataChannel : IDisposable
@@ -89,7 +91,7 @@ namespace Unity.WebRTC
         private bool disposed;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public DelegateOnMessage OnMessage
         {
@@ -101,7 +103,7 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public DelegateOnOpen OnOpen
         {
@@ -113,7 +115,7 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public DelegateOnClose OnClose
         {
@@ -125,47 +127,47 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public int Id => NativeMethods.DataChannelGetID(GetSelfOrThrow());
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public string Label => NativeMethods.DataChannelGetLabel(GetSelfOrThrow()).AsAnsiStringWithFreeMem();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public string Protocol => NativeMethods.DataChannelGetProtocol(GetSelfOrThrow()).AsAnsiStringWithFreeMem();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public ushort MaxRetransmits => NativeMethods.DataChannelGetMaxRetransmits(GetSelfOrThrow());
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public ushort MaxRetransmitTime => NativeMethods.DataChannelGetMaxRetransmitTime(GetSelfOrThrow());
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public bool Ordered => NativeMethods.DataChannelGetOrdered(GetSelfOrThrow());
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public ulong BufferedAmount => NativeMethods.DataChannelGetBufferedAmount(GetSelfOrThrow());
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public bool Negotiated => NativeMethods.DataChannelGetNegotiated(GetSelfOrThrow());
 
         /// <summary>
-        /// The property returns an enum of the <c>RTCDataChannelState</c> which shows 
+        /// The property returns an enum of the <c>RTCDataChannelState</c> which shows
         /// the state of the channel.
         /// </summary>
         /// <remarks>
@@ -284,6 +286,61 @@ namespace Unity.WebRTC
                 throw new InvalidOperationException("DataChannel is not open");
             }
             NativeMethods.DataChannelSendBinary(GetSelfOrThrow(), msg, msg.Length);
+        }
+
+        public unsafe void Send<T>(NativeArray<T> msg)
+            where T : struct
+        {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
+            if (!msg.IsCreated)
+            {
+                throw new ArgumentException("Message array has not been created.", nameof(msg));
+            }
+            NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), new IntPtr(msg.GetUnsafeReadOnlyPtr()), msg.Length * UnsafeUtility.SizeOf<T>());
+        }
+
+        public unsafe void Send<T>(NativeSlice<T> msg)
+            where T : struct
+        {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
+            NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), new IntPtr(msg.GetUnsafeReadOnlyPtr()), msg.Length * UnsafeUtility.SizeOf<T>());
+        }
+
+        public unsafe void Send<T>(NativeArray<T>.ReadOnly msg)
+            where T : struct
+        {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
+            NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), new IntPtr(msg.GetUnsafeReadOnlyPtr()), msg.Length * UnsafeUtility.SizeOf<T>());
+        }
+
+        public unsafe void Send(void* msgPtr, int length)
+        {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
+            NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), new IntPtr(msgPtr), length);
+        }
+
+        public void Send(IntPtr msgPtr, int length)
+        {
+            if (ReadyState != RTCDataChannelState.Open)
+            {
+                throw new InvalidOperationException("DataChannel is not open");
+            }
+            if (msgPtr != IntPtr.Zero && length > 0)
+            {
+                NativeMethods.DataChannelSendPtr(GetSelfOrThrow(), msgPtr, length);
+            }
         }
 
         public void Close()

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -405,7 +405,7 @@ namespace Unity.WebRTC
 
             // Initialize a custom invokable synchronization context to wrap the main thread UnitySynchronizationContext
             s_syncContext = new ExecutableUnitySynchronizationContext(SynchronizationContext.Current);
-            
+
             var flipShader = Resources.Load<Shader>("Flip");
             if (flipShader != null)
             {
@@ -1019,6 +1019,8 @@ namespace Unity.WebRTC
         public static extern RTCDataChannelState DataChannelGetReadyState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern void DataChannelSend(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr)]string msg);
+        [DllImport(WebRTC.Lib)]
+        public static extern void DataChannelSendPtr(IntPtr ptr, IntPtr dataPtr, int size);
         [DllImport(WebRTC.Lib)]
         public static extern void DataChannelSendBinary(IntPtr ptr, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] bytes, int size);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1019,7 +1019,7 @@ namespace Unity.WebRTC
         public static extern RTCDataChannelState DataChannelGetReadyState(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
         public static extern void DataChannelSend(IntPtr ptr, [MarshalAs(UnmanagedType.LPStr)]string msg);
-        [DllImport(WebRTC.Lib)]
+        [DllImport(WebRTC.Lib, EntryPoint = "DataChannelSendBinary")]
         public static extern void DataChannelSendPtr(IntPtr ptr, IntPtr dataPtr, int size);
         [DllImport(WebRTC.Lib)]
         public static extern void DataChannelSendBinary(IntPtr ptr, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] bytes, int size);

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -326,6 +326,7 @@ namespace Unity.WebRTC.RuntimeTest
             return false;
         }
 
+#if UNITY_2021_1_OR_NEWER
         static unsafe bool NativeArrayMemCmp<T>(NativeArray<T>.ReadOnly array, byte[] buffer)
             where T : struct
         {
@@ -337,6 +338,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             return false;
         }
+#endif // UNITY_2021_1_OR_NEWER
 
         static unsafe bool IntPtrMemCmp(IntPtr ptr, byte[] buffer)
         {

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -189,6 +189,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(op13.IsCompleted, Is.True);
             Assert.That(comparisonBuffer, Is.EqualTo(nativeArrayTestMessageReceiver));
 
+#if UNITY_2021_1_OR_NEWER
             // NativeArray.ReadOnly
             using (var nativeArray = new NativeArray<byte>(comparisonBuffer, Allocator.Temp))
             {
@@ -201,6 +202,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return op14;
             Assert.That(op14.IsCompleted, Is.True);
             Assert.That(comparisonBuffer, Is.EqualTo(nativeArrayTestMessageReceiver));
+#endif // UNITY_2020_1_OR_NEWER
 
             test.component.Dispose();
             Object.DestroyImmediate(test.gameObject);
@@ -266,12 +268,14 @@ namespace Unity.WebRTC.RuntimeTest
                 ExecutePendingTasksWithTimeout(ref nativeArrayTestMessageReceiver, millisecondTimeout);
                 Assert.That(NativeArrayMemCmp(message6, nativeArrayTestMessageReceiver), Is.True, "Elements of the received message are not the same as the original message.");
 
+#if UNITY_2021_1_OR_NEWER
                 // NativeArray.ReadOnly
                 var message7 = nativeArray.AsReadOnly();
                 nativeArrayTestMessageReceiver = null;
                 channel1.Send(message7);
                 ExecutePendingTasksWithTimeout(ref nativeArrayTestMessageReceiver, millisecondTimeout);
                 Assert.That(NativeArrayMemCmp(message7, nativeArrayTestMessageReceiver), Is.True, "Elements of the received message are not the same as the original message.");
+#endif // UNITY_2021_1_OR_NEWER
             }
 
             test.component.Dispose();

--- a/Tests/Runtime/Unity.WebRTC.RuntimeTests.asmdef
+++ b/Tests/Runtime/Unity.WebRTC.RuntimeTests.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Unity.WebRTC.RuntimeTests",
+    "rootNamespace": "",
     "references": [
         "Unity.WebRTC",
         "UnityEngine.TestRunner",
@@ -14,7 +15,7 @@
         "WindowsStandalone64"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll"


### PR DESCRIPTION
This adds support to the `RTCDataChannel` for sending the basic Native Collections `NativeArray<T>`, `NativeSlice<T>` and `NativeArray<T>.ReadOnly`.

- Adds `Send` functionality to `RTCDataChannel` for each native collection described above.
- Adds `Send` functionality to `RTCDataChannel` for arbitrary pointers in the `unsafe` context and `IntPtr`s.
- Adds Native Collection send test cases where applicable.

Currently is in a first pass and not completely ready for review but tests are passing.