### PR TITLE
fix: remove wrong return marshal

### DIFF
--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -980,7 +980,6 @@ namespace Unity.WebRTC
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool TransceiverGetCurrentDirection(IntPtr transceiver, ref RTCRtpTransceiverDirection direction);
         [DllImport(WebRTC.Lib)]
-        [return: MarshalAs(UnmanagedType.U1)]
         public static extern RTCErrorType TransceiverStop(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr TransceiverGetMid(IntPtr transceiver);


### PR DESCRIPTION
This `return: MarshalAs` seems to be wrong, since it's not used for other functions with `RTCErrorType` return type.
Although it doesn't cause any error in Unity, I think it's still better to remove it, unless I have misunderstood something.