### PR TITLE
chore: Remove iOS Simulator support

### DIFF
--- a/BuildScripts~/build_plugin_ios.sh
+++ b/BuildScripts~/build_plugin_ios.sh
@@ -55,6 +55,10 @@ xcodebuild archive \
 rm -rf "$WEBRTC_FRAMEWORK_DIR/webrtc.framework"
 cp -r "$WEBRTC_ARCHIVE_DIR/Products/@rpath/webrtc.framework" "$WEBRTC_FRAMEWORK_DIR/webrtc.framework"
 
-lipo -create -o "$WEBRTC_FRAMEWORK_DIR/webrtc.framework/webrtc" \
-  "$WEBRTC_ARCHIVE_DIR/Products/@rpath/webrtc.framework/webrtc" \
-  "$WEBRTC_SIM_ARCHIVE_DIR/Products/@rpath/webrtc.framework/webrtc"
+# todo(kazuki): The command below combines two libraries for supporting iOS and iOS simulator.
+# But currently this is commented out because the combined binary adds a troublesome task to developer 
+# when building iOS app on XCode. We need to support it using XCFramework or another way.
+# 
+# lipo -create -o "$WEBRTC_FRAMEWORK_DIR/webrtc.framework/webrtc" \
+#   "$WEBRTC_ARCHIVE_DIR/Products/@rpath/webrtc.framework/webrtc" \
+#   "$WEBRTC_SIM_ARCHIVE_DIR/Products/@rpath/webrtc.framework/webrtc"

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -30,6 +30,9 @@ This version of the package is compatible with the following versions of the Uni
 - **Android** (**ARM64** only. **ARMv7** is not supported)
 
 > [!NOTE]
+> Building for **iOS Simulator** is not supported.
+
+> [!NOTE]
 > **WebGL** platform is not supported.
 
 ### Encoder support
@@ -73,11 +76,6 @@ This package depends on **NVIDIA Video Codec SDK 9.1**. Please check the graphic
 > Please install like command below 
 >
 > ``` sudo apt install -y libc++1 libc++abi1 ```
-
-> [!NOTE]
-> To make the archive for **iOS platform** to publish App Store, you need to use `lipo` command to eliminate the `x86_64` architecture from the binary in the `webrtc.framework`.
->
-> ```lipo -remove x86_64 Runtime/Plugins/iOS/webrtc.framework/webrtc -o Runtime/Plugins/iOS/webrtc.framework/webrtc```
 
 > [!NOTE]
 > To build the apk file for **Android platform**, you need to configure player settings below.


### PR DESCRIPTION
In the past, when developers build iOS app with WebRTC library, they needed to take a troublesome step below. 

> To make the archive for **iOS platform** to publish App Store, you need to use `lipo` command to eliminate the `x86_64` architecture from the binary in the `webrtc.framework`.
>
> ```lipo -remove x86_64 Runtime/Plugins/iOS/webrtc.framework/webrtc -o Runtime/Plugins/iOS/webrtc.framework/webrtc``` 
>

The cause of this, the iOS framework contains binary for two architecture to support iOS and iOS simulator. But I guess that almost developers want to skip the step instead of not available to build for iOS simulator.

The fundamental solution is using XCFramework, but currently not supported by Unity Editor.
If you have any ideas, please share them.