### PR TITLE
fix: Separate VideoStreamTrack constructor for video receiver and video source

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -293,6 +293,8 @@ namespace webrtc
 
     bool Context::FinalizeEncoder(IEncoder* encoder)
     {
+        if (encoder == nullptr)
+            return false;
         m_mapIdAndEncoder.erase(encoder->Id());
         return true;
     }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -422,14 +422,8 @@ namespace Unity.WebRTC
                     {
                         if (!reference.TryGetTarget(out var track))
                             continue;
-                        if (track.IsEncoderInitialized)
-                        {
-                            track.Update();
-                        }
-                        else
-                        {
-                            track.UpdateReceiveTexture();
-                        }
+                        track.UpdateSendTexture();
+                        track.UpdateReceiveTexture();
                     }
                 }
             }

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -197,14 +197,8 @@ namespace Unity.WebRTC.RuntimeTest
             {
                 if (!reference.TryGetTarget(out var track))
                     continue;
-                if (track.IsEncoderInitialized)
-                {
-                    track.Update();
-                }
-                else
-                {
-                    track.UpdateReceiveTexture();
-                }
+                track.UpdateSendTexture();
+                track.UpdateReceiveTexture();
             }
         }
 


### PR DESCRIPTION
`VideoStreamTrack` created a `UnityVideoRenderer ` instance internally even if the video track is the sender side. This change fixes the issue by not sharing the constructor for sender and receiver.