### PR TITLE
Reduce audio latency using buffer position from attached AudioSource

### DIFF
--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -140,7 +140,7 @@ namespace Unity.WebRTC
                 while (numOfFrames-- > 0)
                 {
                     writtenSamples += WriteBuffer(
-                        m_recvBufs.Count > 0 ? m_recvBufs.Dequeue() : null,
+                        m_recvBufs.Count > 0 ? m_recvBufs.Dequeue() : new float[m_bufInfo.SamplesPer10ms * m_clip.channels],
                         baseOffset + writtenSamples);
                 }
 
@@ -148,7 +148,6 @@ namespace Unity.WebRTC
 
                 int WriteBuffer(float[] data, int offset)
                 {
-                    data ??= new float[m_bufInfo.SamplesPer10ms * m_clip.channels];
                     m_clip.SetData(data, offset % m_clip.samples);
                     return data.Length / m_clip.channels;
                 }

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -157,7 +157,7 @@ namespace Unity.WebRTC
             {
                 m_recvBufs.Enqueue(data);
 
-                if (m_recvBufs.Count >= AudioBufferTracker.NumOfFramesForBuffering && m_bufferReady == false)
+                if (m_recvBufs.Count >= AudioBufferTracker.NumOfFramesForBuffering && !m_bufferReady)
                 {
                     var audioSource = FindAttachedAudioSource();
                     if (audioSource)

--- a/Samples~/Audio/AudioSample.cs
+++ b/Samples~/Audio/AudioSample.cs
@@ -219,14 +219,14 @@ namespace Unity.WebRTC
         void OnAddTrack(MediaStreamTrackEvent e)
         {
             var track = e.Track as AudioStreamTrack;
+            outputAudioSource.SetTrack(track);
             track.OnAudioReceived += OnAudioReceived;
         }
 
-        void OnAudioReceived(AudioClip renderer)
+        void OnAudioReceived(AudioSource renderer)
         {
-            outputAudioSource.clip = renderer;
-            outputAudioSource.loop = true;
-            outputAudioSource.Play();
+            renderer.loop = true;
+            renderer.Play();
         }
 
         void OnHangUp()

--- a/Samples~/MultiAudioReceive/MultiAudioReceiveSample.cs
+++ b/Samples~/MultiAudioReceive/MultiAudioReceiveSample.cs
@@ -65,11 +65,11 @@ namespace Unity.WebRTC.Samples
                 if (e.Track is AudioStreamTrack track)
                 {
                     var outputAudioSource = receiveObjectList[audioIndex];
-                    track.OnAudioReceived += clip =>
+                    outputAudioSource.SetTrack(track);
+                    track.OnAudioReceived += renderer =>
                     {
-                        outputAudioSource.clip = clip;
-                        outputAudioSource.loop = true;
-                        outputAudioSource.Play();
+                        renderer.loop = true;
+                        renderer.Play();
                     };
                     audioIndex++;
                 }

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -95,11 +95,11 @@ namespace Unity.WebRTC.Samples
 
                 if (e.Track is AudioStreamTrack audioTrack)
                 {
-                    audioTrack.OnAudioReceived += clip =>
+                    receiveAudio1.SetTrack(audioTrack);
+                    audioTrack.OnAudioReceived += renderer =>
                     {
-                        receiveAudio1.clip = clip;
-                        receiveAudio1.loop = true;
-                        receiveAudio1.Play();
+                        renderer.loop = true;
+                        renderer.Play();
                     };
                 }
             };
@@ -118,11 +118,11 @@ namespace Unity.WebRTC.Samples
 
                 if (e.Track is AudioStreamTrack audioTrack)
                 {
-                    audioTrack.OnAudioReceived += clip =>
+                    receiveAudio2.SetTrack(audioTrack);
+                    audioTrack.OnAudioReceived += renderer =>
                     {
-                        receiveAudio2.clip = clip;
-                        receiveAudio2.loop = true;
-                        receiveAudio2.Play();
+                        renderer.loop = true;
+                        renderer.Play();
                     };
                 }
             };

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -90,11 +90,11 @@ namespace Unity.WebRTC.Samples
 
                 if (e.Track is AudioStreamTrack audioTrack)
                 {
-                    audioTrack.OnAudioReceived += clip =>
+                    receiveAudio.SetTrack(audioTrack);
+                    audioTrack.OnAudioReceived += renderer =>
                     {
-                        receiveAudio.clip = clip;
-                        receiveAudio.loop = true;
-                        receiveAudio.Play();
+                        renderer.loop = true;
+                        renderer.Play();
                     };
                     receiveAudioStream = e.Streams.First();
                     receiveAudioStream.OnRemoveTrack = ev =>

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -115,8 +115,11 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void AddAndRemoveAudioTrack()
         {
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
             var stream = new MediaStream();
-            var track = new AudioStreamTrack();
+            var track = new AudioStreamTrack(source);
             Assert.That(TrackKind.Audio, Is.EqualTo(track.Kind));
             Assert.That(stream.GetAudioTracks(), Has.Count.EqualTo(0));
             Assert.That(stream.AddTrack(track), Is.True);
@@ -126,6 +129,8 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(stream.GetAudioTracks(), Has.Count.EqualTo(0));
             track.Dispose();
             stream.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -376,7 +381,10 @@ namespace Unity.WebRTC.RuntimeTest
         [Timeout(5000)]
         public IEnumerator ReceiverGetStreams()
         {
-            var audioTrack = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var audioTrack = new AudioStreamTrack(source);
             var stream = new MediaStream();
             stream.AddTrack(audioTrack);
             yield return 0;
@@ -399,6 +407,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             stream.Dispose();
             Object.DestroyImmediate(test.gameObject);
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
     }
 }

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -176,8 +176,11 @@ namespace Unity.WebRTC.RuntimeTest
         [Category("MediaStreamTrack")]
         public void AddAndRemoveAudioStreamTrack()
         {
+            GameObject obj = new GameObject("audio");
+            AudioSource source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
             var stream = new MediaStream();
-            var track = new AudioStreamTrack();
+            var track = new AudioStreamTrack(source);
             Assert.AreEqual(TrackKind.Audio, track.Kind);
             Assert.AreEqual(0, stream.GetAudioTracks().Count());
             Assert.True(stream.AddTrack(track));
@@ -187,6 +190,8 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(0, stream.GetAudioTracks().Count());
             track.Dispose();
             stream.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [Test]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -258,7 +258,10 @@ namespace Unity.WebRTC.RuntimeTest
         public void GetTransceivers()
         {
             var peer = new RTCPeerConnection();
-            var track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var track = new AudioStreamTrack(source);
 
             var sender = peer.AddTrack(track);
             Assert.That(peer.GetTransceivers().ToList(), Has.Count.EqualTo(1));
@@ -266,6 +269,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             track.Dispose();
             peer.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -277,7 +282,10 @@ namespace Unity.WebRTC.RuntimeTest
             var config = GetDefaultConfiguration();
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
-            var audioTrack = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var audioTrack = new AudioStreamTrack(source);
 
             var transceiver1 = peer1.AddTransceiver(TrackKind.Audio);
             transceiver1.Direction = RTCRtpTransceiverDirection.RecvOnly;
@@ -322,6 +330,8 @@ namespace Unity.WebRTC.RuntimeTest
             peer2.Close();
             peer1.Dispose();
             peer2.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
 
@@ -337,7 +347,10 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
 
-            AudioStreamTrack track1 = new AudioStreamTrack();
+            var obj1 = new GameObject("audio1");
+            var source1 = obj1.AddComponent<AudioSource>();
+            source1.clip = AudioClip.Create("test1", 480, 2, 48000, false);
+            AudioStreamTrack track1 = new AudioStreamTrack(source1);
             peer1.AddTrack(track1);
 
             yield return SignalingOffer(peer1, peer2);
@@ -346,7 +359,10 @@ namespace Unity.WebRTC.RuntimeTest
             RTCRtpSender sender1 = peer2.GetTransceivers().First().Sender;
             Assert.That(sender1, Is.Not.Null);
 
-            AudioStreamTrack track2 = new AudioStreamTrack();
+            var obj2 = new GameObject("audio2");
+            var source2 = obj2.AddComponent<AudioSource>();
+            source2.clip = AudioClip.Create("test2", 480, 2, 48000, false);
+            AudioStreamTrack track2 = new AudioStreamTrack(source2);
             RTCRtpSender sender2 = peer2.AddTrack(track2);
             Assert.That(sender2, Is.Not.Null);
             Assert.That(sender1, Is.EqualTo(sender2));
@@ -355,6 +371,10 @@ namespace Unity.WebRTC.RuntimeTest
             track2.Dispose();
             peer1.Dispose();
             peer2.Dispose();
+            Object.DestroyImmediate(source1.clip);
+            Object.DestroyImmediate(source2.clip);
+            Object.DestroyImmediate(obj1);
+            Object.DestroyImmediate(obj2);
         }
 
         [UnityTest]
@@ -523,7 +543,10 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var peer = new RTCPeerConnection();
             var stream = new MediaStream();
-            var track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var track = new AudioStreamTrack(source);
             var sender = peer.AddTrack(track, stream);
 
             var op = peer.CreateOffer();
@@ -544,6 +567,8 @@ namespace Unity.WebRTC.RuntimeTest
             stream.Dispose();
             peer.Close();
             peer.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -556,7 +581,10 @@ namespace Unity.WebRTC.RuntimeTest
             var peer2 = new RTCPeerConnection(ref config);
 
             var stream = new MediaStream();
-            var track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var track = new AudioStreamTrack(source);
             var sender = peer1.AddTrack(track, stream);
 
             var op1 = peer1.CreateOffer();
@@ -579,6 +607,8 @@ namespace Unity.WebRTC.RuntimeTest
             peer2.Close();
             peer1.Dispose();
             peer2.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -593,7 +623,10 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
 
-            var track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var track = new AudioStreamTrack(source);
             peer1.AddTrack(track);
 
             var op1 = peer1.CreateOffer();
@@ -625,6 +658,8 @@ namespace Unity.WebRTC.RuntimeTest
             track.Dispose();
             peer1.Close();
             peer2.Close();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -642,7 +677,10 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2ReceiveCandidateQueue.Enqueue(candidate); };
             peer2.OnIceCandidate = candidate => { peer1ReceiveCandidateQueue.Enqueue(candidate); };
 
-            var track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var track = new AudioStreamTrack(source);
             peer1.AddTrack(track);
 
             var op1 = peer1.CreateOffer();
@@ -703,6 +741,8 @@ namespace Unity.WebRTC.RuntimeTest
             track.Dispose();
             peer1.Close();
             peer2.Close();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -717,7 +757,10 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
 
-            AudioStreamTrack track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            AudioStreamTrack track = new AudioStreamTrack(source);
             peer1.AddTrack(track);
 
             MediaStreamTrack track1 = null;
@@ -730,6 +773,8 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(() => track1.Id, Throws.TypeOf<InvalidOperationException>());
             track.Dispose();
             track1.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -756,7 +801,10 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(state1, Is.EqualTo(RTCPeerConnectionState.New));
             Assert.That(state2, Is.EqualTo(RTCPeerConnectionState.New));
 
-            AudioStreamTrack track1 = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            AudioStreamTrack track1 = new AudioStreamTrack(source);
             peer1.AddTrack(track1);
 
             var op1 = peer1.CreateOffer();
@@ -797,6 +845,8 @@ namespace Unity.WebRTC.RuntimeTest
 
             track1.Dispose();
             peer2.Close();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -866,7 +916,10 @@ namespace Unity.WebRTC.RuntimeTest
             peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
             peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
 
-            AudioStreamTrack track = new AudioStreamTrack();
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            AudioStreamTrack track = new AudioStreamTrack(source);
             peer1.AddTrack(track);
 
             yield return SignalingOffer(peer1, peer2);
@@ -890,6 +943,8 @@ namespace Unity.WebRTC.RuntimeTest
             track.Dispose();
             peer1.Close();
             peer2.Close();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         [UnityTest]
@@ -906,7 +961,11 @@ namespace Unity.WebRTC.RuntimeTest
 
             var stream = new MediaStream();
             MediaStream receiveStream = null;
-            var track = new AudioStreamTrack();
+
+            var obj = new GameObject("audio");
+            var source = obj.AddComponent<AudioSource>();
+            source.clip = AudioClip.Create("test", 480, 2, 48000, false);
+            var track = new AudioStreamTrack(source);
             stream.AddTrack(track);
             RTCRtpSender sender = peer1.AddTrack(track, stream);
 
@@ -940,6 +999,8 @@ namespace Unity.WebRTC.RuntimeTest
             track.Dispose();
             peer1.Dispose();
             peer2.Dispose();
+            Object.DestroyImmediate(source.clip);
+            Object.DestroyImmediate(obj);
         }
 
         private IEnumerator SignalingOffer(RTCPeerConnection @from, RTCPeerConnection to)


### PR DESCRIPTION
Hello.

As commented in #525, current audio playback has very high latency.
In order to resolve this, I tried to call `SetData()` of `AudioClip` with an offset which refers the sample position from attached `AudioSource`. It's a tricky way but works well.

Thank you in advance for your review.