### PR TITLE
fix: failed SetRemoteDescription when call RemoveTrack on MediaStreamSample

### DIFF
--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -5,297 +5,298 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 using System.Text;
-using Unity.WebRTC;
-using Unity.WebRTC.Samples;
 
-class MediaStreamSample : MonoBehaviour
+namespace Unity.WebRTC.Samples
 {
+    class MediaStreamSample : MonoBehaviour
+    {
 #pragma warning disable 0649
-    [SerializeField] private Button callButton;
-    [SerializeField] private Button addTracksButton;
-    [SerializeField] private Button removeTracksButton;
-    [SerializeField] private Camera cam;
-    [SerializeField] private InputField infoText;
-    [SerializeField] private RawImage RtImage;
+        [SerializeField] private Button callButton;
+        [SerializeField] private Button addTracksButton;
+        [SerializeField] private Button removeTracksButton;
+        [SerializeField] private Camera cam;
+        [SerializeField] private InputField infoText;
+        [SerializeField] private RawImage RtImage;
 #pragma warning restore 0649
 
-    private RTCPeerConnection _pc1, _pc2;
-    private List<RTCRtpSender> pc1Senders;
-    private MediaStream videoStream, receiveStream;
-    private DelegateOnIceConnectionChange pc1OnIceConnectionChange;
-    private DelegateOnIceConnectionChange pc2OnIceConnectionChange;
-    private DelegateOnIceCandidate pc1OnIceCandidate;
-    private DelegateOnIceCandidate pc2OnIceCandidate;
-    private DelegateOnTrack pc2Ontrack;
-    private DelegateOnNegotiationNeeded pc1OnNegotiationNeeded;
-    private StringBuilder trackInfos;
-    private bool videoUpdateStarted;
+        private RTCPeerConnection _pc1, _pc2;
+        private List<RTCRtpSender> pc1Senders;
+        private MediaStream videoStream, receiveStream;
+        private DelegateOnIceConnectionChange pc1OnIceConnectionChange;
+        private DelegateOnIceConnectionChange pc2OnIceConnectionChange;
+        private DelegateOnIceCandidate pc1OnIceCandidate;
+        private DelegateOnIceCandidate pc2OnIceCandidate;
+        private DelegateOnTrack pc2Ontrack;
+        private DelegateOnNegotiationNeeded pc1OnNegotiationNeeded;
+        private StringBuilder trackInfos;
+        private bool videoUpdateStarted;
 
-    private void Awake()
-    {
-        WebRTC.Initialize(WebRTCSettings.EncoderType, WebRTCSettings.LimitTextureSize);
-        callButton.onClick.AddListener(Call);
-        addTracksButton.onClick.AddListener(AddTracks);
-        removeTracksButton.onClick.AddListener(RemoveTracks);
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
-    }
-
-    private void Start()
-    {
-        trackInfos = new StringBuilder();
-        pc1Senders = new List<RTCRtpSender>();
-        callButton.interactable = true;
-
-        pc1OnIceConnectionChange = state => { OnIceConnectionChange(_pc1, state); };
-        pc2OnIceConnectionChange = state => { OnIceConnectionChange(_pc2, state); };
-        pc1OnIceCandidate = candidate => { OnIceCandidate(_pc1, candidate); };
-        pc2OnIceCandidate = candidate => { OnIceCandidate(_pc2, candidate); };
-        pc2Ontrack = e => { OnTrack(_pc2, e); };
-        pc1OnNegotiationNeeded = () => { StartCoroutine(PcOnNegotiationNeeded(_pc1)); };
-        infoText.text = !WebRTC.HardwareEncoderSupport()
-            ? "Current GPU doesn't support encoder"
-            : "Current GPU supports encoder";
-    }
-
-    private static RTCConfiguration GetSelectedSdpSemantics()
-    {
-        RTCConfiguration config = default;
-        config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
-        return config;
-    }
-
-    private void OnIceConnectionChange(RTCPeerConnection pc, RTCIceConnectionState state)
-    {
-        switch (state)
+        private void Awake()
         {
-            case RTCIceConnectionState.New:
-                Debug.Log($"{GetName(pc)} IceConnectionState: New");
-                break;
-            case RTCIceConnectionState.Checking:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Checking");
-                break;
-            case RTCIceConnectionState.Closed:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Closed");
-                break;
-            case RTCIceConnectionState.Completed:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Completed");
-                break;
-            case RTCIceConnectionState.Connected:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Connected");
-                break;
-            case RTCIceConnectionState.Disconnected:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Disconnected");
-                break;
-            case RTCIceConnectionState.Failed:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Failed");
-                break;
-            case RTCIceConnectionState.Max:
-                Debug.Log($"{GetName(pc)} IceConnectionState: Max");
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(state), state, null);
-        }
-    }
-
-    IEnumerator PcOnNegotiationNeeded(RTCPeerConnection pc)
-    {
-        Debug.Log($"{GetName(pc)} createOffer start");
-        var op = pc.CreateOffer();
-        yield return op;
-
-        if (!op.IsError)
-        {
-            yield return StartCoroutine(OnCreateOfferSuccess(pc, op.Desc));
-        }
-        else
-        {
-            OnCreateSessionDescriptionError(op.Error);
-        }
-    }
-
-    private void AddTracks()
-    {
-        foreach (var track in videoStream.GetTracks())
-        {
-            pc1Senders.Add(_pc1.AddTrack(track, videoStream));
+            WebRTC.Initialize(WebRTCSettings.EncoderType, WebRTCSettings.LimitTextureSize);
+            callButton.onClick.AddListener(Call);
+            addTracksButton.onClick.AddListener(AddTracks);
+            removeTracksButton.onClick.AddListener(RemoveTracks);
         }
 
-        if (!videoUpdateStarted)
+        private void OnDestroy()
         {
-            StartCoroutine(WebRTC.Update());
-            videoUpdateStarted = true;
+            WebRTC.Dispose();
         }
 
-        addTracksButton.interactable = false;
-        removeTracksButton.interactable = true;
-    }
-
-    private void RemoveTracks()
-    {
-        foreach (var sender in pc1Senders)
+        private void Start()
         {
-            _pc1.RemoveTrack(sender);
+            trackInfos = new StringBuilder();
+            pc1Senders = new List<RTCRtpSender>();
+            callButton.interactable = true;
+
+            pc1OnIceConnectionChange = state => { OnIceConnectionChange(_pc1, state); };
+            pc2OnIceConnectionChange = state => { OnIceConnectionChange(_pc2, state); };
+            pc1OnIceCandidate = candidate => { OnIceCandidate(_pc1, candidate); };
+            pc2OnIceCandidate = candidate => { OnIceCandidate(_pc2, candidate); };
+            pc2Ontrack = e => { OnTrack(_pc2, e); };
+            pc1OnNegotiationNeeded = () => { StartCoroutine(PcOnNegotiationNeeded(_pc1)); };
+            infoText.text = !WebRTC.HardwareEncoderSupport()
+                ? "Current GPU doesn't support encoder"
+                : "Current GPU supports encoder";
         }
 
-        pc1Senders.Clear();
-        addTracksButton.interactable = true;
-        removeTracksButton.interactable = false;
-        trackInfos.Clear();
-        infoText.text = "";
-    }
-
-    private void Call()
-    {
-        callButton.interactable = false;
-        Debug.Log("GetSelectedSdpSemantics");
-        var configuration = GetSelectedSdpSemantics();
-        _pc1 = new RTCPeerConnection(ref configuration);
-        Debug.Log("Created local peer connection object pc1");
-        _pc1.OnIceCandidate = pc1OnIceCandidate;
-        _pc1.OnIceConnectionChange = pc1OnIceConnectionChange;
-        _pc1.OnNegotiationNeeded = pc1OnNegotiationNeeded;
-        _pc2 = new RTCPeerConnection(ref configuration);
-        Debug.Log("Created remote peer connection object pc2");
-        _pc2.OnIceCandidate = pc2OnIceCandidate;
-        _pc2.OnIceConnectionChange = pc2OnIceConnectionChange;
-        _pc2.OnTrack = pc2Ontrack;
-
-        _pc1.CreateDataChannel("data");
-        videoStream = cam.CaptureStream(1280, 720, 1000000);
-        RtImage.texture = cam.targetTexture;
-    }
-
-    private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
-    {
-        GetOtherPc(pc).AddIceCandidate(candidate);
-        Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
-    }
-
-    private void OnTrack(RTCPeerConnection pc, RTCTrackEvent e)
-    {
-        receiveStream = e.Streams.First();
-        receiveStream.OnRemoveTrack = ev =>
+        private static RTCConfiguration GetSelectedSdpSemantics()
         {
-            ev.Track.Dispose();
-        };
-        trackInfos.Append($"{GetName(pc)} receives remote track:\r\n");
-        trackInfos.Append($"Track kind: {e.Track.Kind}\r\n");
-        trackInfos.Append($"Track id: {e.Track.Id}\r\n");
-        infoText.text = trackInfos.ToString();
-    }
-
-    private string GetName(RTCPeerConnection pc)
-    {
-        return (pc == _pc1) ? "pc1" : "pc2";
-    }
-
-    private RTCPeerConnection GetOtherPc(RTCPeerConnection pc)
-    {
-        return (pc == _pc1) ? _pc2 : _pc1;
-    }
-
-    private IEnumerator OnCreateOfferSuccess(RTCPeerConnection pc, RTCSessionDescription desc)
-    {
-        Debug.Log($"Offer from {GetName(pc)}\n{desc.sdp}");
-        Debug.Log($"{GetName(pc)} setLocalDescription start");
-        var op = pc.SetLocalDescription(ref desc);
-        yield return op;
-
-        if (!op.IsError)
-        {
-            OnSetLocalSuccess(pc);
-        }
-        else
-        {
-            var error = op.Error;
-            OnSetSessionDescriptionError(ref error);
+            RTCConfiguration config = default;
+            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            return config;
         }
 
-        var otherPc = GetOtherPc(pc);
-        Debug.Log($"{GetName(otherPc)} setRemoteDescription start");
-        var op2 = otherPc.SetRemoteDescription(ref desc);
-        yield return op2;
-        if (!op2.IsError)
+        private void OnIceConnectionChange(RTCPeerConnection pc, RTCIceConnectionState state)
         {
-            OnSetRemoteSuccess(otherPc);
-        }
-        else
-        {
-            var error = op2.Error;
-            OnSetSessionDescriptionError(ref error);
-        }
-
-        Debug.Log($"{GetName(otherPc)} createAnswer start");
-        // Since the 'remote' side has no media stream we need
-        // to pass in the right constraints in order for it to
-        // accept the incoming offer of audio and video.
-
-        var op3 = otherPc.CreateAnswer();
-        yield return op3;
-        if (!op3.IsError)
-        {
-            yield return OnCreateAnswerSuccess(otherPc, op3.Desc);
-        }
-        else
-        {
-            OnCreateSessionDescriptionError(op3.Error);
-        }
-    }
-
-    private void OnSetLocalSuccess(RTCPeerConnection pc)
-    {
-        Debug.Log($"{GetName(pc)} SetLocalDescription complete");
-    }
-
-    static void OnSetSessionDescriptionError(ref RTCError error)
-    {
-        Debug.LogError($"Error Detail Type: {error.message}");
-    }
-
-    private void OnSetRemoteSuccess(RTCPeerConnection pc)
-    {
-        Debug.Log($"{GetName(pc)} SetRemoteDescription complete");
-    }
-
-    IEnumerator OnCreateAnswerSuccess(RTCPeerConnection pc, RTCSessionDescription desc)
-    {
-        Debug.Log($"Answer from {GetName(pc)}:\n{desc.sdp}");
-        Debug.Log($"{GetName(pc)} setLocalDescription start");
-        var op = pc.SetLocalDescription(ref desc);
-        yield return op;
-
-        if (!op.IsError)
-        {
-            OnSetLocalSuccess(pc);
-        }
-        else
-        {
-            var error = op.Error;
-            OnSetSessionDescriptionError(ref error);
+            switch (state)
+            {
+                case RTCIceConnectionState.New:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: New");
+                    break;
+                case RTCIceConnectionState.Checking:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Checking");
+                    break;
+                case RTCIceConnectionState.Closed:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Closed");
+                    break;
+                case RTCIceConnectionState.Completed:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Completed");
+                    break;
+                case RTCIceConnectionState.Connected:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Connected");
+                    break;
+                case RTCIceConnectionState.Disconnected:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Disconnected");
+                    break;
+                case RTCIceConnectionState.Failed:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Failed");
+                    break;
+                case RTCIceConnectionState.Max:
+                    Debug.Log($"{GetName(pc)} IceConnectionState: Max");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(state), state, null);
+            }
         }
 
-        var otherPc = GetOtherPc(pc);
-        Debug.Log($"{GetName(otherPc)} setRemoteDescription start");
-
-        var op2 = otherPc.SetRemoteDescription(ref desc);
-        yield return op2;
-        if (!op2.IsError)
+        IEnumerator PcOnNegotiationNeeded(RTCPeerConnection pc)
         {
-            OnSetRemoteSuccess(otherPc);
-        }
-        else
-        {
-            var error = op2.Error;
-            OnSetSessionDescriptionError(ref error);
-        }
-    }
+            Debug.Log($"{GetName(pc)} createOffer start");
+            var op = pc.CreateOffer();
+            yield return op;
 
-    private static void OnCreateSessionDescriptionError(RTCError error)
-    {
-        Debug.LogError($"Error Detail Type: {error.message}");
+            if (!op.IsError)
+            {
+                yield return StartCoroutine(OnCreateOfferSuccess(pc, op.Desc));
+            }
+            else
+            {
+                OnCreateSessionDescriptionError(op.Error);
+            }
+        }
+
+        private void AddTracks()
+        {
+            foreach (var track in videoStream.GetTracks())
+            {
+                pc1Senders.Add(_pc1.AddTrack(track, videoStream));
+            }
+
+            if (!videoUpdateStarted)
+            {
+                StartCoroutine(WebRTC.Update());
+                videoUpdateStarted = true;
+            }
+
+            addTracksButton.interactable = false;
+            removeTracksButton.interactable = true;
+        }
+
+        private void RemoveTracks()
+        {
+            foreach (var sender in pc1Senders)
+            {
+                _pc1.RemoveTrack(sender);
+            }
+
+            pc1Senders.Clear();
+            addTracksButton.interactable = true;
+            removeTracksButton.interactable = false;
+            trackInfos.Clear();
+            infoText.text = "";
+        }
+
+        private void Call()
+        {
+            callButton.interactable = false;
+            Debug.Log("GetSelectedSdpSemantics");
+            var configuration = GetSelectedSdpSemantics();
+            _pc1 = new RTCPeerConnection(ref configuration);
+            Debug.Log("Created local peer connection object pc1");
+            _pc1.OnIceCandidate = pc1OnIceCandidate;
+            _pc1.OnIceConnectionChange = pc1OnIceConnectionChange;
+            _pc1.OnNegotiationNeeded = pc1OnNegotiationNeeded;
+            _pc2 = new RTCPeerConnection(ref configuration);
+            Debug.Log("Created remote peer connection object pc2");
+            _pc2.OnIceCandidate = pc2OnIceCandidate;
+            _pc2.OnIceConnectionChange = pc2OnIceConnectionChange;
+            _pc2.OnTrack = pc2Ontrack;
+
+            _pc1.CreateDataChannel("data");
+            videoStream = cam.CaptureStream(1280, 720, 1000000);
+            RtImage.texture = cam.targetTexture;
+        }
+
+        private void OnIceCandidate(RTCPeerConnection pc, RTCIceCandidate candidate)
+        {
+            GetOtherPc(pc).AddIceCandidate(candidate);
+            Debug.Log($"{GetName(pc)} ICE candidate:\n {candidate.Candidate}");
+        }
+
+        private void OnTrack(RTCPeerConnection pc, RTCTrackEvent e)
+        {
+            receiveStream = e.Streams.First();
+            receiveStream.OnRemoveTrack = ev =>
+            {
+                ev.Track.Dispose();
+            };
+            trackInfos.Append($"{GetName(pc)} receives remote track:\r\n");
+            trackInfos.Append($"Track kind: {e.Track.Kind}\r\n");
+            trackInfos.Append($"Track id: {e.Track.Id}\r\n");
+            infoText.text = trackInfos.ToString();
+        }
+
+        private string GetName(RTCPeerConnection pc)
+        {
+            return (pc == _pc1) ? "pc1" : "pc2";
+        }
+
+        private RTCPeerConnection GetOtherPc(RTCPeerConnection pc)
+        {
+            return (pc == _pc1) ? _pc2 : _pc1;
+        }
+
+        private IEnumerator OnCreateOfferSuccess(RTCPeerConnection pc, RTCSessionDescription desc)
+        {
+            Debug.Log($"Offer from {GetName(pc)}\n{desc.sdp}");
+            Debug.Log($"{GetName(pc)} setLocalDescription start");
+            var op = pc.SetLocalDescription(ref desc);
+            yield return op;
+
+            if (!op.IsError)
+            {
+                OnSetLocalSuccess(pc);
+            }
+            else
+            {
+                var error = op.Error;
+                OnSetSessionDescriptionError(ref error);
+            }
+
+            var otherPc = GetOtherPc(pc);
+            Debug.Log($"{GetName(otherPc)} setRemoteDescription start");
+            var op2 = otherPc.SetRemoteDescription(ref desc);
+            yield return op2;
+            if (!op2.IsError)
+            {
+                OnSetRemoteSuccess(otherPc);
+            }
+            else
+            {
+                var error = op2.Error;
+                OnSetSessionDescriptionError(ref error);
+            }
+
+            Debug.Log($"{GetName(otherPc)} createAnswer start");
+            // Since the 'remote' side has no media stream we need
+            // to pass in the right constraints in order for it to
+            // accept the incoming offer of audio and video.
+
+            var op3 = otherPc.CreateAnswer();
+            yield return op3;
+            if (!op3.IsError)
+            {
+                yield return OnCreateAnswerSuccess(otherPc, op3.Desc);
+            }
+            else
+            {
+                OnCreateSessionDescriptionError(op3.Error);
+            }
+        }
+
+        private void OnSetLocalSuccess(RTCPeerConnection pc)
+        {
+            Debug.Log($"{GetName(pc)} SetLocalDescription complete");
+        }
+
+        static void OnSetSessionDescriptionError(ref RTCError error)
+        {
+            Debug.LogError($"Error Detail Type: {error.message}");
+        }
+
+        private void OnSetRemoteSuccess(RTCPeerConnection pc)
+        {
+            Debug.Log($"{GetName(pc)} SetRemoteDescription complete");
+        }
+
+        IEnumerator OnCreateAnswerSuccess(RTCPeerConnection pc, RTCSessionDescription desc)
+        {
+            Debug.Log($"Answer from {GetName(pc)}:\n{desc.sdp}");
+            Debug.Log($"{GetName(pc)} setLocalDescription start");
+            var op = pc.SetLocalDescription(ref desc);
+            yield return op;
+
+            if (!op.IsError)
+            {
+                OnSetLocalSuccess(pc);
+            }
+            else
+            {
+                var error = op.Error;
+                OnSetSessionDescriptionError(ref error);
+            }
+
+            var otherPc = GetOtherPc(pc);
+            Debug.Log($"{GetName(otherPc)} setRemoteDescription start");
+
+            var op2 = otherPc.SetRemoteDescription(ref desc);
+            yield return op2;
+            if (!op2.IsError)
+            {
+                OnSetRemoteSuccess(otherPc);
+            }
+            else
+            {
+                var error = op2.Error;
+                OnSetSessionDescriptionError(ref error);
+            }
+        }
+
+        private static void OnCreateSessionDescriptionError(RTCError error)
+        {
+            Debug.LogError($"Error Detail Type: {error.message}");
+        }
     }
 }


### PR DESCRIPTION
fix change: 0a80cd4
- `RemoveTrack` only call from Sender(pc1) side.
- Remove `OnNegotiationNeeded` process on Receiver(pc2) side
- Register `OnRemoveTrack` process for dispose track on Receiver(pc2) side