### PR TITLE
Add preserving active render target before updating WebRTC video textures

### DIFF
--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -418,6 +418,8 @@ namespace Unity.WebRTC
                 // Wait until all frame rendering is done
                 yield return new WaitForEndOfFrame();
                 {
+                    var tempTextureActive = RenderTexture.active;
+                    RenderTexture.active = null;
                     foreach (var reference in VideoStreamTrack.s_tracks.Values)
                     {
                         if (!reference.TryGetTarget(out var track))
@@ -431,6 +433,7 @@ namespace Unity.WebRTC
                             track.UpdateReceiveTexture();
                         }
                     }
+                    RenderTexture.active = tempTextureActive;
                 }
             }
         }


### PR DESCRIPTION
Hello.

In order to work correctly APIs like `ScreenCapture.CaptureScreenshotIntoRenderTexture()` which depends on `WaitForEndOfFrame()`, preserving active render target before updating WebRTC video textures is added.

Thank you in advance for your review.