### PR TITLE
test: Workaround for failure of testcase TransceiverTest.TransceiverStop 

### DIFF
--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -216,6 +216,9 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
             Assert.That(transceiver2.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
 
+            // Dispose on the main thread.
+            test.component.Dispose();
+
             Object.DestroyImmediate(go);
             Object.DestroyImmediate(test.gameObject);
         }

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -191,9 +191,10 @@ namespace Unity.WebRTC.RuntimeTest
 
             var go = new GameObject("Test");
             var cam = go.AddComponent<Camera>();
+            var track = cam.CaptureStreamTrack(1280, 720, 0);
 
             var test = new MonoBehaviourTest<SignalingPeers>();
-            test.component.AddTransceiver(0, cam.CaptureStreamTrack(1280, 720, 0));
+            test.component.AddTransceiver(0, track);
             yield return test;
             test.component.CoroutineUpdate();
 
@@ -218,6 +219,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             // Dispose on the main thread.
             test.component.Dispose();
+            track.Dispose();
 
             Object.DestroyImmediate(go);
             Object.DestroyImmediate(test.gameObject);

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -217,7 +217,8 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
             Assert.That(transceiver2.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
 
-            // Dispose on the main thread.
+            //TODO:: Disposing process of MediaStreamTrack is unstable when using GC.
+            //At the moment, Dispose methods needs to be called on the main thread for workaround.
             test.component.Dispose();
             track.Dispose();
 


### PR DESCRIPTION
This is a workaround for the failure of testcase `TransceiverTest.TransceiverStop`.

Disposing process of MediaStreamTrack is unstable when using GC.
At the moment, Dispose methods needs to be called on the main thread for workaround.