### PR TITLE
feat: Update plugin interface headers provided by Unity2021.2.6

### DIFF
--- a/Plugin~/unity/include/IUnityGraphics.h
+++ b/Plugin~/unity/include/IUnityGraphics.h
@@ -1,4 +1,4 @@
-﻿// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
 //
 // Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
 //
@@ -7,6 +7,7 @@
 #pragma once
 #include "IUnityInterface.h"
 
+// Has to match the GfxDeviceRenderer enum
 typedef enum UnityGfxRenderer
 {
     //kUnityGfxRendererOpenGL            =  0, // Legacy OpenGL, removed
@@ -23,7 +24,11 @@ typedef enum UnityGfxRenderer
     kUnityGfxRendererD3D12             = 18, // Direct3D 12
     kUnityGfxRendererVulkan            = 21, // Vulkan
     kUnityGfxRendererNvn               = 22, // Nintendo Switch NVN API
-    kUnityGfxRendererXboxOneD3D12      = 23  // MS XboxOne Direct3D 12
+    kUnityGfxRendererXboxOneD3D12      = 23,  // MS XboxOne Direct3D 12
+    kUnityGfxRendererGameCoreXboxOne   = 24, // GameCore Xbox One
+    kUnityGfxRendererGameCoreXboxSeries  = 25, // GameCore XboxSeries
+    kUnityGfxRendererPS5               = 26, // PS5
+    kUnityGfxRendererPS5NGGC           = 27  // PS5 NGGC
 } UnityGfxRenderer;
 
 typedef enum UnityGfxDeviceEventType

--- a/Plugin~/unity/include/IUnityGraphicsD3D11.h
+++ b/Plugin~/unity/include/IUnityGraphicsD3D11.h
@@ -18,6 +18,10 @@ UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D11)
 
     ID3D11RenderTargetView* (UNITY_INTERFACE_API * RTVFromRenderBuffer)(UnityRenderBuffer surface);
     ID3D11ShaderResourceView* (UNITY_INTERFACE_API * SRVFromNativeTexture)(UnityTextureID texture);
+
+    IDXGISwapChain* (UNITY_INTERFACE_API * GetSwapChain)();
+    UINT32(UNITY_INTERFACE_API * GetSyncInterval)();
+    UINT(UNITY_INTERFACE_API * GetPresentFlags)();
 };
 
 UNITY_REGISTER_INTERFACE_GUID(0xAAB37EF87A87D748ULL, 0xBF76967F07EFB177ULL, IUnityGraphicsD3D11)

--- a/Plugin~/unity/include/IUnityGraphicsD3D12.h
+++ b/Plugin~/unity/include/IUnityGraphicsD3D12.h
@@ -21,13 +21,106 @@ struct UnityGraphicsD3D12ResourceState
     D3D12_RESOURCE_STATES current;  // State this resource will be in after this command list is executed.
 };
 
+struct UnityGraphicsD3D12RecordingState
+{
+    ID3D12GraphicsCommandList* commandList;              // D3D12 command list that is currently recorded by Unity
+};
+
+enum UnityD3D12GraphicsQueueAccess
+{
+    // No queue acccess, no work must be submitted to UnityD3D12Instance::graphicsQueue from the plugin event callback
+    kUnityD3D12GraphicsQueueAccess_DontCare,
+
+    // Make sure that Unity worker threads don't access the D3D12 graphics queue
+    // This disables access to the current Unity command buffer
+    kUnityD3D12GraphicsQueueAccess_Allow,
+};
+
+enum UnityD3D12EventConfigFlagBits
+{
+    kUnityD3D12EventConfigFlag_EnsurePreviousFrameSubmission = (1 << 0), // default: (NOT SUPPORTED)
+    kUnityD3D12EventConfigFlag_FlushCommandBuffers = (1 << 1),           // submit existing command buffers, default: not set
+    kUnityD3D12EventConfigFlag_SyncWorkerThreads = (1 << 2),             // wait for worker threads to finish, default: not set
+    kUnityD3D12EventConfigFlag_ModifiesCommandBuffersState = (1 << 3),   // should be set when descriptor set bindings, vertex buffer bindings, etc are changed (default: set)
+};
+
+struct UnityD3D12PluginEventConfig
+{
+    UnityD3D12GraphicsQueueAccess graphicsQueueAccess;
+    UINT32 flags;                                           // UnityD3D12EventConfigFlagBits to be used when invoking a native plugin
+    bool ensureActiveRenderTextureIsBound;                  // If true, the actively bound render texture will be bound prior the execution of the native plugin method.
+};
+
 typedef struct UnityGraphicsD3D12PhysicalVideoMemoryControlValues UnityGraphicsD3D12PhysicalVideoMemoryControlValues;
-struct UnityGraphicsD3D12PhysicalVideoMemoryControlValues // all values in bytes
+struct UnityGraphicsD3D12PhysicalVideoMemoryControlValues // all absolute values in bytes
 {
     UINT64 reservation;           // Minimum required physical memory for an application [default = 64MB].
     UINT64 systemMemoryThreshold; // If free physical video memory drops below this threshold, resources will be allocated in system memory. [default = 64MB]
-    UINT64 residencyThreshold;    // Minimum free physical video memory needed to start bringing evicted resources back after shrunken video memory budget expands again. [default = 128MB]
+    UINT64 residencyHysteresisThreshold;    // Minimum free physical video memory needed to start bringing evicted resources back after shrunken video memory budget expands again. [default = 128MB]
+    float nonEvictableRelativeThreshold;    // The relative proportion of the video memory budget that must be kept available for non-evictable resources. [default = 0.25]
 };
+
+// Should only be used on the rendering/submission thread.
+UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D12v7)
+{
+    ID3D12Device* (UNITY_INTERFACE_API * GetDevice)();
+
+    IDXGISwapChain* (UNITY_INTERFACE_API * GetSwapChain)();
+    UINT32(UNITY_INTERFACE_API * GetSyncInterval)();
+    UINT(UNITY_INTERFACE_API * GetPresentFlags)();
+
+    ID3D12Fence* (UNITY_INTERFACE_API * GetFrameFence)();
+    // Returns the value set on the frame fence once the current frame completes or the GPU is flushed
+    UINT64(UNITY_INTERFACE_API * GetNextFrameFenceValue)();
+
+    //     Executes a given command list on a worker thread.
+    //    [Optional] Declares expected and post-execution resource states.
+    //     Returns the fence value.
+    UINT64(UNITY_INTERFACE_API * ExecuteCommandList)(ID3D12GraphicsCommandList * commandList, int stateCount, UnityGraphicsD3D12ResourceState * states);
+
+    void(UNITY_INTERFACE_API * SetPhysicalVideoMemoryControlValues)(const UnityGraphicsD3D12PhysicalVideoMemoryControlValues * memInfo);
+
+    ID3D12CommandQueue* (UNITY_INTERFACE_API * GetCommandQueue)();
+
+    ID3D12Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer rb);
+    ID3D12Resource* (UNITY_INTERFACE_API * TextureFromNativeTexture)(UnityTextureID texture);
+
+    // Change the precondition for a specific user-defined event
+    // Should be called during initialization
+    void(UNITY_INTERFACE_API * ConfigureEvent)(int eventID, const UnityD3D12PluginEventConfig * pluginEventConfig);
+
+    bool(UNITY_INTERFACE_API * CommandRecordingState)(UnityGraphicsD3D12RecordingState * outCommandRecordingState);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x4624B0DA41B64AACULL, 0x915AABCB9BC3F0D3ULL, IUnityGraphicsD3D12v7)
+
+// Should only be used on the rendering/submission thread.
+UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D12v6)
+{
+    ID3D12Device* (UNITY_INTERFACE_API * GetDevice)();
+
+    ID3D12Fence* (UNITY_INTERFACE_API * GetFrameFence)();
+    // Returns the value set on the frame fence once the current frame completes or the GPU is flushed
+    UINT64(UNITY_INTERFACE_API * GetNextFrameFenceValue)();
+
+    //     Executes a given command list on a worker thread.
+    //    [Optional] Declares expected and post-execution resource states.
+    //     Returns the fence value.
+    UINT64(UNITY_INTERFACE_API * ExecuteCommandList)(ID3D12GraphicsCommandList * commandList, int stateCount, UnityGraphicsD3D12ResourceState * states);
+
+    void(UNITY_INTERFACE_API * SetPhysicalVideoMemoryControlValues)(const UnityGraphicsD3D12PhysicalVideoMemoryControlValues * memInfo);
+
+    ID3D12CommandQueue* (UNITY_INTERFACE_API * GetCommandQueue)();
+
+    ID3D12Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer rb);
+    ID3D12Resource* (UNITY_INTERFACE_API * TextureFromNativeTexture)(UnityTextureID texture);
+
+    // Change the precondition for a specific user-defined event
+    // Should be called during initialization
+    void(UNITY_INTERFACE_API * ConfigureEvent)(int eventID, const UnityD3D12PluginEventConfig * pluginEventConfig);
+
+    bool(UNITY_INTERFACE_API * CommandRecordingState)(UnityGraphicsD3D12RecordingState* outCommandRecordingState);
+};
+UNITY_REGISTER_INTERFACE_GUID(0xA396DCE58CAC4D78ULL, 0xAFDD9B281F20B840ULL, IUnityGraphicsD3D12v6)
 
 // Should only be used on the rendering/submission thread.
 UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D12v5)
@@ -47,7 +140,7 @@ UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D12v5)
 
     ID3D12CommandQueue* (UNITY_INTERFACE_API * GetCommandQueue)();
 
-    ID3D12Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer * rb);
+    ID3D12Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer rb);
 };
 UNITY_REGISTER_INTERFACE_GUID(0xF5C8D8A37D37BC42ULL, 0xB02DFE93B5064A27ULL, IUnityGraphicsD3D12v5)
 

--- a/Plugin~/unity/include/IUnityLog.h
+++ b/Plugin~/unity/include/IUnityLog.h
@@ -1,0 +1,37 @@
+// Unity Native Plugin API copyright © 2015 Unity Technologies ApS
+//
+// Licensed under the Unity Companion License for Unity - dependent projects--see[Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License).
+//
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.Please review the license for details on these and other terms and conditions.
+
+#pragma once
+#include "IUnityInterface.h"
+
+/// The type of the log message
+enum UnityLogType
+{
+    /// UnityLogType used for Errors.
+    kUnityLogTypeError = 0,
+    /// UnityLogType used for Warnings.
+    kUnityLogTypeWarning = 2,
+    /// UnityLogType used for regular log messages.
+    kUnityLogTypeLog = 3,
+    /// UnityLogType used for Exceptions.
+    kUnityLogTypeException = 4,
+};
+
+#define UNITY_WRAP_CODE(CODE_) do { CODE_; } while (0)
+#define UNITY_LOG(PTR_, MSG_) UNITY_WRAP_CODE((PTR_)->Log(kUnityLogTypeLog, MSG_, __FILE__, __LINE__))
+#define UNITY_LOG_WARNING(PTR_, MSG_) UNITY_WRAP_CODE((PTR_)->Log(kUnityLogTypeWarning, MSG_, __FILE__, __LINE__))
+#define UNITY_LOG_ERROR(PTR_, MSG_) UNITY_WRAP_CODE((PTR_)->Log(kUnityLogTypeError, MSG_, __FILE__, __LINE__))
+
+UNITY_DECLARE_INTERFACE(IUnityLog)
+{
+    // Writes information message to Unity log.
+    // \param type type log channel type which defines importance of the message.
+    // \param message UTF-8 null terminated string.
+    // \param fileName UTF-8 null terminated string with file name of the point where message is generated.
+    // \param fileLine integer file line number of the point where message is generated.
+    void(UNITY_INTERFACE_API * Log)(UnityLogType type, const char* message, const char *fileName, const int fileLine);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x9E7507fA5B444D5DULL, 0x92FB979515EA83FCULL, IUnityLog)

--- a/Plugin~/unity/include/IUnityProfiler.h
+++ b/Plugin~/unity/include/IUnityProfiler.h
@@ -78,7 +78,7 @@ enum UnityBuiltinProfilerCategory_
     kUnityProfilerCategoryPlayerLoop = 20,
     kUnityProfilerCategoryDirector = 21,
     kUnityProfilerCategoryVR = 22,
-    kUnityProfilerCategoryAllocation = 23,
+    kUnityProfilerCategoryAllocation = 23, kUnityProfilerCategoryMemory = 23,
     kUnityProfilerCategoryInternal = 24,
     kUnityProfilerCategoryFileIO = 25,
     kUnityProfilerCategoryUISystemLayout = 26,
@@ -87,6 +87,11 @@ enum UnityBuiltinProfilerCategory_
     kUnityProfilerCategoryBuildInterface = 29,
     kUnityProfilerCategoryInput = 30,
     kUnityProfilerCategoryVirtualTexturing = 31,
+    kUnityProfilerCategoryGPU = 32,
+    kUnityProfilerCategoryPhysics2D = 33,
+    kUnityProfilerCategoryNetworkOperations = 34,
+    kUnityProfilerCategoryUIDetails = 35,
+    kUnityProfilerCategoryDebug = 36,
 };
 typedef uint16_t UnityProfilerCategoryId;
 
@@ -115,7 +120,7 @@ enum UnityProfilerMarkerFlag_
 
     kUnityProfilerMarkerFlagWarning = 1 << 4,            // Indicates undesirable, performance-wise suboptimal code path.
 
-    kCounter = 1 << 7,                                   // Marker is also used as a counter.
+    kUnityProfilerMarkerFlagCounter = 1 << 7,            // Marker is also used as a counter.
 
     kUnityProfilerMarkerFlagVerbosityDebug = 1 << 10,    // Internal debug markers - e.g. JobSystem Idle.
     kUnityProfilerMarkerFlagVerbosityInternal = 1 << 11, // Internal markers - e.g. Mutex/semaphore waits.
@@ -159,7 +164,8 @@ enum UnityProfilerMarkerDataType_
     kUnityProfilerMarkerDataTypeDouble = 7,
     kUnityProfilerMarkerDataTypeString = 8,
     kUnityProfilerMarkerDataTypeString16 = 9,
-    kUnityProfilerMarkerDataTypeBlob8 = 11
+    kUnityProfilerMarkerDataTypeBlob8 = 11,
+    kUnityProfilerMarkerDataTypeCount // Total count of data types
 };
 typedef uint8_t UnityProfilerMarkerDataType;
 
@@ -185,16 +191,273 @@ typedef struct UnityProfilerMarkerData
 
 enum UnityProfilerFlowEventType_
 {
-    // The flow began withing a current marker scope (enclosed scope).
+    // Starts flow chain for a current profiler marker scope (__enclosing__ scope).
+    // Mark the scheduler function with "begin" flow to connect it later to execution function on another thread.
     kUnityProfilerFlowEventTypeBegin = 0,
     // The flow continues with the next sample.
-    kUnityProfilerFlowEventTypeNext = 1,
-    // The flow ends with the next sample.
+    // Marks the __next__ profiler sample connected to the sample which started the flow (kUnityProfilerFlowEventTypeBegin) or previous (in time) kUnityProfilerFlowEventTypeNext flow event.
+    // All parallel flow instances are equivalent and connected to the same previous in time kUnityProfilerFlowEventTypeBegin or kUnityProfilerFlowEventTypeNext events and next (also in time) kUnityProfilerFlowEventTypeNext event.
+    kUnityProfilerFlowEventTypeParallelNext = 1,
+    // Ends flow started by kUnityProfilerFlowEventTypeBegin. Usually represents a sync point (SyncFence)
+    // Marks the __enclosing__ sample as endpoint.
     kUnityProfilerFlowEventTypeEnd = 2,
+    // The flow continues with the next sample.
+    // Marks the __next__ profiler sample connected to the sample which started the flow (kUnityProfilerFlowEventTypeBegin).
+    kUnityProfilerFlowEventTypeNext = 3,
 };
 typedef uint8_t UnityProfilerFlowEventType;
 
+enum UnityProfilerCounterFlags_
+{
+    kUnityProfilerCounterFlagNone = 0,
+    // Automatic flush of counter value to recorder or profiler at the end of a frame
+    kUnityProfilerCounterFlushOnEndOfFrame = 1 << 1,
+    // Automatic reset counter value to zero on flush
+    kUnityProfilerCounterFlagResetToZeroOnFlush = 1 << 2,
+    // Use atomic to access counters value. Don't use
+    kUnityProfilerCounterFlagAtomic = 1 << 3,
+    // Pull-style counter. Don't use
+    kUnityProfilerCounterFlagGetter = 1 << 4
+};
+typedef uint16_t UnityProfilerCounterFlags;
+
+
 typedef uint64_t UnityProfilerThreadId;
+
+typedef void (*UnityProfilerCounterStatePtrCallback)(void* userData);
+
+#ifdef __cplusplus
+template<typename T> struct UnityProfilerDataUnitHelper;
+template<> struct UnityProfilerDataUnitHelper<int32_t> { static const UnityProfilerMarkerDataType GetProfilerType() { return kUnityProfilerMarkerDataTypeInt32; } };
+template<> struct UnityProfilerDataUnitHelper<uint32_t> { static const UnityProfilerMarkerDataType GetProfilerType() { return kUnityProfilerMarkerDataTypeUInt32; } };
+template<> struct UnityProfilerDataUnitHelper<int64_t> { static const UnityProfilerMarkerDataType GetProfilerType() { return kUnityProfilerMarkerDataTypeInt64; } };
+template<> struct UnityProfilerDataUnitHelper<uint64_t> { static const UnityProfilerMarkerDataType GetProfilerType() { return kUnityProfilerMarkerDataTypeUInt64; } };
+template<> struct UnityProfilerDataUnitHelper<float> { static const UnityProfilerMarkerDataType GetProfilerType() { return kUnityProfilerMarkerDataTypeFloat; } };
+template<> struct UnityProfilerDataUnitHelper<double> { static const UnityProfilerMarkerDataType GetProfilerType() { return kUnityProfilerMarkerDataTypeDouble; } };
+
+template<typename T> struct UnityProfilerCounter;
+#endif
+
+// Available since 2021.2
+UNITY_DECLARE_INTERFACE(IUnityProfilerV2)
+{
+    void BeginSample(const UnityProfilerMarkerDesc * markerDesc)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeBegin, 0, NULL);
+    }
+
+    void BeginSample(const UnityProfilerMarkerDesc * markerDesc, uint16_t eventDataCount, const UnityProfilerMarkerData * eventData)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeBegin, eventDataCount, eventData);
+    }
+
+    void EndSample(const UnityProfilerMarkerDesc * markerDesc)
+    {
+        (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeEnd, 0, NULL);
+    }
+
+    // Create instrumentation event.
+    // \param markerDesc is a pointer to marker description struct.
+    // \param eventType is an event type - UnityProfilerMarkerEventType_.
+    // \param eventDataCount is an event metadata count passed in eventData. Must be less than eventDataCount specified in CreateMarker.
+    // \param eventData is a metadata array of eventDataCount elements.
+    void(UNITY_INTERFACE_API * EmitEvent)(const UnityProfilerMarkerDesc * markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData * eventData);
+
+    // Returns 1 if Unity Profiler is enabled, 0 overwise.
+    int(UNITY_INTERFACE_API * IsEnabled)();
+
+    // Returns 1 if Unity Profiler is available, 0 overwise.
+    // Profiler is available only in Development builds. Release builds have Unity Profiler compiled out.
+    // However individual markers can be available even in Release builds (e.g. GC.Collect) and be collected with
+    // Recorder API or forwarded to platform and other profilers (via IUnityProfilerCallbacks::RegisterMarkerEventCallback API).
+    // You can choose whenever you want or not emit profiler event in Development and Release builds using the cached result of this method.
+    int(UNITY_INTERFACE_API * IsAvailable)();
+
+    // Creates a new Unity Profiler marker.
+    // \param desc Pointer to the const UnityProfilerMarkerDesc* which is set to the created marker in a case of a succesful execution.
+    // \param name Marker name to be displayed in Unity Profiler.
+    // \param flags Marker flags. One of UnityProfilerMarkerFlag_ enum. Use kUnityProfilerMarkerFlagDefault if not sure.
+    // \param eventDataCount Maximum count of potential metadata parameters count.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * CreateMarker)(const UnityProfilerMarkerDesc * *desc, const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount);
+
+    // Set a metadata description for the Unity Profiler marker.
+    // \param markerDesc is a pointer to marker description struct.
+    // \param index metadata index to set name for.
+    // \param metadataType Data type. Must be of UnityProfilerMarkerDataType_ enum.
+    // \param name Metadata name.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * SetMarkerMetadataName)(const UnityProfilerMarkerDesc * desc, int index, const char* metadataName, UnityProfilerMarkerDataType metadataType, UnityProfilerMarkerDataUnit metadataUnit);
+
+    // Creates a new Unity Profiler category.
+    // \param category is a pointer to UnityProfilerCategoryId variable which is set to the created category id in case of a succesful execution.
+    // \param name Category name to be displayed in Unity Profiler.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * CreateCategory)(UnityProfilerCategoryId *category, const char* name, uint32_t unused);
+
+    // Registers current thread with Unity Profiler.
+    // Has no effect in Release Players.
+    // \param threadId Optional Unity Profiler thread identifier which it written on successful method call. Can be used with UnregisterThread.
+    // \param groupName Thread group name. Unity Profiler aggregates threads with the same group.
+    // \param name Thread name.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * RegisterThread)(UnityProfilerThreadId * threadId, const char* groupName, const char* name);
+
+    // Unregisters current thread from Unity Profiler and cleans up all associated memory.
+    // Has no effect in Release Players.
+    // \param threadId Unity Profiler thread identifier obtained with RegisterThread call. Use 0 to cleanup the current thread.
+    // \return 0 on success and non-zero in case of error.
+    int(UNITY_INTERFACE_API * UnregisterThread)(UnityProfilerThreadId threadId);
+
+#ifdef __cplusplus
+    // Creates a new Unity Profiler counter wrapper object.
+    // \param category Counter marker category which assignes marker to one of visualized groups on the profiler chart.
+    // \param name Counter marker name to be displayed in Unity Profiler.
+    // \param valueUnit Data unit, defines how data will be visualized. Must be of UnityProfilerMarkerDataUnit_ enum.
+    // \param activateFunc Callback called when new coutner data receiver is connected.
+    // \param deactivateFunc Callback called when coutner data receiver is disconnected.
+    // \param userData User data pointer passed to activate and deactivate callbacks.
+    // \return UnityProfilerCounter counter struct.
+    template<typename T>
+    UnityProfilerCounter<T> CreateCounter(UnityProfilerCategoryId category, const char* name, UnityProfilerMarkerDataUnit dataUnit,
+        UnityProfilerCounterStatePtrCallback activateFunc = nullptr, UnityProfilerCounterStatePtrCallback deactivateFunc = nullptr, void* userData = nullptr)
+    {
+        return UnityProfilerCounter<T>(
+            this,
+            this->CreateCounterValue(
+                category,
+                name,
+                kUnityProfilerMarkerFlagCounter,
+                UnityProfilerDataUnitHelper<T>::GetProfilerType(),
+                dataUnit,
+                sizeof(T),
+                kUnityProfilerCounterFlagNone,
+                activateFunc,
+                deactivateFunc,
+                userData
+            )
+        );
+    }
+
+#endif
+
+    // Creates a new Unity Profiler counter.
+    // \param category Counter marker category which assignes marker to one of visualized groups on the profiler chart.
+    // \param name Counter marker name to be displayed in Unity Profiler.
+    // \param flags Counter marker flags. One of UnityProfilerMarkerFlag_ enum. Use kUnityProfilerMarkerFlagDefault if not sure.
+    // \param valueType Data type. Must be of UnityProfilerMarkerDataType_ enum.
+    // \param valueUnit Data unit, defines how data will be visualized. Must be of UnityProfilerMarkerDataUnit_ enum.
+    // \param valueSize Data size, must be less or equal to 8.
+    // \param counterFlags Counter flags. One of UnityProfilerCounterFlags_ enum. Use kUnityProfilerCounterFlagNone if not sure.
+    // \param activateFunc Callback called when new coutner data receiver is connected.
+    // \param deactivateFunc Callback called when coutner data receiver is disconnected.
+    // \param userData User data pointer passed to activate and deactivate callbacks.
+    // \return CounterValue object address on success and null in case of error.
+    void* (UNITY_INTERFACE_API* CreateCounterValue)(
+        UnityProfilerCategoryId category,
+        const char* name,
+        UnityProfilerMarkerFlags flags,
+        UnityProfilerMarkerDataType valueType,
+        UnityProfilerMarkerDataUnit valueUnit,
+        size_t valueSize,
+        UnityProfilerCounterFlags counterFlags,
+        UnityProfilerCounterStatePtrCallback activateFunc,
+        UnityProfilerCounterStatePtrCallback deactivateFunc,
+        void* userData
+    );
+
+    void(UNITY_INTERFACE_API * FlushCounterValue)(void* counter);
+};
+UNITY_REGISTER_INTERFACE_GUID(0xB957E0189CB6A30BULL, 0x83CE589AE85B9068ULL, IUnityProfilerV2)
+
+#ifdef __cplusplus
+struct UnityProfilerCounterValue
+{
+    UnityProfilerCounterValue()
+        : m_Profiler(nullptr)
+        , m_Value(nullptr)
+    {
+    }
+
+    UnityProfilerCounterValue(IUnityProfilerV2* profiler, void* value)
+        : m_Profiler(profiler)
+        , m_Value(value)
+    {
+    }
+
+    template<typename T>
+    inline T& Value() { return *static_cast<T*>(m_Value); }
+
+    template<typename T>
+    inline const T& Value() const { return *static_cast<T*>(m_Value); }
+
+    inline void Flush()
+    {
+        m_Profiler->FlushCounterValue(m_Value);
+    }
+
+private:
+    void* m_Value;
+    IUnityProfilerV2* m_Profiler;
+};
+
+template<typename T>
+struct UnityProfilerCounter : public UnityProfilerCounterValue
+{
+    UnityProfilerCounter() {}
+    UnityProfilerCounter(IUnityProfilerV2* profiler, void* value) : UnityProfilerCounterValue(profiler, value) {}
+
+    T& operator*() { return Value<T>(); }
+    const T& operator*() const { return Value<T>(); }
+
+    operator T&() { return Value<T>(); }
+    operator T() const { return Value<T>(); }
+
+    T& operator=(const T& s)
+    {
+        Value<T>() = s;
+        return Value<T>();
+    }
+
+    T operator++(int)
+    {
+        T copy(Value<T>());
+        ++(Value<T>());
+        return copy;
+    }
+
+    UnityProfilerCounter<T>& operator++()
+    {
+        ++(Value<T>());
+        return *this;
+    }
+
+    T operator--(int)
+    {
+        T copy(Value<T>());
+        --(Value<T>());
+        return copy;
+    }
+
+    UnityProfilerCounter& operator--()
+    {
+        --(Value<T>());
+        return *this;
+    }
+
+    UnityProfilerCounter& operator-=(T& s)
+    {
+        (Value<T>()) -= s;
+        return *this;
+    }
+
+    UnityProfilerCounter& operator+=(T& s)
+    {
+        (Value<T>()) += s;
+        return *this;
+    }
+};
+#endif
 
 // Available since 2020.1
 UNITY_DECLARE_INTERFACE(IUnityProfiler)
@@ -214,51 +477,15 @@ UNITY_DECLARE_INTERFACE(IUnityProfiler)
         (this->EmitEvent)(markerDesc, kUnityProfilerMarkerEventTypeEnd, 0, NULL);
     }
 
-    // Create instrumentation event.
-    // \param markerDesc is a pointer to marker description struct.
-    // \param eventType is an event type - UnityProfilerMarkerEventType_.
-    // \param eventDataCount is an event metadata count passed in eventData. Must be less than eventDataCount specified in CreateMarker.
-    // \param eventData is a metadata array of eventDataCount elements.
     void(UNITY_INTERFACE_API * EmitEvent)(const UnityProfilerMarkerDesc* markerDesc, UnityProfilerMarkerEventType eventType, uint16_t eventDataCount, const UnityProfilerMarkerData* eventData);
 
-    // Returns 1 if Unity Profiler is enabled, 0 overwise.
     int(UNITY_INTERFACE_API * IsEnabled)();
-
-    // Returns 1 if Unity Profiler is available, 0 overwise.
-    // Profiler is available only in Development builds. Release builds have Unity Profiler compiled out.
-    // However individual markers can be available even in Release builds (e.g. GC.Collect) and be collected with
-    // Recorder API or forwarded to platform and other profilers (via IUnityProfilerCallbacks::RegisterMarkerEventCallback API).
-    // You can choose whenever you want or not emit profiler event in Development and Release builds using the cached result of this method.
     int(UNITY_INTERFACE_API * IsAvailable)();
 
-    // Creates a new Unity Profiler marker.
-    // \param desc Pointer to the const UnityProfilerMarkerDesc* which is set to the created marker in a case of a succesful execution.
-    // \param name Marker name to be displayed in Unity Profiler.
-    // \param flags Marker flags. One of UnityProfilerMarkerFlag_ enum. Use kUnityProfilerMarkerFlagDefault if not sure.
-    // \param eventDataCount Maximum count of potential metadata parameters count.
-    // \return 0 on success and non-zero in case of error.
     int(UNITY_INTERFACE_API * CreateMarker)(const UnityProfilerMarkerDesc** desc, const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount);
-
-    // Set a metadata description for the Unity Profiler marker.
-    // \param markerDesc is a pointer to marker description struct.
-    // \param index metadata index to set name for.
-    // \param metadataType Data type. Must be of UnityProfilerMarkerDataType_ enum.
-    // \param name Metadata name.
-    // \return 0 on success and non-zero in case of error.
     int(UNITY_INTERFACE_API * SetMarkerMetadataName)(const UnityProfilerMarkerDesc* desc, int index, const char* metadataName, UnityProfilerMarkerDataType metadataType, UnityProfilerMarkerDataUnit metadataUnit);
 
-    // Registers current thread with Unity Profiler.
-    // Has no effect in Release Players.
-    // \param threadId Optional Unity Profiler thread identifier which it written on successful method call. Can be used with UnregisterThread.
-    // \param groupName Thread group name. Unity Profiler aggregates threads with the same group.
-    // \param name Thread name.
-    // \return 0 on success and non-zero in case of error.
     int(UNITY_INTERFACE_API * RegisterThread)(UnityProfilerThreadId* threadId, const char* groupName, const char* name);
-
-    // Unregisters current thread from Unity Profiler and cleans up all associated memory.
-    // Has no effect in Release Players.
-    // \param threadId Unity Profiler thread identifier obtained with RegisterThread call. Use 0 to cleanup the current thread.
-    // \return 0 on success and non-zero in case of error.
     int(UNITY_INTERFACE_API * UnregisterThread)(UnityProfilerThreadId threadId);
 };
 UNITY_REGISTER_INTERFACE_GUID(0x2CE79ED8316A4833ULL, 0x87076B2013E1571FULL, IUnityProfiler)

--- a/Plugin~/unity/include/IUnityRenderingExtensions.h
+++ b/Plugin~/unity/include/IUnityRenderingExtensions.h
@@ -110,6 +110,7 @@ typedef enum UnityRenderingExtQueryType
                                                                             //      and it will clear the whole render target not just per-eye on demand.
     kUnityRenderingExtQueryKeepOriginalDoubleWideWidth_DEPRECATED  = 1 << 4,           // Instructs unity to keep the original double wide width. By default unity will try and have a power-of-two width for mip-mapping requirements.
     kUnityRenderingExtQueryRequestVRFlushCallback       = 1 << 5,           // Instructs unity to provide callbacks when the VR eye textures need flushing. Useful for multi GPU synchronization.
+    kUnityRenderingExtQueryOverridePresentFrame         = 1 << 6,           // The plugin handles it's own SwapChain Present. Unity will skip its internal Present calls
 } UnityRenderingExtQueryType;
 
 
@@ -232,8 +233,8 @@ typedef enum UnityRenderingExtTextureFormat
     kUnityRenderingExtFormatD24_UNorm,
     kUnityRenderingExtFormatD24_UNorm_S8_UInt,
     kUnityRenderingExtFormatD32_SFloat,
-    kUnityRenderingExtFormatD32_SFloat_S8_Uint,
-    kUnityRenderingExtFormatS8_Uint,
+    kUnityRenderingExtFormatD32_SFloat_S8_UInt,
+    kUnityRenderingExtFormatS8_UInt,
 
     // Compression formats
     kUnityRenderingExtFormatRGBA_DXT1_SRGB,
@@ -290,9 +291,9 @@ typedef enum UnityRenderingExtTextureFormat
     kUnityRenderingExtFormatYUV2,
 
     // Automatic formats, back-end decides
-    kUnityRenderingExtFormatDepthAuto,
-    kUnityRenderingExtFormatShadowAuto,
-    kUnityRenderingExtFormatVideoAuto,
+    kUnityRenderingExtFormatDepthAuto_removed_donotuse,
+    kUnityRenderingExtFormatShadowAuto_removed_donotuse,
+    kUnityRenderingExtFormatVideoAuto_removed_donotuse,
 
     // ASTC hdr profile
     kUnityRenderingExtFormatRGBA_ASTC4X4_UFloat,

--- a/Plugin~/unity/include/IUnityShaderCompilerAccess.h
+++ b/Plugin~/unity/include/IUnityShaderCompilerAccess.h
@@ -42,6 +42,11 @@ enum UnityShaderCompilerExtCompilerPlatform
     kUnityShaderCompilerExtCompPlatformVulkan,          // Vulkan SPIR-V, compiled with MS D3DCompiler + HLSLcc
     kUnityShaderCompilerExtCompPlatformSwitch,          // Nintendo Switch (NVN)
     kUnityShaderCompilerExtCompPlatformXboxOneD3D12,    // Xbox One D3D12
+    kUnityShaderCompilerExtCompPlatformGameCoreXboxOne, // GameCore XboxOne
+    kUnityShaderCompilerExtCompPlatformGameCoreXboxSeries,// GameCore XboxSeries
+    kUnityShaderCompilerExtCompPlatformPS5,
+    kUnityShaderCompilerExtCompPlatformPS5NGGC,
+
     kUnityShaderCompilerExtCompPlatformCount
 };
 


### PR DESCRIPTION
These header files are brought from the `PluginAPI` folder in Unity Editor 2021.2.6.
`C:\Program Files\Unity\Hub\Editor\2021.2.6f1\Editor\Data\PluginAPI`