### PR TITLE
fix: avoid crash when set parameters (scaleResolutionDownBy)

### DIFF
--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -91,7 +91,7 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        public RTCErrorType SetParameters(RTCRtpSendParameters parameters)
+        public RTCError SetParameters(RTCRtpSendParameters parameters)
         {
             if (Track is VideoStreamTrack videoTrack)
             {
@@ -103,24 +103,17 @@ namespace Unity.WebRTC
                         continue;
                     }
 
-                    try
-                    {
-                        WebRTC.ValidateTextureSize((int)(videoTrack.Texture.width / scale),
-                            (int)(videoTrack.Texture.height / scale), Application.platform, WebRTC.GetEncoderType());
-                    }
-                    catch (ArgumentException)
-                    {
-                        return RTCErrorType.InvalidParameter;
-                    }
+                    return WebRTC.ValidateTextureSize((int)(videoTrack.Texture.width / scale),
+                        (int)(videoTrack.Texture.height / scale), Application.platform, WebRTC.GetEncoderType());
                 }
             }
 
             parameters.CreateInstance(out RTCRtpSendParametersInternal instance);
             IntPtr ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf(instance));
             Marshal.StructureToPtr(instance, ptr, false);
-            RTCErrorType error = NativeMethods.SenderSetParameters(GetSelfOrThrow(), ptr);
+            RTCErrorType type = NativeMethods.SenderSetParameters(GetSelfOrThrow(), ptr);
             Marshal.FreeCoTaskMem(ptr);
-            return error;
+            return new RTCError {errorType = type};
         }
 
         /// <summary>

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using UnityEngine;
 
 namespace Unity.WebRTC
 {
@@ -92,6 +93,28 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCErrorType SetParameters(RTCRtpSendParameters parameters)
         {
+            if (Track is VideoStreamTrack videoTrack)
+            {
+                foreach (var encoding in parameters.encodings)
+                {
+                    var scale = encoding.scaleResolutionDownBy;
+                    if (!scale.HasValue)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        WebRTC.ValidateTextureSize((int)(videoTrack.Texture.width / scale),
+                            (int)(videoTrack.Texture.height / scale), Application.platform, WebRTC.GetEncoderType());
+                    }
+                    catch (ArgumentException)
+                    {
+                        return RTCErrorType.InvalidParameter;
+                    }
+                }
+            }
+
             parameters.CreateInstance(out RTCRtpSendParametersInternal instance);
             IntPtr ptr = Marshal.AllocCoTaskMem(Marshal.SizeOf(instance));
             Marshal.StructureToPtr(instance, ptr, false);

--- a/Runtime/Scripts/RTCRtpSender.cs
+++ b/Runtime/Scripts/RTCRtpSender.cs
@@ -103,8 +103,12 @@ namespace Unity.WebRTC
                         continue;
                     }
 
-                    return WebRTC.ValidateTextureSize((int)(videoTrack.Texture.width / scale),
+                    var error = WebRTC.ValidateTextureSize((int)(videoTrack.Texture.width / scale),
                         (int)(videoTrack.Texture.height / scale), Application.platform, WebRTC.GetEncoderType());
+                    if (error.errorType != RTCErrorType.None)
+                    {
+                        return error;
+                    }
                 }
             }
 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -129,7 +129,11 @@ namespace Unity.WebRTC
         public VideoStreamTrack(IntPtr texturePtr, int width, int height, GraphicsFormat format, bool needFlip)
             : this(Guid.NewGuid().ToString(), new VideoTrackSource(), needFlip)
         {
-            WebRTC.ValidateTextureSize(width, height, Application.platform, WebRTC.GetEncoderType());
+            var error = WebRTC.ValidateTextureSize(width, height, Application.platform, WebRTC.GetEncoderType());
+            if (error.errorType != RTCErrorType.None)
+            {
+                throw new ArgumentException(error.message);
+            }
             WebRTC.ValidateGraphicsFormat(format);
             WebRTC.Context.SetVideoEncoderParameter(GetSelfOrThrow(), width, height, format, texturePtr);
             WebRTC.Context.InitializeEncoder(GetSelfOrThrow());

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -483,11 +483,12 @@ namespace Unity.WebRTC
         /// <param name="height"></param>
         /// <param name="platform"></param>
         /// <param name="encoderType"></param>
-        public static void ValidateTextureSize(int width, int height, RuntimePlatform platform, EncoderType encoderType)
+        /// <returns></returns>
+        public static RTCError ValidateTextureSize(int width, int height, RuntimePlatform platform, EncoderType encoderType)
         {
             if (!s_limitTextureSize)
             {
-                return;
+                return new RTCError {errorType = RTCErrorType.None};
             }
 
             // Check NVCodec capabilities
@@ -503,11 +504,14 @@ namespace Unity.WebRTC
                 if (width < minWidth || maxWidth < width ||
                     height < minHeight || maxHeight < height)
                 {
-                    throw new ArgumentException(
-                        $"Texture size is invalid. " +
-                        $"minWidth:{minWidth}, maxWidth:{maxWidth} " +
-                        $"minHeight:{minHeight}, maxHeight:{maxHeight} " +
-                        $"current size width:{width} height:{height}");
+                    return new RTCError
+                    {
+                        errorType = RTCErrorType.InvalidRange,
+                        message = $"Texture size is invalid. " +
+                                  $"minWidth:{minWidth}, maxWidth:{maxWidth} " +
+                                  $"minHeight:{minHeight}, maxHeight:{maxHeight} " +
+                                  $"current size width:{width} height:{height}"
+                    };
                 }
             }
 
@@ -517,10 +521,16 @@ namespace Unity.WebRTC
                 const int minimumTextureSize = 114;
                 if (width < minimumTextureSize || height < minimumTextureSize)
                 {
-                    throw new ArgumentException(
-                        $"Texture size need {minimumTextureSize}, current size width:{width} height:{height}");
+                    return new RTCError
+                    {
+                        errorType = RTCErrorType.InvalidRange,
+                        message =
+                            $"Texture size need {minimumTextureSize}, current size width:{width} height:{height}"
+                    };
                 }
             }
+
+            return new RTCError {errorType = RTCErrorType.None};
         }
 
         /// <summary>

--- a/Samples~/Audio/AudioSample.cs
+++ b/Samples~/Audio/AudioSample.cs
@@ -285,10 +285,10 @@ namespace Unity.WebRTC
                 parameters.encodings[0].minBitrate = bandwidth * 1000;
             }
 
-            RTCErrorType error = sender.SetParameters(parameters);
-            if (error != RTCErrorType.None)
+            RTCError error = sender.SetParameters(parameters);
+            if (error.errorType != RTCErrorType.None)
             {
-                Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error);
+                Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error.errorType);
             }
 
             Debug.Log("SetParameters:" + bandwidth);

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -277,6 +277,8 @@ class BandwidthSample : MonoBehaviour
         if (error != RTCErrorType.None)
         {
             Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error);
+            statsField.text += $"Failed change bandwidth to {bandwidth * 1000}{Environment.NewLine}";
+            bandwidthSelector.value = 0;
         }
     }
 
@@ -293,6 +295,9 @@ class BandwidthSample : MonoBehaviour
         if (error != RTCErrorType.None)
         {
             Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error);
+            statsField.text +=
+                $"Failed scale down video resolution to {(int)(width / scale)}x{(int)(width / scale)}{Environment.NewLine}";
+            scaleResolutionDownSelector.value = 0;
         }
     }
 

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -273,10 +273,10 @@ class BandwidthSample : MonoBehaviour
             parameters.encodings[0].minBitrate = bandwidth * 1000;
         }
 
-        RTCErrorType error = sender.SetParameters(parameters);
-        if (error != RTCErrorType.None)
+        RTCError error = sender.SetParameters(parameters);
+        if (error.errorType != RTCErrorType.None)
         {
-            Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error);
+            Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error.errorType);
             statsField.text += $"Failed change bandwidth to {bandwidth * 1000}{Environment.NewLine}";
             bandwidthSelector.value = 0;
         }
@@ -291,10 +291,10 @@ class BandwidthSample : MonoBehaviour
         RTCRtpSendParameters parameters = sender.GetParameters();
         parameters.encodings[0].scaleResolutionDownBy = scale;
 
-        RTCErrorType error = sender.SetParameters(parameters);
-        if (error != RTCErrorType.None)
+        RTCError error = sender.SetParameters(parameters);
+        if (error.errorType != RTCErrorType.None)
         {
-            Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error);
+            Debug.LogErrorFormat("RTCRtpSender.SetParameters failed {0}", error.errorType);
             statsField.text +=
                 $"Failed scale down video resolution to {(int)(width / scale)}x{(int)(width / scale)}{Environment.NewLine}";
             scaleResolutionDownSelector.value = 0;

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -297,8 +297,8 @@ namespace Unity.WebRTC.RuntimeTest
                 Assert.That(parameters.encodings, Has.Length.GreaterThan(0).And.All.Not.Null);
                 const uint framerate = 20;
                 parameters.encodings[0].maxFramerate = framerate;
-                RTCErrorType error = sender.SetParameters(parameters);
-                Assert.That(error, Is.EqualTo(RTCErrorType.None));
+                RTCError error = sender.SetParameters(parameters);
+                Assert.That(error.errorType, Is.EqualTo(RTCErrorType.None));
                 var parameters2 = sender.GetParameters();
                 Assert.That(parameters2.encodings[0].maxFramerate, Is.EqualTo(framerate));
             }
@@ -341,16 +341,16 @@ namespace Unity.WebRTC.RuntimeTest
                 Assert.That(parameters.encodings, Has.Length.GreaterThan(0).And.All.Not.Null);
                 const uint nonErrorScale = 2;
                 parameters.encodings[0].scaleResolutionDownBy = nonErrorScale;
-                RTCErrorType error = sender.SetParameters(parameters);
-                Assert.That(error, Is.EqualTo(RTCErrorType.None));
+                RTCError error = sender.SetParameters(parameters);
+                Assert.That(error.errorType, Is.EqualTo(RTCErrorType.None));
                 var parameters2 = sender.GetParameters();
                 Assert.That(parameters2.encodings[0].scaleResolutionDownBy, Is.EqualTo(nonErrorScale));
 
                 // limit texture size by WebRTC.ValidateTextureSize
                 const uint errorScale = 8;
                 parameters2.encodings[0].scaleResolutionDownBy = errorScale;
-                RTCErrorType error2 = sender.SetParameters(parameters2);
-                Assert.That(error2, Is.EqualTo(RTCErrorType.InvalidParameter));
+                RTCError error2 = sender.SetParameters(parameters2);
+                Assert.That(error2.errorType, Is.EqualTo(RTCErrorType.InvalidRange));
             }
 
             test.component.Dispose();

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -70,7 +70,8 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var encoderType = WebRTC.GetEncoderType();
             var platform = Application.platform;
-            Assert.That(() => WebRTC.ValidateTextureSize(width, height, platform, encoderType), Throws.Nothing);
+            var error = WebRTC.ValidateTextureSize(width, height, platform, encoderType);
+            Assert.That(error.errorType, Is.EqualTo(RTCErrorType.None));
         }
 
         [Test]


### PR DESCRIPTION
- Validate texture resolution after scaling down
- Add test `SetParametersReturnErrorIfInvalidTextureResolution` (only run Android)
- On `BandWidth` sample, if happen error, output failed text on statusField.

![Screenshot_20220121-104301_WebRTC_](https://user-images.githubusercontent.com/26959415/150451368-ae551b5a-9b8a-4cf8-9491-034c2ddf8848.jpg)
