### PR TITLE
fix: Fixed the issue when garbage collected but the finalizer has not been called

### DIFF
--- a/Runtime/Scripts/RTCRtpReceiver.cs
+++ b/Runtime/Scripts/RTCRtpReceiver.cs
@@ -30,7 +30,10 @@ namespace Unity.WebRTC
             }
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
-                WebRTC.Table.Remove(self);
+                if (WebRTC.Table.TryGetValue(self, out object value) && value == this)
+                {
+                    WebRTC.Table.Remove(self);
+                }
             }
             base.Dispose();
         }

--- a/Runtime/Scripts/WeakReferenceTable.cs
+++ b/Runtime/Scripts/WeakReferenceTable.cs
@@ -59,5 +59,13 @@ namespace Unity.WebRTC
         {
             return m_table.ContainsKey(key);
         }
+        public bool TryGetValue(object key, out object value)
+        {
+            value = null;
+            if (!m_table.ContainsKey(key))
+                return false;
+            value = this[key];
+            return true;
+        }
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -724,7 +724,7 @@ namespace Unity.WebRTC
 
         internal static T FindOrCreate<T>(IntPtr ptr, Func<IntPtr, T> constructor) where T : class
         {
-            if (Context.table.ContainsKey(ptr))
+            if (Context.table.ContainsKey(ptr) && Context.table[ptr] != null)
             {
                 if(Context.table[ptr] is T value)
                     return value;

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -724,10 +724,19 @@ namespace Unity.WebRTC
 
         internal static T FindOrCreate<T>(IntPtr ptr, Func<IntPtr, T> constructor) where T : class
         {
-            if (Context.table.ContainsKey(ptr) && Context.table[ptr] != null)
+            if (Context.table.ContainsKey(ptr))
             {
-                if(Context.table[ptr] is T value)
+                if (Context.table[ptr] == null)
+                {
+                    // The object has been garbage collected.
+                    // But the finalizer has not been called.
+                    Context.table.Remove(ptr);
+                    return constructor(ptr);
+                }
+                if (Context.table[ptr] is T value)
+                {
                     return value;
+                }
                 throw new InvalidCastException($"{ptr} is not {typeof(T).Name}");
             }
             else

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -49,7 +49,7 @@ namespace Unity.WebRTC.RuntimeTest
             var test = new MonoBehaviourTest<SignalingPeers>();
 
             var track = new AudioStreamTrack(source);
-            var sender = test.component.AddTrack(0, track);
+            test.component.AddTrack(0, track);
             yield return test;
             GC.Collect();
             var receivers = test.component.GetPeerReceivers(1);

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -42,6 +42,29 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        public IEnumerator GCCollect()
+        {
+            GameObject obj = new GameObject("audio");
+            AudioSource source = obj.AddComponent<AudioSource>();
+            var test = new MonoBehaviourTest<SignalingPeers>();
+
+            var track = new AudioStreamTrack(source);
+            var sender = test.component.AddTrack(0, track);
+            yield return test;
+            GC.Collect();
+            var receivers = test.component.GetPeerReceivers(1);
+            Assert.That(receivers.Count(), Is.EqualTo(1));
+            var receiver = receivers.First();
+            var audioTrack = receiver.Track as AudioStreamTrack;
+            Assert.That(audioTrack, Is.Not.Null);
+
+            test.component.Dispose();
+            UnityEngine.Object.DestroyImmediate(test.gameObject);
+            UnityEngine.Object.DestroyImmediate(obj);
+        }
+
+        [UnityTest]
+        [Timeout(5000)]
         public IEnumerator AddMultiAudioTrack()
         {
             GameObject obj = new GameObject("audio");


### PR DESCRIPTION
Related issue #631

This PR fixes the problem occurs by the gabage collection.

The instance of `WeakReference` class is destroyed when collected by GC, but the finalizer of the instance runs after destroying with slightly delay. If called `Dispose` method among the delay, it occurs the issue.