### PR TITLE
fix: Audio conversion improvements

### DIFF
--- a/Plugin~/WebRTCPlugin/AudioTrackSinkAdapter.cpp
+++ b/Plugin~/WebRTCPlugin/AudioTrackSinkAdapter.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "AudioTrackSinkAdapter.h"
+#include "common_audio/include/audio_util.h"
 
 namespace unity
 {
@@ -35,13 +36,12 @@ namespace webrtc
 
         const size_t size = number_of_channels * number_of_frames;
         const int16_t* data = static_cast<const int16_t*>(audio_data);
-        const float_t INVERSE = 1.0 / SHRT_MAX;
 
         std::vector<float_t> _converted_data(size);
 
         for (size_t i = 0; i < size; i++)
         {
-            _converted_data[i] = data[i] * INVERSE;
+            _converted_data[i] = webrtc::S16ToFloat(data[i]);
         }
 
         _callback(

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "UnityAudioTrackSource.h"
+#include "common_audio/include/audio_util.h"
 
 namespace unity
 {
@@ -53,8 +54,7 @@ void UnityAudioTrackSource::PushAudioData(
     _convertedAudioData.reserve(_convertedAudioData.size() + nNumFrames);
     for (size_t i = 0; i < nNumFrames; i++)
     {
-        _convertedAudioData.push_back(
-            pAudioData[i] >= 0 ? pAudioData[i] * SHRT_MAX : pAudioData[i] * -SHRT_MIN);
+        _convertedAudioData.push_back(::webrtc::FloatToS16(pAudioData[i]));
     }
 }
 


### PR DESCRIPTION
The original PR is here. #613 @aet fixed this.
(cherry picked from commit eecce18f3589684ac533e0022dd587b94abfadd3)

This change is replacing the process of conversions between `int16_t` and `float`.
`webrtc::S16ToFloat` and `webrtc::FloatToS16` are provided by webrtc library.