### PR TITLE
fix: Add AudioStreamTrack constructor for sending audio generated by AudioListener

### DIFF
--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1408,12 +1408,10 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
         Context* context,
-        AudioTrackInterface* track,
+        UnityAudioTrackSource* source,
         int32 sample_rate,
         int32 number_of_channels)
     {
-        UnityAudioTrackSource* source =
-            static_cast<UnityAudioTrackSource*>(track->GetSource());
         auto adm = context->GetAudioDevice();
         if (source != nullptr && adm != nullptr)
         {
@@ -1423,10 +1421,8 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT void ContextUninitLocalAudio(
         Context* context,
-        AudioTrackInterface* track)
+        UnityAudioTrackSource* source)
     {
-        UnityAudioTrackSource* source =
-            static_cast<UnityAudioTrackSource*>(track->GetSource());
         auto adm = context->GetAudioDevice();
         if (source != nullptr && adm != nullptr)
         {
@@ -1434,16 +1430,13 @@ extern "C"
         }
     }
 
-    UNITY_INTERFACE_EXPORT void ContextProcessLocalAudio(
-        Context* context,
-        AudioTrackInterface* track,
+    UNITY_INTERFACE_EXPORT void AudioSourceProcessLocalAudio(
+        UnityAudioTrackSource* source,
         float* audio_data,
         int32 sample_rate,
         int32 number_of_channels,
         int32 number_of_frames)
     {
-        UnityAudioTrackSource* source =
-            static_cast<UnityAudioTrackSource*>(track->GetSource());
         if (source != nullptr)
         {
             source->PushAudioData(

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -316,19 +316,14 @@ namespace Unity.WebRTC
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
 
-        internal void InitLocalAudio(IntPtr track, int sampleRate, int channels)
+        internal void AudioSourceInitLocalAudio(IntPtr source, int sampleRate, int channels)
         {
-            NativeMethods.ContextInitLocalAudio(self, track, sampleRate, channels);
+            NativeMethods.ContextInitLocalAudio(self, source, sampleRate, channels);
         }
 
-        internal void UninitLocalAudio(IntPtr track)
+        internal void AudioSourceUninitLocalAudio(IntPtr source)
         {
-            NativeMethods.ContextUninitLocalAudio(self, track);
-        }
-
-        internal void ProcessLocalAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
-        {
-            NativeMethods.ContextProcessLocalAudio(self, track, array, sampleRate, channels, frames);
+            NativeMethods.ContextUninitLocalAudio(self, source);
         }
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1090,11 +1090,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextInitLocalAudio(IntPtr context, IntPtr track, int sampleRate, int channels);
+        public static extern void ContextInitLocalAudio(IntPtr context, IntPtr source, int sampleRate, int channels);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextUninitLocalAudio(IntPtr context, IntPtr track);
+        public static extern void ContextUninitLocalAudio(IntPtr context, IntPtr source);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
+        public static extern void AudioSourceProcessLocalAudio(IntPtr source, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]


### PR DESCRIPTION
This pull request adds `AudioStreamTrack` constructor to send audio stream.
In the past, `AudioStreamTrack` constructor is only one, which needs `AudioSource` instance.

To use with other components like AudioListener, we needed to add another constructor.