### PR TITLE
linux vulkan loader fix

### DIFF
--- a/Plugin~/WebRTCPlugin/Dynlink/libcuda.so.init.c
+++ b/Plugin~/WebRTCPlugin/Dynlink/libcuda.so.init.c
@@ -25,7 +25,7 @@ extern "C" {
 
 #define CHECK(cond, fmt, ...) do { \
     if(!(cond)) { \
-      fprintf(stderr, "implib-gen: libcuda.so: " fmt "\n", ##__VA_ARGS__); \
+      fprintf(stderr, "implib-gen: libcuda.so.1: " fmt "\n", ##__VA_ARGS__); \
       assert(0 && "Assertion in generated code"); \
       exit(1); \
     } \
@@ -49,10 +49,10 @@ static void *load_library() {
   CHECK(0, "internal error"); // We shouldn't get here
 #elif CALL_USER_CALLBACK
   extern void *(const char *lib_name);
-  lib_handle = ("libcuda.so");
+  lib_handle = ("libcuda.so.1");
   CHECK(lib_handle, "callback '' failed to load library");
 #else
-  lib_handle = dlopen("libcuda.so", RTLD_LAZY | RTLD_GLOBAL);
+  lib_handle = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_GLOBAL);
   CHECK(lib_handle, "failed to load library: %s", dlerror());
 #endif
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/LoadVulkanFunctions.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/LoadVulkanFunctions.cpp
@@ -17,10 +17,15 @@ namespace webrtc
 #include "ListOfVulkanFunctions.inl"
 
 bool LoadVulkanLibrary(LIBRARY_TYPE& library) {
-#if defined(_WIN32)
+// Keep the logic similar to Unity internals at VKApiFunctions.cpp
+#if defined(UNITY_WIN)
     library = LoadLibrary("vulkan-1.dll");
-#elif defined(__linux)
+#elif defined(UNITY_ANDROID)
     library = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+#elif defined(UNITY_LINUX)
+    library = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+#else
+#error Unsupported Platform
 #endif
     if (library == nullptr)
         return false;
@@ -28,7 +33,7 @@ bool LoadVulkanLibrary(LIBRARY_TYPE& library) {
 }
 
 bool LoadExportedVulkanFunction(LIBRARY_TYPE const& library) {
-#if defined(_WIN32)
+#if defined(UNITY_WIN)
 #define LoadFunction GetProcAddress
 #elif defined(__linux)
 #define LoadFunction dlsym

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -17,7 +17,7 @@ UnityVideoRenderer::UnityVideoRenderer(
 
 UnityVideoRenderer::~UnityVideoRenderer()
 {
-    DebugLog("Destory UnityVideoRenderer Id:%d", m_id);
+    DebugLog("Destroy UnityVideoRenderer Id:%d", m_id);
     {
         std::unique_lock<std::mutex> lock(m_mutex);
     }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -235,7 +235,7 @@ extern "C"
     {
 #if CUDA_PLATFORM
         IGraphicsDevice* device = GraphicsUtility::GetGraphicsDevice();
-        if(!device->IsCudaSupport())
+        if(!device || !device->IsCudaSupport())
         {
             return false;
         }


### PR DESCRIPTION
When I was updating Nvidia drivers on various Linux environments, I noticed that in some cases libvulkan.so and libcuda.so are simply missing and WebRTC crashes. But core unity renderer continues to get initialized as it's depending on libvulkan.so.1 instead on Linux and for some reason uses libvulkan.so explicitly for Android.

There's also a small error handling fix for current hardware encoder probe in case we have not detected a graphics device at all. Loading of vulkan driver fails, yet we shouldn't even get to this point as core unity has already moved forward using vulkan.
