### PR TITLE
chore: Upgrade the package version 2.4.0-exp.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,6 +27,7 @@ body:
         What version of the package are you using?
         You can check the Unity version in Package Manager Window. See [manual](https://docs.unity3d.com/Manual/upm-ui.html).
       options:
+        - 2.4.0-exp.6
         - 2.4.0-exp.5
         - 2.4.0-exp.4
         - 2.4.0-exp.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the webrtc package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.4.0-exp.6] - 2022-02-24
+
+### Fixed
+
+- Fixed a crash bug where disposing `AudioStreamTrack` on a receiver side.
+
 ## [2.4.0-exp.5] - 2022-02-02
 
 ### Added

--- a/Documentation~/install.md
+++ b/Documentation~/install.md
@@ -32,7 +32,7 @@ Check Package Manager window, Click `+` button and select `Add package from git 
 Input the string below to the input field.
 
 ```
-com.unity.webrtc@2.4.0-exp.5
+com.unity.webrtc@2.4.0-exp.6
 ```
 
 The list of version string is [here](https://github.com/Unity-Technologies/com.unity.webrtc/tags). In most cases, the latest version is recommended to use.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Please read this if you have an interest to customize native code in this projec
 | `2.4.0-exp.3` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | - Fix bugs | Jun 2021 |
 | `2.4.0-exp.4` | [M89](https://groups.google.com/g/discuss-webrtc/c/Zrsn2hi8FV0/m/KIbn0EZPBQAJ) | - Audio renderer support <br>- Apple Silicon support | Aug 2021 |
 | `2.4.0-exp.5` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Fix audio streaming issues | Feb 2022 |
-| `2.4.0-exp.6` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Fix video streaming issues | Apr 2022 |
+| `2.4.0-exp.6` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Hotfix | Feb 2022 |
+| `2.4.0-exp.7` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Fix video streaming issues | Apr 2022 |
 
 ## Licenses
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "2.4.0-exp.5",
+  "version": "2.4.0-exp.6",
   "unity": "2019.4",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [


### PR DESCRIPTION
#630 fixes a crash bug which occurrs high frequency. So we decided to release hotfix version for developers using it.