### PR TITLE
chore: Auto testing for macOS Apple Silicon 

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -481,7 +481,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 
-{% endfor %} # {% for architecture in architectures %}
+{% endfor %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -188,6 +188,20 @@ test_targets_android:
     playergraphicsapi: OpenGLES3
     extra-editor-arg: gles3
 
+test_architectures_macos:
+  - name: x64
+    editor_version: 2019.4
+    architecture: x64
+  - name: x64
+    editor_version: 2020.3
+    architecture: x64
+  - name: x64 (Rosetta 2)
+    editor_version: 2021.2
+    architecture: x64
+  - name: arm64 (Apple Silicon)
+    editor_version: 2021.2
+    architecture: arm64
+
 package:
   name: webrtc
   packagename: com.unity.webrtc
@@ -434,8 +448,12 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
 
 {% else %}
 
-test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
-  name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
+{% assign architectures = test_architectures_macos | where: "editor_version", editor.version %}
+{% for architecture in architectures %}
+
+# editmode/playmode test on macOS(Intel/Silicon)
+test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ architecture.architecture }}_{{ gfx_type.name }}:
+  name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ architecture.name }} {{ gfx_type.name }}
   agent:
     type: {{ target.type }}
     image: {{ target.image }}
@@ -447,7 +465,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
       TEST_RESULT_DIR: upm-ci~/test-results/
       TEST_TARGET: macos
       TEST_PLATFORM: {{ param.platform }}
-      TEST_ARCHITECTURE : {{ target.architecture }}
+      TEST_ARCHITECTURE : {{ architecture.architecture }}
       SCRIPTING_BACKEND: {{ param.backend }}
       EDITOR_VERSION: {{ editor.version }}
       EXTRA_EDITOR_ARG: {{ gfx_type.extra-editor-arg }}
@@ -463,6 +481,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 
+{% endfor %} # {% for architecture in architectures %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -3,7 +3,7 @@
 editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.1
+  - version: 2021.2
 
 platforms:
   - name: win

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -190,15 +190,31 @@ test_targets_android:
 
 test_architectures_macos:
   - name: x64
+    target_name: macos
+    editor_version: 2019.4
+    architecture: x64
+  - name: x64 (Rosetta 2)
+    target_name: macos-m1
     editor_version: 2019.4
     architecture: x64
   - name: x64
+    target_name: macos
     editor_version: 2020.3
     architecture: x64
   - name: x64 (Rosetta 2)
+    target_name: macos-m1
+    editor_version: 2020.3
+    architecture: x64
+  - name: x64
+    target_name: macos
+    editor_version: 2021.2
+    architecture: x64
+  - name: x64 (Rosetta 2)
+    target_name: macos-m1
     editor_version: 2021.2
     architecture: x64
   - name: arm64 (Apple Silicon)
+    target_name: macos-m1
     editor_version: 2021.2
     architecture: arm64
 
@@ -448,7 +464,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
 
 {% else %}
 
-{% assign architectures = test_architectures_macos | where: "editor_version", editor.version %}
+{% assign architectures = test_architectures_macos | where: "editor_version", editor.version | where: "target_name", target.name %}
 {% for architecture in architectures %}
 
 # editmode/playmode test on macOS(Intel/Silicon)

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -411,6 +411,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
 
 {% elsif param.platform == "standalone" %}
 
+# build standalone runtime for testing on macOS(Intel/Silicon)
 build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
   name : Build {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
   agent:
@@ -425,7 +426,7 @@ build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name
     - unity-downloader-cli -c Editor -c {{ param.additional_component_arg }} -u {{ editor.version }} --fast -w
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr
     - chmod +x ./utr
-    - ./utr --suite=playmode --platform=StandaloneOSX --editor-location=.Editor --testproject=WebRTC~ --player-save-path=build/players --architecture={{ target.architecture }} --artifacts_path=build/logs --scripting-backend={{ param.backend }} --build-only
+    - ./utr --suite=playmode --platform=StandaloneOSX --editor-location=.Editor --testproject=WebRTC~ --player-save-path=build/players --artifacts_path=build/logs --scripting-backend={{ param.backend }} --build-only
   artifacts:
     players:
       paths:
@@ -436,8 +437,12 @@ build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 
-test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}:
-  name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ gfx_type.name }}
+# standalone test on macOS(Intel/Silicon)
+{% assign architectures = test_architectures_macos | where: "editor_version", editor.version | where: "target_name", target.name %}
+{% for architecture in architectures %}
+
+test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ architecture.architecture }}_{{ gfx_type.name }}:
+  name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ architecture.name }} {{ gfx_type.name }}
   agent:
     type: {{ target.type }}
     image: {{ target.image }}
@@ -462,12 +467,15 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#build_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 
+# end standalone test on macOS(Intel/Silicon)
+{% endfor %}
+
 {% else %}
 
+# editmode/playmode test on macOS(Intel/Silicon)
 {% assign architectures = test_architectures_macos | where: "editor_version", editor.version | where: "target_name", target.name %}
 {% for architecture in architectures %}
 
-# editmode/playmode test on macOS(Intel/Silicon)
 test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ architecture.architecture }}_{{ gfx_type.name }}:
   name : Test {{ package.packagename }} with {{ param.platform }} {{ param.backend }} {{ editor.version }} on {{ target.name }} {{ architecture.name }} {{ gfx_type.name }}
   agent:
@@ -497,7 +505,9 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
   dependencies:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 
+# end editmode/playmode test on macOS(Intel/Silicon)
 {% endfor %}
+
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -542,13 +552,12 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% for target in test_targets %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-{% if target.is_gpu == "true" or target.name == "macos"%}
-    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endif -%}
-# todo(kazuki) : 
-# editor/playmode test are not conducted on m1 mac 
-# XCode command line tools has not installed on m1 mac device (Standalone test don't need to install them)
-{% if target.name == "macos-m1" and param.platform == "standalone" %} 
+{% if target.name == "macos" or target.name == "macos-m1" %}
+{% assign architectures = test_architectures_macos | where: "editor_version", editor.version | where: "target_name", target.name %}
+{% for architecture in architectures %}
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ architecture.architecture }}_{{ gfx_type.name }}
+{% endfor %}
+{% elsif target.is_gpu == "true" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif -%}
 {% endfor %}

--- a/BuildScripts~/template/remote.sh.template
+++ b/BuildScripts~/template/remote.sh.template
@@ -52,7 +52,8 @@ curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-stand
   --output utr
 chmod +x ./utr
 
-if [ ${TEST_TARGET} = "macos" ] && [ ${architecture} = "arm64" ]
+# Install Rosetta when architecture is x64 and device is Apple Silicon
+if [ ${TEST_TARGET} = "macos" ] && [ ${architecture} = "x64" ] && [ `uname -m` == "arm64" ]
 then
   # install rosetta 2
   softwareupdate --install-rosetta --agree-to-license


### PR DESCRIPTION
This pull request adds auto-testing jobs for supporting macOS architectures below.

editor version | target device name | runtime architecture
-- | -- | --
2019.4 | macos | x64
2019.4 | macos-m1 | x64 (rosetta 2)
2020.3 | macos | x64
2020.3 | macos-m1 | x64 (rosetta 2)
2021.2 | macos | x64
2021.2 | macos-m1 | x64 (rosetta 2)
2021.2 | macos-m1 | arm64