### PR TITLE
Fix RTCStats.Type regression on Windows

### DIFF
--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -29,7 +29,7 @@ mkdir -p "$ARTIFACTS_DIR/lib"
 
 for target_cpu in "arm64"
 do
-  mkdir "$ARTIFACTS_DIR/lib/${target_cpu}"
+  mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
 
   for is_debug in "true" "false"
   do

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -62,7 +62,7 @@ do
     ninja -C "$OUTPUT_DIR" webrtc
 
     # copy static library
-    mkdir "$ARTIFACTS_DIR/lib/${target_cpu}"
+    mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
     cp "$OUTPUT_DIR/obj/libwebrtc.a" "$ARTIFACTS_DIR/lib/${target_cpu}/"
   done
 

--- a/BuildScripts~/build_libwebrtc_linux.sh
+++ b/BuildScripts~/build_libwebrtc_linux.sh
@@ -29,7 +29,7 @@ mkdir -p "$ARTIFACTS_DIR/lib"
 
 for target_cpu in "x64"
 do
-  mkdir "$ARTIFACTS_DIR/lib/${target_cpu}"
+  mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
   for is_debug in "true" "false"
   do
     args="is_debug=${is_debug} target_os=\"linux\" target_cpu=\"${target_cpu}\" rtc_include_tests=false rtc_build_examples=false rtc_use_h264=false symbol_level=0 enable_iterator_debugging=false is_component_build=false use_rtti=true rtc_use_x11=false libcxx_abi_unstable=false";

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -58,7 +58,7 @@ do
     ninja -C "$OUTPUT_DIR" webrtc
 
     # copy static library
-    mkdir "$ARTIFACTS_DIR/lib/${target_cpu}"
+    mkdir -p "$ARTIFACTS_DIR/lib/${target_cpu}"
     cp "$OUTPUT_DIR/obj/libwebrtc.a" "$ARTIFACTS_DIR/lib/${target_cpu}/"
   done
 

--- a/Plugin~/WebRTCPlugin/AudioTrackSinkAdapter.cpp
+++ b/Plugin~/WebRTCPlugin/AudioTrackSinkAdapter.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "AudioTrackSinkAdapter.h"
-#include "common_audio/include/audio_util.h"
 #include "audio/remix_resample.h"
 #include "common_audio/include/audio_util.h"
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -688,7 +688,7 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT int64_t StatsMemberGetLong(const RTCStatsMemberInterface* member)
     {
-        return *member->cast_to<::webrtc::RTCStatsMember<uint64_t>>();
+        return *member->cast_to<::webrtc::RTCStatsMember<int64_t>>();
     }
 
     UNITY_INTERFACE_EXPORT uint64_t StatsMemberGetUnsignedLong(const RTCStatsMemberInterface* member)

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -105,7 +105,9 @@ namespace webrtc
             return *this;
         }
 
+        #if defined(__clang__) || defined(__GNUC__)
         __attribute__((optnone))
+        #endif
         explicit operator const absl::optional<T>&() const
         {
             absl::optional<T> dst = absl::nullopt;
@@ -583,7 +585,7 @@ extern "C"
     }
 
 
-    const std::map<std::string, byte> statsTypes =
+    const std::map<std::string, uint32_t> statsTypes =
     {
         { "codec", 0 },
         { "inbound-rtp", 1 },
@@ -608,11 +610,11 @@ extern "C"
         { "ice-server", 20 }
     };
 
-    UNITY_INTERFACE_EXPORT const RTCStats** StatsReportGetStatsList(const RTCStatsReport* report, size_t* length, byte** types)
+    UNITY_INTERFACE_EXPORT const RTCStats** StatsReportGetStatsList(const RTCStatsReport* report, size_t* length, uint32_t** types)
     {
         const size_t size = report->size();
         *length = size;
-        *types = static_cast<byte*>(CoTaskMemAlloc(sizeof(byte) * size));
+        *types = static_cast<uint32_t*>(CoTaskMemAlloc(sizeof(uint32_t) * size));
         void* buf = CoTaskMemAlloc(sizeof(RTCStats*) * size);
         const RTCStats** ret = static_cast<const RTCStats**>(buf);
         if(size == 0)
@@ -649,7 +651,7 @@ extern "C"
         return ConvertString(stats->id());
     }
 
-    UNITY_INTERFACE_EXPORT byte StatsGetType(const RTCStats* stats)
+    UNITY_INTERFACE_EXPORT uint32_t StatsGetType(const RTCStats* stats)
     {
         return statsTypes.at(stats->type());
     }

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -41,12 +41,6 @@ namespace Unity.WebRTC
     /// <summary>
     ///
     /// </summary>
-    /// <param name="renderer"></param>
-    public delegate void OnAudioReceived(AudioSource renderer);
-
-    /// <summary>
-    ///
-    /// </summary>
     public class AudioStreamTrack : MediaStreamTrack
     {
         /// <summary>

--- a/Runtime/Scripts/RTCStats.cs
+++ b/Runtime/Scripts/RTCStats.cs
@@ -794,7 +794,7 @@ namespace Unity.WebRTC
             IntPtr ptrStatsArray = NativeMethods.StatsReportGetStatsList(self, out ulong length, ref ptrStatsTypeArray);
 
             IntPtr[] array = ptrStatsArray.AsArray<IntPtr>((int)length);
-            byte[] types = ptrStatsTypeArray.AsArray<byte>((int)length);
+            uint[] types = ptrStatsTypeArray.AsArray<uint>((int)length);
 
             m_dictStats = new Dictionary<string, RTCStats>();
             for (int i = 0; i < (int)length; i++)


### PR DESCRIPTION
The following code stopped triggering for me on PC once https://github.com/Unity-Technologies/com.unity.webrtc/pull/563 landed, while it still works on Mac/Linux where everything is built with Clang. I rarely use this functionality, so I didn't bother to debug this much further, but changing the type does help.

After changing the type, the plugin works the same if built with VS or Clang for PC
```
foreach (var rtpReceiver in pc.GetReceivers())
{
    RTCStatsReportAsyncOperation op = rtpReceiver.GetStats();
    yield return op;

    if (!op.IsError)
    {
        foreach (RTCStats stats in op.Value.Stats.Values)
        {
            RTCStatsType type = stats.Type;

            if (type == RTCStatsType.InboundRtp)
            {
                Debug.Log("RTCStatsType.InboundRtp")
            }
            if (type == RTCStatsType.Track)
            {
                Debug.Log("RTCStatsType.Track")
            }
        }
    }

    op.Value?.Dispose();
    op = null;
}
```
