### PR TITLE
fix slowly drifting audio desync + rely more on audio render thread

### DIFF
--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -63,30 +63,6 @@ namespace webrtc
                 kChannels, kSamplesPerFrame, data,
                 &elapsed_time_ms, &ntp_time_ms);
         }
-
-        if (recording_)
-        {
-            for (const auto& pair : callbacks_) {
-                pair.second();
-            }
-        }
-    }
-
-    void DummyAudioDevice::RegisterSendAudioCallback(
-        UnityAudioTrackSource* source, int sampleRate, int channels) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (callbacks_.find(source) == callbacks_.end()) {
-            callbacks_.emplace(source, [source, sampleRate, channels]() {
-                source->SendAudioData(sampleRate, channels); });
-        }
-    }
-
-    void DummyAudioDevice::UnregisterSendAudioCallback(
-        UnityAudioTrackSource* source) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (callbacks_.find(source) != callbacks_.end()) {
-            callbacks_.erase(source);
-        }
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -314,10 +314,6 @@ namespace webrtc
             return 0;
         }
 #endif
-        void RegisterSendAudioCallback(
-            UnityAudioTrackSource* source, int sampleRate, int channels);
-        void UnregisterSendAudioCallback(
-            UnityAudioTrackSource* source);
 
     private:
         void ProcessAudio();
@@ -337,7 +333,6 @@ namespace webrtc
         mutable std::mutex mutex_;
         webrtc::AudioTransport* audio_transport_{ nullptr };
         using callback_t = std::function<void()>;
-        std::unordered_map<UnityAudioTrackSource*, callback_t> callbacks_;
         TaskQueueFactory* tackQueueFactory_;
     };
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -332,7 +332,6 @@ namespace webrtc
         std::atomic<bool> recording_{ false };
         mutable std::mutex mutex_;
         webrtc::AudioTransport* audio_transport_{ nullptr };
-        using callback_t = std::function<void()>;
         TaskQueueFactory* tackQueueFactory_;
     };
 

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -21,7 +21,6 @@ namespace webrtc
         void PushAudioData(
             const float* pAudioData, int nSampleRate,
             size_t nNumChannels, size_t nNumFrames);
-        void SendAudioData(int nSampleRate, size_t nNumChannels);
 
     protected:
         UnityAudioTrackSource();
@@ -34,7 +33,9 @@ namespace webrtc
         std::vector<AudioTrackSinkInterface*> _arrSink;
         std::mutex _mutex;
         cricket::AudioOptions _options;
-        bool _bufferInit = false;
+        int _sampleRate = 0;
+        size_t _numChannels = 0;
+        size_t _numFrames = 0;
     };
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1408,30 +1408,6 @@ extern "C"
         ContextManager::GetInstance()->curContext = context;
     }
 
-    UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
-        Context* context,
-        UnityAudioTrackSource* source,
-        int32 sample_rate,
-        int32 number_of_channels)
-    {
-        auto adm = context->GetAudioDevice();
-        if (source != nullptr && adm != nullptr)
-        {
-            adm->RegisterSendAudioCallback(source, sample_rate, number_of_channels);
-        }
-    }
-
-    UNITY_INTERFACE_EXPORT void ContextUninitLocalAudio(
-        Context* context,
-        UnityAudioTrackSource* source)
-    {
-        auto adm = context->GetAudioDevice();
-        if (source != nullptr && adm != nullptr)
-        {
-            adm->UnregisterSendAudioCallback(source);
-        }
-    }
-
     UNITY_INTERFACE_EXPORT void AudioSourceProcessLocalAudio(
         UnityAudioTrackSource* source,
         float* audio_data,

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -302,8 +302,6 @@ namespace Unity.WebRTC
 
     internal class AudioTrackSource : RefCountedObject
     {
-        bool inited = false;
-
         public AudioTrackSource() : base(WebRTC.Context.CreateAudioTrackSource())
         {
             WebRTC.Table.Add(self, this);
@@ -314,23 +312,8 @@ namespace Unity.WebRTC
             this.Dispose();
         }
 
-        public void Initialize(int sampleRate, int channels)
-        {
-            // initialize audio streaming for sender
-            WebRTC.Context.AudioSourceInitLocalAudio(GetSelfOrThrow(), sampleRate, channels);
-            inited = true;
-        }
-
-        public void Uninitialize()
-        {
-            WebRTC.Context.AudioSourceUninitLocalAudio(GetSelfOrThrow());
-            inited = false;
-        }
-
         public void Update(IntPtr array, int sampleRate, int channels, int frames)
         {
-            if (!inited)
-                Initialize(sampleRate, channels);
             NativeMethods.AudioSourceProcessLocalAudio(GetSelfOrThrow(), array, sampleRate, channels, frames);
         }
 
@@ -345,8 +328,6 @@ namespace Unity.WebRTC
             {
                 WebRTC.Table.Remove(self);
             }
-            if (inited)
-                Uninitialize();
             base.Dispose();
         }
     }

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -315,15 +315,5 @@ namespace Unity.WebRTC
             textureUpdateFunction = textureUpdateFunction == IntPtr.Zero ? GetUpdateTextureFunc() : textureUpdateFunction;
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
-
-        internal void AudioSourceInitLocalAudio(IntPtr source, int sampleRate, int channels)
-        {
-            NativeMethods.ContextInitLocalAudio(self, source, sampleRate, channels);
-        }
-
-        internal void AudioSourceUninitLocalAudio(IntPtr source)
-        {
-            NativeMethods.ContextUninitLocalAudio(self, source);
-        }
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1104,10 +1104,6 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextInitLocalAudio(IntPtr context, IntPtr source, int sampleRate, int channels);
-        [DllImport(WebRTC.Lib)]
-        public static extern void ContextUninitLocalAudio(IntPtr context, IntPtr source);
-        [DllImport(WebRTC.Lib)]
         public static extern void AudioSourceProcessLocalAudio(IntPtr source, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);


### PR DESCRIPTION
I've been told lately that audio desync starts to get noticeable after 30-40mins in our testcase that's a pretty heavily loaded app. Tried to look into what could be the regression from our previous M85 build from 13 months ago compared to what M92 webrtc has today.

It sounds like there's a chance for _convertedAudioData to build up slowly over time, so I took the chance to streamline the code similar to what was being done a year ago. I've tested this myself with over 4 hours of looping video to see if there's any desync, so far things seem to work but I'll get more feedback of the fix tomorrow.