### PR TITLE
Fix: avoid crash using OpenGLCore on windows

### DIFF
--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -17,7 +17,7 @@ namespace Unity.WebRTC
 
         public static Context Create(int id = 0, EncoderType encoderType = EncoderType.Hardware, bool forTest = false)
         {
-            if (encoderType == EncoderType.Hardware && !NativeMethods.GetHardwareEncoderSupport())
+            if (encoderType == EncoderType.Hardware && !WebRTC.HardwareEncoderSupport())
             {
                 throw new ArgumentException("Hardware encoder is not supported");
             }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -720,12 +720,24 @@ namespace Unity.WebRTC
         internal static Context Context { get { return s_context; } }
         internal static WeakReferenceTable Table { get { return s_context?.table; } }
 
-        public static bool SupportHardwareEncoder
+        // avoid crash when call GetHardwareEncoderSupport using OpenGL graphics on Win/Mac
+        public static bool HardwareEncoderSupport()
         {
-            get
+            // OpenGL APIs on windows/osx are not supported
+            if (Application.platform == RuntimePlatform.WindowsEditor ||
+                Application.platform == RuntimePlatform.WindowsPlayer ||
+                Application.platform == RuntimePlatform.OSXEditor ||
+                Application.platform == RuntimePlatform.OSXPlayer)
             {
-                return NativeMethods.GetHardwareEncoderSupport();
+                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3)
+                {
+                    return false;
+                }
             }
+
+            return NativeMethods.GetHardwareEncoderSupport();
         }
 
         /// <summary>

--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -61,7 +61,7 @@ class MediaStreamSample : MonoBehaviour
         pc2Ontrack = e => { OnTrack(_pc2, e); };
         pc1OnNegotiationNeeded = () => { StartCoroutine(PcOnNegotiationNeeded(_pc1)); };
         pc2OnNegotiationNeeded = () => { StartCoroutine(PcOnNegotiationNeeded(_pc2)); };
-        infoText.text = !WebRTC.SupportHardwareEncoder ? "Current GPU doesn't support encoder" : "Current GPU supports encoder";
+        infoText.text = !WebRTC.HardwareEncoderSupport() ? "Current GPU doesn't support encoder" : "Current GPU supports encoder";
     }
 
     private static RTCConfiguration GetSelectedSdpSemantics()

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -13,7 +13,7 @@ namespace Unity.WebRTC.RuntimeTest
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static void OnLoad()
         {
-            var ignoreHardwareEncoderTest = !NativeMethods.GetHardwareEncoderSupport();
+            var ignoreHardwareEncoderTest = !WebRTC.HardwareEncoderSupport();
             ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedHardwareForHardwareCodec,
                 ignoreHardwareEncoderTest);
 

--- a/Tests/Runtime/TestHelper.cs
+++ b/Tests/Runtime/TestHelper.cs
@@ -7,8 +7,7 @@ namespace Unity.WebRTC.RuntimeTest
     {
         public static bool HardwareCodecSupport()
         {
-            var value = NativeMethods.GetHardwareEncoderSupport();
-            if (!value)
+            if (!WebRTC.HardwareEncoderSupport())
                 return false;
             WebRTC.Initialize(EncoderType.Hardware);
             var isSupported = CheckVideoCodecCapabilities();
@@ -31,10 +30,9 @@ namespace Unity.WebRTC.RuntimeTest
 
         public static bool CheckVideoSendRecvCodecSupport(EncoderType encoderType)
         {
-            // hardware encoder is not supported 
-            if (encoderType == EncoderType.Hardware &&
-                !NativeMethods.GetHardwareEncoderSupport())
-                return false;                
+            // hardware encoder is not supported
+            if (encoderType == EncoderType.Hardware && !WebRTC.HardwareEncoderSupport())
+                return false;
 
             WebRTC.Initialize(encoderType);
             var capabilitiesSenderCodec = RTCRtpSender.GetCapabilities(TrackKind.Video)


### PR DESCRIPTION

related issue: https://github.com/Unity-Technologies/com.unity.webrtc/issues/528