### PR TITLE
fix: avoid crashes when using Full HD resolution with HWA enabled on Windows

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -242,8 +242,8 @@ namespace webrtc
         }
         if (nvEncInitializeParams.frameRateNum != m_frameRate)
         {
-            // nvcodec do not allow a framerate over 240
-            const uint32_t kMaxFramerate = 240;
+            // NV_ENC_LEVEL_H264_51 do not allow a framerate over 120
+            const uint32_t kMaxFramerate = 120;
             uint32_t targetFramerate = std::min(m_frameRate, kMaxFramerate);
             nvEncInitializeParams.frameRateNum = targetFramerate;
             settingChanged = true;


### PR DESCRIPTION
H264 profile Level `NV_ENC_LEVEL_H264_51` do not allow a framerate over 120.
So change maxFramerate.