### PR TITLE
refactor: Fixed clang compiler warning

### DIFF
--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -48,7 +48,6 @@ endif()
 
 # enable debug output 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_FLAGS_DEBUG "-D_DEBUG")
 
 # set iterator debug level
 if(Windows)

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -54,8 +54,6 @@ if(Windows)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_ITERATOR_DEBUG_LEVEL=0 /Zi /Od")
 endif()
 
-#set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-external:I")
-
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -54,6 +54,8 @@ if(Windows)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_ITERATOR_DEBUG_LEVEL=0 /Zi /Od")
 endif()
 
+#set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-external:I")
+
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 

--- a/Plugin~/NvCodec/CMakeLists.txt
+++ b/Plugin~/NvCodec/CMakeLists.txt
@@ -40,6 +40,13 @@ else ()
   find_library(NVENCODEAPI_LIB nvidia-encode)
 endif()
 
+if(WIN32)
+  # Select runtime library (MT, MTD) on windows platform
+  set_target_properties(NvCodec
+    PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+endif()
+
 set(NVCODEC_LIBRARIES
   NvCodec
   ${CUVID_LIB}

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -54,13 +54,38 @@ target_compile_options(WebRTCLib
     -Wall
     -Wextra
     -Wformat=2
-    -Wno-undef
-    -Wno-type-limits
+    -Wno-class-varargs
+    -Wno-comma
+    -Wno-covered-switch-default
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
+    -Wno-deprecated-copy-dtor
+    -Wno-documentation
+    -Wno-documentation-unknown-command
+    -Wno-double-promotion
+    -Wno-float-equal
+    #-Wno-ignored-qualifiers
+    -Wno-implicit-int-float-conversion
+    -Wno-inconsistent-missing-destructor-override
+    -Wno-language-extension-token
     -Wno-missing-field-initializers
     -Wno-missing-prototypes
+    -Wno-nonportable-system-include-path
     -Wno-padded
+    -Wno-reserved-id-macro
+    -Wno-shadow-field
+    -Wno-shadow-field-in-constructor
+    -Wno-sign-conversion
+    -Wno-suggest-destructor-override
+    -Wno-suggest-override
+    -Wno-switch-enum
+    -Wno-thread-safety-negative
+    -Wno-type-limits
+    -Wno-undef
+    -Wno-undefined-func-template
+    -Wno-unused-parameter
+    -Wno-unused-template
+    -Wno-zero-as-null-pointer-constant
 )
 
 target_compile_definitions(WebRTCLib
@@ -125,6 +150,7 @@ if(Windows)
       Strmiids
   )
   target_include_directories(WebRTCLib
+    SYSTEM
     PUBLIC
       ${CUDA_INCLUDE_DIRS}
       ${Vulkan_INCLUDE_DIR}
@@ -159,6 +185,7 @@ elseif(macOS)
       ${FRAMEWORK_LIBS}
   )
   target_include_directories(WebRTCLib
+    SYSTEM
     PUBLIC
       ${WEBRTC_OBJC_INCLUDE_DIR}
   )
@@ -187,6 +214,7 @@ elseif(Linux)
       ${GLIB_LIBRARIES}
   )
   target_include_directories(WebRTCLib
+    SYSTEM
     PUBLIC
       ${CUDA_INCLUDE_DIRS}
       ${Vulkan_INCLUDE_DIR}
@@ -214,6 +242,7 @@ elseif(iOS)
       WEBRTC_POSIX
   )
   target_include_directories(WebRTCLib
+    SYSTEM
     PUBLIC
       ${WEBRTC_OBJC_INCLUDE_DIR}
   )
@@ -265,9 +294,26 @@ endif()
 target_include_directories(WebRTCLib
   PUBLIC
     .
-    ${CMAKE_SOURCE_DIR}/unity/include
     ${WEBRTC_INCLUDE_DIR}
 )
+
+target_include_directories(WebRTCLib
+  SYSTEM
+  PUBLIC
+    ${CMAKE_SOURCE_DIR}/unity/include
+)
+
+
+# file(GLOB UNITY_HEADER_FILES
+#   "${CMAKE_SOURCE_DIR}/unity/include/*.h"
+# )
+
+# set_source_files_properties(
+#   ${UNITY_HEADER_FILES}
+#   PROPERTIES 
+#   COMPILE_FLAGS 
+#   "-Wno-everything"
+# )
 
 #
 # Configure WebRTC Unity plugin

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -48,6 +48,22 @@ target_sources(WebRTCLib
     UnityLogStream.cpp
 )
 
+target_compile_options(WebRTCLib
+  PRIVATE 
+    -Wall
+    -Wextra
+    -Wno-missing-field-initializers
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-padded
+)
+
+target_compile_definitions(WebRTCLib
+  PRIVATE 
+    "$<$<CONFIG:Debug>:DEBUG>"
+)
+
+
 if(iOS OR macOS)
   target_sources(WebRTCLib
     PRIVATE
@@ -74,13 +90,6 @@ if(Windows)
                    CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
     string(REPLACE /GR /GR- "${flag_var}" "${${flag_var}}")
   endforeach()
-endif()
-
-if(UNIX)
-  target_compile_options(WebRTCLib 
-    PUBLIC
-      -Wall -Wextra -Wno-unknown-pragmas -Wno-unused-parameter -Wno-missing-field-initializers -Wno-long-long
-  )
 endif()
 
 if(Windows)
@@ -296,6 +305,21 @@ if(Android)
       Jni.cpp
   )
 endif()
+
+target_compile_options(WebRTCPlugin
+  PRIVATE 
+    -Wall
+    -Wextra
+    -Wno-missing-field-initializers
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-padded
+)
+
+target_compile_definitions(WebRTCPlugin
+  PRIVATE 
+    "$<$<CONFIG:Debug>:DEBUG>"
+)
 
 # rename dll/framework filename
 set_target_properties(WebRTCPlugin

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -48,7 +48,7 @@ target_sources(WebRTCLib
     UnityLogStream.cpp
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Visual Studio Generator has not been supported supression warnings of external headers yet.
   # https://gitlab.kitware.com/cmake/cmake/-/issues/17904
   if(NOT CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -58,37 +58,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         -Wall
         -Wextra
         -Wformat=2
-        # -Wno-class-varargs
-        # -Wno-comma
-        # -Wno-covered-switch-default
-        # -Wno-c++98-compat
-        # -Wno-c++98-compat-pedantic
-        # -Wno-deprecated-copy-dtor
-        # -Wno-documentation
-        # -Wno-documentation-unknown-command
-        # -Wno-double-promotion
-        # -Wno-float-equal
-        # -Wno-implicit-int-float-conversion
-        # -Wno-inconsistent-missing-destructor-override
-        # -Wno-language-extension-token
-        # -Wno-missing-field-initializers
-        # -Wno-missing-prototypes
-        # -Wno-nonportable-system-include-path
-        # -Wno-padded
-        # -Wno-reserved-id-macro
-        # -Wno-shadow-field
-        # -Wno-shadow-field-in-constructor
-        # -Wno-sign-conversion
-        # -Wno-suggest-destructor-override
-        # -Wno-suggest-override
-        # -Wno-switch-enum
-        # -Wno-thread-safety-negative
-        # -Wno-type-limits
-        # -Wno-undef
-        # -Wno-undefined-func-template
-        # -Wno-unused-parameter
-        # -Wno-unused-template
-        # -Wno-zero-as-null-pointer-constant
+        -Wno-unused-parameter
     )
   endif()
 endif()
@@ -297,32 +267,16 @@ elseif(Android)
 endif()
 
 target_include_directories(WebRTCLib
+  SYSTEM
   PUBLIC
-    .
+    ${CMAKE_SOURCE_DIR}/unity/include
     ${WEBRTC_INCLUDE_DIR}
 )
 
 target_include_directories(WebRTCLib
-  SYSTEM
   PUBLIC
-    ${CMAKE_SOURCE_DIR}/unity/include
+    .
 )
-
-
-# file(GLOB UNITY_HEADER_FILES
-#   "${CMAKE_SOURCE_DIR}/unity/include/*.h"
-# )
-
-# set_source_files_properties(
-#   ${UNITY_HEADER_FILES}
-#   PROPERTIES 
-#   COMPILE_FLAGS 
-#   "-Wno-everything"
-# )
-
-#
-# Configure WebRTC Unity plugin
-#
 
 if(iOS)
   add_library(WebRTCPlugin SHARED)

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -48,45 +48,50 @@ target_sources(WebRTCLib
     UnityLogStream.cpp
 )
 
-target_compile_options(WebRTCLib
-  PUBLIC
-    -Werror 
-    -Wall
-    -Wextra
-    -Wformat=2
-    -Wno-class-varargs
-    -Wno-comma
-    -Wno-covered-switch-default
-    -Wno-c++98-compat
-    -Wno-c++98-compat-pedantic
-    -Wno-deprecated-copy-dtor
-    -Wno-documentation
-    -Wno-documentation-unknown-command
-    -Wno-double-promotion
-    -Wno-float-equal
-    #-Wno-ignored-qualifiers
-    -Wno-implicit-int-float-conversion
-    -Wno-inconsistent-missing-destructor-override
-    -Wno-language-extension-token
-    -Wno-missing-field-initializers
-    -Wno-missing-prototypes
-    -Wno-nonportable-system-include-path
-    -Wno-padded
-    -Wno-reserved-id-macro
-    -Wno-shadow-field
-    -Wno-shadow-field-in-constructor
-    -Wno-sign-conversion
-    -Wno-suggest-destructor-override
-    -Wno-suggest-override
-    -Wno-switch-enum
-    -Wno-thread-safety-negative
-    -Wno-type-limits
-    -Wno-undef
-    -Wno-undefined-func-template
-    -Wno-unused-parameter
-    -Wno-unused-template
-    -Wno-zero-as-null-pointer-constant
-)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Visual Studio Generator has not been supported supression warnings of external headers yet.
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/17904
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+    target_compile_options(WebRTCLib
+      PUBLIC
+        -Werror 
+        -Wall
+        -Wextra
+        -Wformat=2
+        # -Wno-class-varargs
+        # -Wno-comma
+        # -Wno-covered-switch-default
+        # -Wno-c++98-compat
+        # -Wno-c++98-compat-pedantic
+        # -Wno-deprecated-copy-dtor
+        # -Wno-documentation
+        # -Wno-documentation-unknown-command
+        # -Wno-double-promotion
+        # -Wno-float-equal
+        # -Wno-implicit-int-float-conversion
+        # -Wno-inconsistent-missing-destructor-override
+        # -Wno-language-extension-token
+        # -Wno-missing-field-initializers
+        # -Wno-missing-prototypes
+        # -Wno-nonportable-system-include-path
+        # -Wno-padded
+        # -Wno-reserved-id-macro
+        # -Wno-shadow-field
+        # -Wno-shadow-field-in-constructor
+        # -Wno-sign-conversion
+        # -Wno-suggest-destructor-override
+        # -Wno-suggest-override
+        # -Wno-switch-enum
+        # -Wno-thread-safety-negative
+        # -Wno-type-limits
+        # -Wno-undef
+        # -Wno-undefined-func-template
+        # -Wno-unused-parameter
+        # -Wno-unused-template
+        # -Wno-zero-as-null-pointer-constant
+    )
+  endif()
+endif()
 
 target_compile_definitions(WebRTCLib
   PRIVATE 

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -54,6 +54,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # https://gitlab.kitware.com/cmake/cmake/-/issues/17904
   if(CMAKE_GENERATOR MATCHES "Visual Studio")
     set(VISUALSTUDIO_GENERATOR 1)
+  else()
+    set(VISUALSTUDIO_GENERATOR 0)
   endif()
 
   target_compile_options(WebRTCLib

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -64,7 +64,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 target_compile_definitions(WebRTCLib
-  PRIVATE 
+  PUBLIC 
     "$<$<CONFIG:Debug>:DEBUG>"
 )
 
@@ -315,11 +315,6 @@ if(Android)
       Jni.cpp
   )
 endif()
-
-target_compile_definitions(WebRTCPlugin
-  PRIVATE 
-    "$<$<CONFIG:Debug>:DEBUG>"
-)
 
 # rename dll/framework filename
 set_target_properties(WebRTCPlugin

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -52,9 +52,10 @@ target_compile_options(WebRTCLib
   PRIVATE 
     -Wall
     -Wextra
-    -Wno-missing-field-initializers
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
+    -Wno-missing-field-initializers
+    -Wno-missing-prototypes
     -Wno-padded
 )
 
@@ -310,9 +311,10 @@ target_compile_options(WebRTCPlugin
   PRIVATE 
     -Wall
     -Wextra
-    -Wno-missing-field-initializers
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
+    -Wno-missing-field-initializers
+    -Wno-missing-prototypes
     -Wno-padded
 )
 

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -48,24 +48,27 @@ target_sources(WebRTCLib
     UnityLogStream.cpp
 )
 
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Visual Studio Generator has not been supported supression warnings of external headers yet.
   # https://gitlab.kitware.com/cmake/cmake/-/issues/17904
-  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio")
-    target_compile_options(WebRTCLib
-      PUBLIC
-        -Werror 
-        -Wall
-        -Wextra
-        -Wformat=2
-        -Wno-unused-parameter
-    )
+  if(CMAKE_GENERATOR MATCHES "Visual Studio")
+    set(VISUALSTUDIO_GENERATOR 1)
   endif()
+
+  target_compile_options(WebRTCLib
+    PUBLIC
+      $<$<NOT:${VISUALSTUDIO_GENERATOR}>:-Werror>
+      -Wall
+      -Wextra
+      -Wformat=2
+      -Wno-unused-parameter
+  )
 endif()
 
 target_compile_definitions(WebRTCLib
   PUBLIC 
-    "$<$<CONFIG:Debug>:DEBUG>"
+    $<$<CONFIG:Debug>:DEBUG>
 )
 
 

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -49,9 +49,13 @@ target_sources(WebRTCLib
 )
 
 target_compile_options(WebRTCLib
-  PRIVATE 
+  PUBLIC
+    -Werror 
     -Wall
     -Wextra
+    -Wformat=2
+    -Wno-undef
+    -Wno-type-limits
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
     -Wno-missing-field-initializers
@@ -306,17 +310,6 @@ if(Android)
       Jni.cpp
   )
 endif()
-
-target_compile_options(WebRTCPlugin
-  PRIVATE 
-    -Wall
-    -Wextra
-    -Wno-c++98-compat
-    -Wno-c++98-compat-pedantic
-    -Wno-missing-field-initializers
-    -Wno-missing-prototypes
-    -Wno-padded
-)
 
 target_compile_definitions(WebRTCPlugin
   PRIVATE 

--- a/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/EncoderFactory.cpp
@@ -121,7 +121,7 @@ namespace webrtc
             }           
         }
         encoder->InitV();
-        return std::move(encoder);
+        return encoder;
     }
     
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/IEncoder.h
+++ b/Plugin~/WebRTCPlugin/Codec/IEncoder.h
@@ -18,7 +18,7 @@ namespace webrtc
 
     class IEncoder {
     public:
-        virtual ~IEncoder() {};        
+        virtual ~IEncoder() {}        
         virtual void InitV() = 0;   //Can throw exception. 
         virtual void SetRates(uint32_t bitRate, int64_t frameRate) = 0;
         virtual void UpdateSettings() = 0;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -92,7 +92,7 @@ namespace webrtc
         presetConfig.version = NV_ENC_PRESET_CONFIG_VER;
         presetConfig.presetCfg.version = NV_ENC_CONFIG_VER;
         errorCode = pNvEncodeAPI->nvEncGetEncodePresetConfig(pEncoderInterface, nvEncInitializeParams.encodeGUID, nvEncInitializeParams.presetGUID, &presetConfig);
-        checkf(NV_RESULT(errorCode), StringFormat("Failed to select NVEncoder preset config %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "Failed to select NVEncoder preset config");
         std::memcpy(&nvEncConfig, &presetConfig.presetCfg, sizeof(NV_ENC_CONFIG));
         nvEncConfig.profileGUID = NV_ENC_H264_PROFILE_BASELINE_GUID;
         nvEncConfig.gopLength = nvEncInitializeParams.frameRateNum;
@@ -115,13 +115,13 @@ namespace webrtc
         capsParam.capsToQuery = NV_ENC_CAPS_ASYNC_ENCODE_SUPPORT;
         int32 asyncMode = 0;
         errorCode = pNvEncodeAPI->nvEncGetEncodeCaps(pEncoderInterface, nvEncInitializeParams.encodeGUID, &capsParam, &asyncMode);
-        checkf(NV_RESULT(errorCode), StringFormat("Failed to get NVEncoder capability params %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "Failed to get NVEncoder capability params");
         nvEncInitializeParams.enableEncodeAsync = 0;
 #pragma endregion
 #pragma region initialize hardware encoder session
         errorCode = pNvEncodeAPI->nvEncInitializeEncoder(pEncoderInterface, &nvEncInitializeParams);
         result = NV_RESULT(errorCode);
-        checkf(result, StringFormat("Failed to initialize NVEncoder %d", errorCode).c_str());
+        checkf(result, "Failed to initialize NVEncoder");
 #pragma endregion
         InitEncoderResources();
         m_isNvEncoderSupported = true;
@@ -132,7 +132,7 @@ namespace webrtc
         if (pEncoderInterface)
         {
             errorCode = pNvEncodeAPI->nvEncDestroyEncoder(pEncoderInterface);
-            checkf(NV_RESULT(errorCode), StringFormat("Failed to destroy NV encoder interface %d", errorCode).c_str());
+            checkf(NV_RESULT(errorCode), "Failed to destroy NV encoder interface");
             pEncoderInterface = nullptr;
         }
     }
@@ -255,8 +255,7 @@ namespace webrtc
             std::memcpy(&nvEncReconfigureParams.reInitEncodeParams, &nvEncInitializeParams, sizeof(nvEncInitializeParams));
             nvEncReconfigureParams.version = NV_ENC_RECONFIGURE_PARAMS_VER;
             errorCode = pNvEncodeAPI->nvEncReconfigureEncoder(pEncoderInterface, &nvEncReconfigureParams);
-            checkf(NV_RESULT(errorCode), StringFormat("Failed to reconfigure encoder setting %d %d %d",
-                errorCode, nvEncInitializeParams.frameRateNum, nvEncConfig.rcParams.averageBitRate).c_str());
+            checkf(NV_RESULT(errorCode), "Failed to reconfigure encoder setting");
         }
     }
 
@@ -301,7 +300,7 @@ namespace webrtc
             isIdrFrame = false;
         }
         errorCode = pNvEncodeAPI->nvEncEncodePicture(pEncoderInterface, &picParams);
-        checkf(NV_RESULT(errorCode), StringFormat("Failed to encode frame, error is %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "Failed to encode frame");
 #pragma endregion
         ProcessEncodedFrame(frame, timestamp_us);
         frameCount++;
@@ -317,14 +316,14 @@ namespace webrtc
         lockBitStream.outputBitstream = frame.outputFrame;
         lockBitStream.doNotWait = nvEncInitializeParams.enableEncodeAsync;
         errorCode = pNvEncodeAPI->nvEncLockBitstream(pEncoderInterface, &lockBitStream);
-        checkf(NV_RESULT(errorCode), StringFormat("Failed to lock bit stream, error is %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "Failed to lock bit stream");
         if (lockBitStream.bitstreamSizeInBytes)
         {
             frame.encodedFrame.resize(lockBitStream.bitstreamSizeInBytes);
             std::memcpy(frame.encodedFrame.data(), lockBitStream.bitstreamBufferPtr, lockBitStream.bitstreamSizeInBytes);
         }
         errorCode = pNvEncodeAPI->nvEncUnlockBitstream(pEncoderInterface, frame.outputFrame);
-        checkf(NV_RESULT(errorCode), StringFormat("Failed to unlock bit stream, error is %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "Failed to unlock bit stream");
 #pragma endregion
         const rtc::scoped_refptr<FrameBuffer> buffer =
             new rtc::RefCountedObject<FrameBuffer>(
@@ -365,7 +364,7 @@ namespace webrtc
         registerResource.bufferFormat = m_bufferFormat;
         registerResource.bufferUsage = NV_ENC_INPUT_IMAGE;
         errorCode = pNvEncodeAPI->nvEncRegisterResource(pEncoderInterface, &registerResource);
-        checkf(NV_RESULT(errorCode), StringFormat("nvEncRegisterResource error is %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "nvEncRegisterResource error");
         return registerResource.registeredResource;
     }
     void NvEncoder::MapResources(InputFrame& inputFrame)
@@ -374,7 +373,7 @@ namespace webrtc
         mapInputResource.version = NV_ENC_MAP_INPUT_RESOURCE_VER;
         mapInputResource.registeredResource = inputFrame.registeredResource;
         errorCode = pNvEncodeAPI->nvEncMapInputResource(pEncoderInterface, &mapInputResource);
-        checkf(NV_RESULT(errorCode), StringFormat("nvEncMapInputResource error is %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "nvEncMapInputResource error");
         inputFrame.mappedResource = mapInputResource.mappedResource;
     }
     NV_ENC_OUTPUT_PTR NvEncoder::InitializeBitstreamBuffer()
@@ -382,7 +381,7 @@ namespace webrtc
         NV_ENC_CREATE_BITSTREAM_BUFFER createBitstreamBuffer = {};
         createBitstreamBuffer.version = NV_ENC_CREATE_BITSTREAM_BUFFER_VER;
         errorCode = pNvEncodeAPI->nvEncCreateBitstreamBuffer(pEncoderInterface, &createBitstreamBuffer);
-        checkf(NV_RESULT(errorCode), StringFormat("nvEncCreateBitstreamBuffer error is %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "nvEncCreateBitstreamBuffer error");
         return createBitstreamBuffer.bitstreamBuffer;
     }
     void NvEncoder::InitEncoderResources()
@@ -405,14 +404,14 @@ namespace webrtc
         if(frame.inputFrame.mappedResource)
         {
             errorCode = pNvEncodeAPI->nvEncUnmapInputResource(pEncoderInterface, frame.inputFrame.mappedResource);
-            checkf(NV_RESULT(errorCode), StringFormat("Failed to unmap input resource %d", errorCode).c_str());
+            checkf(NV_RESULT(errorCode), "Failed to unmap input resource");
             frame.inputFrame.mappedResource = nullptr;
         }
 
         if(frame.inputFrame.registeredResource)
         {
             errorCode = pNvEncodeAPI->nvEncUnregisterResource(pEncoderInterface, frame.inputFrame.registeredResource);
-            checkf(NV_RESULT(errorCode), StringFormat("Failed to unregister input buffer resource %d", errorCode).c_str());
+            checkf(NV_RESULT(errorCode), "Failed to unregister input buffer resource");
             frame.inputFrame.registeredResource = nullptr;
         }
 
@@ -422,8 +421,7 @@ namespace webrtc
             ReleaseFrameInputBuffer(frame);
             if (frame.outputFrame != nullptr) {
                 errorCode = pNvEncodeAPI->nvEncDestroyBitstreamBuffer(pEncoderInterface, frame.outputFrame);
-                checkf(NV_RESULT(errorCode),
-                       StringFormat("Failed to destroy output buffer bit stream %d", errorCode).c_str());
+                checkf(NV_RESULT(errorCode), "Failed to destroy output buffer bit stream");
                 frame.outputFrame = nullptr;
             }
         }

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -74,7 +74,7 @@ namespace webrtc
         nvEncInitializeParams.darWidth = m_width;
         nvEncInitializeParams.darHeight = m_height;
         nvEncInitializeParams.encodeGUID = NV_ENC_CODEC_H264_GUID;
-        nvEncInitializeParams.presetGUID = NV_ENC_PRESET_LOW_LATENCY_HQ_GUID;
+        nvEncInitializeParams.presetGUID = NV_ENC_PRESET_P4_GUID;
         nvEncInitializeParams.frameRateNum = m_frameRate;
         nvEncInitializeParams.frameRateDen = 1;
         nvEncInitializeParams.enablePTD = 1;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -50,7 +50,7 @@ namespace webrtc
         }
 #pragma region open an encode session
         //open an encode session
-        NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS openEncodeSessionExParams = { 0 };
+        NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS openEncodeSessionExParams = {};
         openEncodeSessionExParams.version = NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER;
 
         openEncodeSessionExParams.device = m_device->GetEncodeDevicePtrV();
@@ -59,13 +59,13 @@ namespace webrtc
 
         errorCode = pNvEncodeAPI->nvEncOpenEncodeSessionEx(&openEncodeSessionExParams, &pEncoderInterface);
 
-        if(!NV_RESULT(errorCode))
+        if(!(NV_RESULT(errorCode)))
         {
             m_initializationResult = CodecInitializationResult::EncoderInitializationFailed;
             return;
         }
 
-        checkf(NV_RESULT(errorCode), StringFormat("Unable to open NvEnc encode session %d", errorCode).c_str());
+        checkf(NV_RESULT(errorCode), "Unable to open NvEnc encode session");
 #pragma endregion
 #pragma region set initialization parameters
         nvEncInitializeParams.version = NV_ENC_INITIALIZE_PARAMS_VER;
@@ -88,7 +88,7 @@ namespace webrtc
         nvEncInitializeParams.maxEncodeHeight = 0;
 #pragma endregion
 #pragma region get preset config and set it
-        NV_ENC_PRESET_CONFIG presetConfig = { 0 };
+        NV_ENC_PRESET_CONFIG presetConfig = {};
         presetConfig.version = NV_ENC_PRESET_CONFIG_VER;
         presetConfig.presetCfg.version = NV_ENC_CONFIG_VER;
         errorCode = pNvEncodeAPI->nvEncGetEncodePresetConfig(pEncoderInterface, nvEncInitializeParams.encodeGUID, nvEncInitializeParams.presetGUID, &presetConfig);
@@ -110,7 +110,7 @@ namespace webrtc
         nvEncConfig.encodeCodecConfig.h264Config.level = NV_ENC_LEVEL_H264_51;
 #pragma endregion
 #pragma region get encoder capability
-        NV_ENC_CAPS_PARAM capsParam = { 0 };
+        NV_ENC_CAPS_PARAM capsParam = {};
         capsParam.version = NV_ENC_CAPS_PARAM_VER;
         capsParam.capsToQuery = NV_ENC_CAPS_ASYNC_ENCODE_SUPPORT;
         int32 asyncMode = 0;
@@ -284,7 +284,7 @@ namespace webrtc
         uint32 bufferIndexToWrite = frameCount % bufferedFrameNum;
         Frame& frame = bufferedFrames[bufferIndexToWrite];
 #pragma region configure per-frame encode parameters
-        NV_ENC_PIC_PARAMS picParams = { 0 };
+        NV_ENC_PIC_PARAMS picParams = {};
         picParams.version = NV_ENC_PIC_PARAMS_VER;
         picParams.pictureStruct = NV_ENC_PIC_STRUCT_FRAME;
         picParams.inputBuffer = frame.inputFrame.mappedResource;
@@ -312,7 +312,7 @@ namespace webrtc
     void NvEncoder::ProcessEncodedFrame(Frame& frame, int64_t timestamp_us)
     {
 #pragma region retrieve encoded frame from output buffer
-        NV_ENC_LOCK_BITSTREAM lockBitStream = { 0 };
+        NV_ENC_LOCK_BITSTREAM lockBitStream = {};
         lockBitStream.version = NV_ENC_LOCK_BITSTREAM_VER;
         lockBitStream.outputBitstream = frame.outputFrame;
         lockBitStream.doNotWait = nvEncInitializeParams.enableEncodeAsync;
@@ -347,7 +347,8 @@ namespace webrtc
 
     NV_ENC_REGISTERED_PTR NvEncoder::RegisterResource(NV_ENC_INPUT_RESOURCE_TYPE inputType, void *buffer)
     {
-        NV_ENC_REGISTER_RESOURCE registerResource = { NV_ENC_REGISTER_RESOURCE_VER };
+        NV_ENC_REGISTER_RESOURCE registerResource = {};
+        registerResource.version = NV_ENC_REGISTER_RESOURCE_VER;
         registerResource.resourceType = inputType;
         registerResource.resourceToRegister = buffer;
 
@@ -369,7 +370,7 @@ namespace webrtc
     }
     void NvEncoder::MapResources(InputFrame& inputFrame)
     {
-        NV_ENC_MAP_INPUT_RESOURCE mapInputResource = { 0 };
+        NV_ENC_MAP_INPUT_RESOURCE mapInputResource = {};
         mapInputResource.version = NV_ENC_MAP_INPUT_RESOURCE_VER;
         mapInputResource.registeredResource = inputFrame.registeredResource;
         errorCode = pNvEncodeAPI->nvEncMapInputResource(pEncoderInterface, &mapInputResource);
@@ -378,7 +379,7 @@ namespace webrtc
     }
     NV_ENC_OUTPUT_PTR NvEncoder::InitializeBitstreamBuffer()
     {
-        NV_ENC_CREATE_BITSTREAM_BUFFER createBitstreamBuffer = { 0 };
+        NV_ENC_CREATE_BITSTREAM_BUFFER createBitstreamBuffer = {};
         createBitstreamBuffer.version = NV_ENC_CREATE_BITSTREAM_BUFFER_VER;
         errorCode = pNvEncodeAPI->nvEncCreateBitstreamBuffer(pEncoderInterface, &createBitstreamBuffer);
         checkf(NV_RESULT(errorCode), StringFormat("nvEncCreateBitstreamBuffer error is %d", errorCode).c_str());

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoder.cpp
@@ -74,7 +74,13 @@ namespace webrtc
         nvEncInitializeParams.darWidth = m_width;
         nvEncInitializeParams.darHeight = m_height;
         nvEncInitializeParams.encodeGUID = NV_ENC_CODEC_H264_GUID;
-        nvEncInitializeParams.presetGUID = NV_ENC_PRESET_P4_GUID;
+
+// todo(kazuki):: fix workaround
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        nvEncInitializeParams.presetGUID = NV_ENC_PRESET_LOW_LATENCY_HQ_GUID;
+#pragma clang diagnostic pop
+
         nvEncInitializeParams.frameRateNum = m_frameRate;
         nvEncInitializeParams.frameRateDen = 1;
         nvEncInitializeParams.enablePTD = 1;

--- a/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SoftwareCodec/SoftwareEncoder.cpp
@@ -15,9 +15,9 @@ namespace webrtc
 
     SoftwareEncoder::SoftwareEncoder(int width, int height, IGraphicsDevice* device, UnityRenderingExtTextureFormat textureFormat) :
     m_device(device),
+    m_encodeTex(nullptr),
     m_width(width),
     m_height(height),
-    m_encodeTex(nullptr),
     m_textureFormat(textureFormat)
     {
     }

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -26,6 +26,8 @@ namespace unity
 {
 namespace webrtc
 {
+    std::unique_ptr<ContextManager> ContextManager::s_instance;
+
     ContextManager* ContextManager::GetInstance()
     {
         if (s_instance == nullptr)

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -154,8 +154,7 @@ namespace webrtc
         config.enable_implicit_rollback = true;
         return true;
     }
-#pragma warning(push)
-#pragma warning(disable: 4715)
+
     webrtc::SdpType ConvertSdpType(RTCSdpType type)
     {
         switch (type)
@@ -188,11 +187,9 @@ namespace webrtc
             throw std::invalid_argument("Unknown SdpType");
         }
     }
-#pragma warning(pop)
 
     Context::Context(int uid, UnityEncoderType encoderType, bool forTest)
-        : m_uid(uid)
-        , m_encoderType(encoderType)
+        : m_encoderType(encoderType)
         , m_workerThread(rtc::Thread::CreateWithSocketServer())
         , m_signalingThread(rtc::Thread::CreateWithSocketServer())
         , m_taskQueueFactory(CreateDefaultTaskQueueFactory())

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -26,13 +26,19 @@ namespace unity
 {
 namespace webrtc
 {
-
-    ContextManager ContextManager::s_instance;
+    ContextManager* ContextManager::GetInstance()
+    {
+        if (s_instance == nullptr)
+        {
+            s_instance = std::make_unique<ContextManager>();
+        }
+        return s_instance.get();
+    }
 
     Context* ContextManager::GetContext(int uid) const
     {
-        auto it = s_instance.m_contexts.find(uid);
-        if (it != s_instance.m_contexts.end()) {
+        auto it = s_instance->m_contexts.find(uid);
+        if (it != s_instance->m_contexts.end()) {
             return it->second.get();
         }
         return nullptr;
@@ -40,13 +46,13 @@ namespace webrtc
 
     Context* ContextManager::CreateContext(int uid, UnityEncoderType encoderType, bool forTest)
     {
-        auto it = s_instance.m_contexts.find(uid);
-        if (it != s_instance.m_contexts.end()) {
+        auto it = s_instance->m_contexts.find(uid);
+        if (it != s_instance->m_contexts.end()) {
             DebugLog("Using already created context with ID %d", uid);
             return nullptr;
         }
         auto ctx = new Context(uid, encoderType, forTest);
-        s_instance.m_contexts[uid].reset(ctx);
+        s_instance->m_contexts[uid].reset(ctx);
         return ctx;
     }
 
@@ -57,7 +63,7 @@ namespace webrtc
 
     bool ContextManager::Exists(Context *context)
     {
-        for(auto it = s_instance.m_contexts.begin(); it != s_instance.m_contexts.end(); ++it)
+        for(auto it = s_instance->m_contexts.begin(); it != s_instance->m_contexts.end(); ++it)
         {
             if(it->second.get() == context)
                 return true;
@@ -67,10 +73,10 @@ namespace webrtc
 
     void ContextManager::DestroyContext(int uid)
     {
-        auto it = s_instance.m_contexts.find(uid);
-        if (it != s_instance.m_contexts.end())
+        auto it = s_instance->m_contexts.find(uid);
+        if (it != s_instance->m_contexts.end())
         {
-            s_instance.m_contexts.erase(it);
+            s_instance->m_contexts.erase(it);
             DebugLog("Unregistered context with ID %d", uid);
         }
     }
@@ -184,10 +190,10 @@ namespace webrtc
 
     Context::Context(int uid, UnityEncoderType encoderType, bool forTest)
         : m_uid(uid)
+        , m_encoderType(encoderType)
         , m_workerThread(rtc::Thread::CreateWithSocketServer())
         , m_signalingThread(rtc::Thread::CreateWithSocketServer())
         , m_taskQueueFactory(CreateDefaultTaskQueueFactory())
-        , m_encoderType(encoderType)
     {
         m_workerThread->Start();
         m_signalingThread->Start();
@@ -496,10 +502,14 @@ namespace webrtc
         rtc::scoped_refptr<PeerConnectionObject> obj =
                 new rtc::RefCountedObject<PeerConnectionObject>(*this);
         PeerConnectionDependencies dependencies(obj);
-        obj->connection = m_peerConnectionFactory->CreatePeerConnection(
+        auto connection = m_peerConnectionFactory->CreatePeerConnectionOrError(
                 config, std::move(dependencies));
-        if (obj->connection == nullptr)
+        if (!connection.ok())
+        {
+            RTC_LOG(LS_ERROR) << connection.error().message();
             return nullptr;
+        }
+        obj->connection = connection.MoveValue();
         const PeerConnectionObject* ptr = obj.get();
         m_mapClients[ptr] = std::move(obj);
         return m_mapClients[ptr].get();

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -9,12 +9,11 @@
 #include "UnityVideoTrackSource.h"
 #include "Codec/IEncoder.h"
 
-using namespace ::webrtc;
-
 namespace unity
 {
 namespace webrtc
 {
+    using namespace ::webrtc;
 
     class Context;
     class IGraphicsDevice;
@@ -23,8 +22,9 @@ namespace webrtc
     class ContextManager
     {
     public:
-        static ContextManager* GetInstance() { return &s_instance; }
-     
+        static ContextManager* GetInstance();
+        ~ContextManager();
+
         Context* GetContext(int uid) const;
         Context* CreateContext(int uid, UnityEncoderType encoderType, bool forTest);
         void DestroyContext(int uid);
@@ -33,9 +33,8 @@ namespace webrtc
         using ContextPtr = std::unique_ptr<Context>;
         Context* curContext = nullptr;
     private:
-        ~ContextManager();
         std::map<int, ContextPtr> m_contexts;
-        static ContextManager s_instance;
+        static std::unique_ptr<ContextManager> s_instance;
     };
 
     struct VideoEncoderParameter

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -155,7 +155,6 @@ namespace webrtc
         std::mutex mutex;
 
     private:
-        int m_uid;
         UnityEncoderType m_encoderType;
         std::unique_ptr<rtc::Thread> m_workerThread;
         std::unique_ptr<rtc::Thread> m_signalingThread;

--- a/Plugin~/WebRTCPlugin/DataChannelObject.cpp
+++ b/Plugin~/WebRTCPlugin/DataChannelObject.cpp
@@ -55,7 +55,6 @@ namespace webrtc
             size_t size = buffer.data.size();
             if (onMessage != nullptr)
             {
-#pragma warning(suppress: 4267)
                 onMessage(this->dataChannel, buffer.data.data(), static_cast<int32_t>(size));
             }
         }

--- a/Plugin~/WebRTCPlugin/DataChannelObject.cpp
+++ b/Plugin~/WebRTCPlugin/DataChannelObject.cpp
@@ -56,7 +56,7 @@ namespace webrtc
             if (onMessage != nullptr)
             {
 #pragma warning(suppress: 4267)
-                onMessage(this->dataChannel, buffer.data.data(), size);
+                onMessage(this->dataChannel, buffer.data.data(), static_cast<int32_t>(size));
             }
         }
     }

--- a/Plugin~/WebRTCPlugin/DataChannelObject.h
+++ b/Plugin~/WebRTCPlugin/DataChannelObject.h
@@ -9,7 +9,7 @@ namespace webrtc
 
     class PeerConnectionObject;
     class DataChannelObject;
-    using DelegateOnMessage = void(*)(DataChannelInterface*, const byte*, int);
+    using DelegateOnMessage = void(*)(DataChannelInterface*, const byte*, int32_t);
     using DelegateOnOpen = void(*)(DataChannelInterface*);
     using DelegateOnClose = void(*)(DataChannelInterface*);
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -324,9 +324,9 @@ namespace webrtc
         bool PlayoutThreadProcess();
 
         const int32_t kFrameLengthMs = 10;
-        const size_t kBytesPerSample = 2;
+        const int32_t kBytesPerSample = 2;
         const size_t kChannels = 2;
-        const size_t kSamplingRate = 48000;
+        const int32_t kSamplingRate = 48000;
         const size_t kSamplesPerFrame = kSamplingRate * kFrameLengthMs / 1000;
         std::vector<int16_t> audio_data;
         std::unique_ptr<rtc::TaskQueue> taskQueue_;

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.cpp
@@ -48,13 +48,13 @@ namespace webrtc
 
     int32_t DummyVideoEncoder::RegisterEncodeCompleteCallback(webrtc::EncodedImageCallback* callback)
     {
-        this->callback = callback;
+        this->m_callback = callback;
         return WEBRTC_VIDEO_CODEC_OK;
     }
 
     int32_t DummyVideoEncoder::Release()
     {
-        this->callback = nullptr;
+        this->m_callback = nullptr;
         this->m_setKeyFrame.disconnect_all();
         this->m_setRates.disconnect_all();
         return WEBRTC_VIDEO_CODEC_OK;
@@ -103,7 +103,7 @@ namespace webrtc
         codecInfo.codecType = webrtc::kVideoCodecH264;
         codecInfo.codecSpecific.H264.packetization_mode = webrtc::H264PacketizationMode::NonInterleaved;
 
-        const auto result = callback->OnEncodedImage(m_encodedImage, &codecInfo);
+        const auto result = m_callback->OnEncodedImage(m_encodedImage, &codecInfo);
         if (result.error != webrtc::EncodedImageCallback::Result::OK)
         {
             LogPrint("Encode callback failed %d", result.error);
@@ -120,7 +120,7 @@ namespace webrtc
 
     void DummyVideoEncoder::SetRates(const RateControlParameters& parameters)
     {
-        int64_t frameRate = parameters.framerate_fps;
+        int64_t frameRate = static_cast<int64_t>(parameters.framerate_fps);
 
         uint32_t bitRate = parameters.bitrate.get_sum_bps();
 

--- a/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
+++ b/Plugin~/WebRTCPlugin/DummyVideoEncoder.h
@@ -33,7 +33,7 @@ namespace webrtc
         // Default fallback: Just use the sum of bitrates as the single target rate.
         virtual void SetRates(const RateControlParameters& parameters) override;
     private:
-        webrtc::EncodedImageCallback* callback = nullptr;
+        webrtc::EncodedImageCallback* m_callback = nullptr;
         webrtc::EncodedImage m_encodedImage;
         webrtc::H264BitstreamParser m_h264BitstreamParser;
         webrtc::VideoCodec m_codec;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
@@ -91,8 +91,6 @@ CUresult CudaContext::Init(const VkInstance instance, VkPhysicalDevice physicalD
     }
 
     CUdevice cuDevice = 0;
-    bool foundDevice = false;
-
     result = cuInit(0);
     if (result != CUDA_SUCCESS) {
         return result;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -114,7 +114,11 @@ namespace webrtc
         textureDescriptor.pixelFormat = ConvertFormat(textureFormat);
         textureDescriptor.width = width;
         textureDescriptor.height = height;
-        textureDescriptor.allowGPUOptimizedContents = false;
+        if (@available(macOS 10.14, *)) {
+            textureDescriptor.allowGPUOptimizedContents = false;
+        } else {
+            // Fallback on earlier versions
+        }
 #if TARGET_OS_OSX
         textureDescriptor.storageMode = MTLStorageMode(MTLStorageModeManaged);
 #else

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -115,7 +115,11 @@ namespace webrtc
         textureDescriptor.width = width;
         textureDescriptor.height = height;
         if (@available(macOS 10.14, *)) {
-            textureDescriptor.allowGPUOptimizedContents = false;
+            if (@available(iOS 12.0, *)) {
+                textureDescriptor.allowGPUOptimizedContents = false;
+            } else {
+                // Fallback on earlier versions
+            }
         } else {
             // Fallback on earlier versions
         }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -114,12 +114,8 @@ namespace webrtc
         textureDescriptor.pixelFormat = ConvertFormat(textureFormat);
         textureDescriptor.width = width;
         textureDescriptor.height = height;
-        if (@available(macOS 10.14, *)) {
-            if (@available(iOS 12.0, *)) {
-                textureDescriptor.allowGPUOptimizedContents = false;
-            } else {
-                // Fallback on earlier versions
-            }
+        if (@available(macOS 10.14, iOS 12.0, *)) {
+            textureDescriptor.allowGPUOptimizedContents = false;
         } else {
             // Fallback on earlier versions
         }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.h
@@ -31,10 +31,14 @@ private:
 
 //---------------------------------------------------------------------------------------------------------------------
 
+// todo(kazuki):: fix workaround
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wint-to-void-pointer-cast"
 void* OpenGLTexture2D::GetNativeTexturePtrV() { return (void*)m_texture; }
 const void* OpenGLTexture2D::GetNativeTexturePtrV() const { return (void*)m_texture; };
 void* OpenGLTexture2D::GetEncodeTexturePtrV() { return (void*)m_texture; }
 const void* OpenGLTexture2D::GetEncodeTexturePtrV() const { return (const void*)m_texture; }
+#pragma clang diagnostic pop
 
 } // end namespace webrtd
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/ListOfVulkanFunctions.inl
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/ListOfVulkanFunctions.inl
@@ -1,3 +1,7 @@
+// todo(kazuki):: fix workaround
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+
 #ifndef EXPORTED_VULKAN_FUNCTION
 #define EXPORTED_VULKAN_FUNCTION( function )
 #endif
@@ -76,3 +80,5 @@ DEVICE_VULKAN_FUNCTION(vkQueueSubmit)
 DEVICE_VULKAN_FUNCTION(vkDestroyPipelineLayout)
 
 #undef DEVICE_LEVEL_VULKAN_FUNCTION
+
+#pragma clang diagnostic pop

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/LoadVulkanFunctions.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/LoadVulkanFunctions.cpp
@@ -9,6 +9,10 @@ namespace unity
 namespace webrtc
 {
 
+// todo(kazuki):: fix workaround
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+
 #define EXPORTED_VULKAN_FUNCTION(func) PFN_##func func;
 #define GLOBAL_VULKAN_FUNCTION(func) PFN_##func func;
 #define INSTANCE_VULKAN_FUNCTION(func) PFN_##func func;
@@ -77,6 +81,7 @@ bool LoadDeviceVulkanFunction(VkDevice device) {
 #include "ListOfVulkanFunctions.inl"
     return true;
 }
+#pragma clang diagnostic pop
 
 } // namespace webrtc
 } // namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<UnityVulkanImage> VulkanGraphicsDevice::AccessTexture(void* ptr)
     {
         return nullptr;
     }
-    return std::move(unityVulkanImage);
+    return unityVulkanImage;
 }
 
 //Returns null if failed

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -14,12 +14,15 @@ VulkanGraphicsDevice::VulkanGraphicsDevice( IUnityGraphicsVulkan* unityVulkan, c
     const VkPhysicalDevice physicalDevice,
     const VkDevice device, const VkQueue graphicsQueue, const uint32_t queueFamilyIndex)
     : m_unityVulkan(unityVulkan)
-    , m_instance(instance)
     , m_physicalDevice(physicalDevice)
     , m_device(device)
     , m_graphicsQueue(graphicsQueue)
     , m_commandPool(VK_NULL_HANDLE)
     , m_queueFamilyIndex(queueFamilyIndex)
+    , m_allocator(nullptr)
+#if CUDA_PLATFORM
+    , m_instance(instance)
+#endif
 {
 }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <vulkan/vulkan.h>
+#include "IUnityRenderingExtensions.h"
+#include "IUnityGraphicsVulkan.h"
 #include "WebRTCConstants.h"
 #if CUDA_PLATFORM
 #include "GraphicsDevice/Cuda/CudaContext.h"
@@ -38,22 +41,20 @@ public:
     virtual CUcontext GetCuContext() override { return m_cudaContext.GetContext(); }
 #endif
 private:
-
     VkResult CreateCommandPool();
 
     IUnityGraphicsVulkan*   m_unityVulkan;
-    VkInstance              m_instance;
     VkPhysicalDevice        m_physicalDevice;
     VkDevice                m_device;
     VkQueue                 m_graphicsQueue;
     VkCommandPool           m_commandPool;
     uint32_t m_queueFamilyIndex;
-
+    VkAllocationCallbacks* m_allocator;
 #if CUDA_PLATFORM
+    VkInstance m_instance;
     CudaContext m_cudaContext;
     bool m_isCudaSupport;
 #endif
-    const VkAllocationCallbacks* m_allocator = nullptr;
 };
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -3,12 +3,11 @@
 #include "DataChannelObject.h"
 #include "PeerConnectionStatsCollectorCallback.h"
 
-using namespace ::webrtc;
-
 namespace unity
 {
 namespace webrtc
 {
+    using namespace ::webrtc;
 
     using DelegateCreateSDSuccess = void(*)(PeerConnectionObject*, RTCSdpType, const char*);
     using DelegateCreateSDFailure = void(*)(PeerConnectionObject*, webrtc::RTCErrorType, const char*);

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -2,12 +2,12 @@
 
 #include <mutex>
 
-using namespace ::webrtc;
-
 namespace unity
 {
 namespace webrtc
 {
+    using namespace ::webrtc;
+
     class UnityAudioTrackSource : public LocalAudioSource
     {
     public:

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -27,7 +27,6 @@ namespace webrtc
 
     UnityVideoDecoderFactory::UnityVideoDecoderFactory(bool forTest)
     : internal_decoder_factory_(CreateDecoderFactory())
-    , forTest_(forTest)
     {
     }
 

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -27,6 +27,9 @@ namespace webrtc
 
     UnityVideoDecoderFactory::UnityVideoDecoderFactory(bool forTest)
     : internal_decoder_factory_(CreateDecoderFactory())
+#if CUDA_PLATFORM
+    , forTest_(forTest)
+#endif
     {
     }
 

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
@@ -15,6 +15,9 @@ namespace webrtc
         UnityVideoDecoderFactory(bool forTest);
     private:
         const std::unique_ptr<VideoDecoderFactory> internal_decoder_factory_;
+#if CUDA_PLATFORM
+        bool forTest_;
+#endif
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
@@ -15,7 +15,6 @@ namespace webrtc
         UnityVideoDecoderFactory(bool forTest);
     private:
         const std::unique_ptr<VideoDecoderFactory> internal_decoder_factory_;
-        bool forTest_;
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -108,7 +108,7 @@ namespace webrtc
         #if defined(__clang__) || defined(__GNUC__)
         __attribute__((optnone))
         #endif
-        explicit operator const absl::optional<T>&() const
+        explicit operator const absl::optional<T>() const
         {
             absl::optional<T> dst = absl::nullopt;
             if (hasValue)
@@ -1053,9 +1053,10 @@ extern "C"
         return transceiver->direction();
     }
 
-    UNITY_INTERFACE_EXPORT void TransceiverSetDirection(RtpTransceiverInterface* transceiver, RtpTransceiverDirection direction)
+    UNITY_INTERFACE_EXPORT RTCErrorType TransceiverSetDirection(RtpTransceiverInterface* transceiver, RtpTransceiverDirection direction)
     {
-        transceiver->SetDirection(direction);
+        RTCError error = transceiver->SetDirectionWithError(direction);
+        return error.type();
     }
 
     struct RTCRtpCodecCapability
@@ -1078,7 +1079,7 @@ extern "C"
     UNITY_INTERFACE_EXPORT RTCErrorType TransceiverSetCodecPreferences(RtpTransceiverInterface* transceiver, RTCRtpCodecCapability* codecs, size_t length)
     {
         std::vector<RtpCodecCapability> _codecs(length);
-        for(int i = 0; i < length; i++)
+        for(size_t i = 0; i < length; i++)
         {
             std::string mimeType = ConvertString(codecs[i].mimeType);
             std::tie(_codecs[i].kind, _codecs[i].name) = ConvertMimeType(mimeType);

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -55,7 +55,7 @@ namespace webrtc
         int32_t length;
         T* values;
 
-        T& operator[](int i) const
+        T& operator[](size_t i) const
         {
             return values[i];
         }
@@ -155,7 +155,7 @@ namespace webrtc
         while (true)
         {
             pos = s.find(delimiter);
-            int length = pos;
+            size_t length = pos;
             if(pos == std::string::npos)
                 length = str.length();
             if (length == 0)

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -140,7 +140,7 @@ namespace webrtc
     std::string StringFormat(const std::string& format, Args ... args)
     {
         size_t size = snprintf(nullptr, 0, format.c_str(), args ...) + 1;
-        std::unique_ptr<char[]> buf(char[size]);
+        std::unique_ptr<char[]> buf(new char[size]);
         snprintf(buf.get(), size, format.c_str(), args ...);
         return std::string(buf.get(), buf.get() + size - 1);
     }

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -136,14 +136,6 @@ namespace webrtc
 #if SUPPORT_OPENGL_CORE || SUPPORT_OPENGL_ES
     void OnOpenGLDebugMessage( GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam);
 #endif
-    template<class ... Args>
-    std::string StringFormat(const std::string& format, Args ... args)
-    {
-        size_t size = snprintf(nullptr, 0, format.c_str(), args ...) + 1;
-        std::unique_ptr<char[]> buf(new char[size]);
-        snprintf(buf.get(), size, format.c_str(), args ...);
-        return std::string(buf.get(), buf.get() + size - 1);
-    }
 
     using byte = unsigned char;
     using uint8 = unsigned char;

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -100,11 +100,14 @@
 
 #endif
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
 #if _WIN32 && _DEBUG
 #define _CRTDBG_MAP_ALLOC
 #include <crtdbg.h>
 #define new new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #endif
+#pragma clang diagnostic pop
 
 // audio codec isac
 #define WEBRTC_USE_BUILTIN_ISAC_FLOAT 1
@@ -137,7 +140,7 @@ namespace webrtc
     std::string StringFormat(const std::string& format, Args ... args)
     {
         size_t size = snprintf(nullptr, 0, format.c_str(), args ...) + 1;
-        std::unique_ptr<char[]> buf(new char[size]);
+        std::unique_ptr<char[]> buf(char[size]);
         snprintf(buf.get(), size, format.c_str(), args ...);
         return std::string(buf.get(), buf.get() + size - 1);
     }

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -43,11 +43,6 @@ endif()
 
 include(GoogleTest)
 
-target_compile_definitions(WebRTCLibTest
-  PRIVATE 
-    "$<$<CONFIG:Debug>:DEBUG>"
-)
-
 if(NOT iOS)
   target_include_directories(WebRTCLibTest
     PRIVATE

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -43,6 +43,21 @@ endif()
 
 include(GoogleTest)
 
+target_compile_options(WebRTCLibTest
+  PRIVATE
+    -Wall
+    -Wextra
+    -Wno-missing-field-initializers
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-padded
+)
+
+target_compile_definitions(WebRTCLibTest
+  PRIVATE 
+    "$<$<CONFIG:Debug>:DEBUG>"
+)
+
 if(NOT iOS)
   target_include_directories(WebRTCLibTest
     PRIVATE

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -43,17 +43,6 @@ endif()
 
 include(GoogleTest)
 
-target_compile_options(WebRTCLibTest
-  PRIVATE
-    -Wall
-    -Wextra
-    -Wno-c++98-compat
-    -Wno-c++98-compat-pedantic
-    -Wno-missing-field-initializers
-    -Wno-missing-prototypes
-    -Wno-padded
-)
-
 target_compile_definitions(WebRTCLibTest
   PRIVATE 
     "$<$<CONFIG:Debug>:DEBUG>"

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -47,9 +47,10 @@ target_compile_options(WebRTCLibTest
   PRIVATE
     -Wall
     -Wextra
-    -Wno-missing-field-initializers
     -Wno-c++98-compat
     -Wno-c++98-compat-pedantic
+    -Wno-missing-field-initializers
+    -Wno-missing-prototypes
     -Wno-padded
 )
 

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -38,7 +38,6 @@ protected:
 
     static void OnFrameSizeChange(UnityVideoRenderer* renderer, int width, int height)
     {
-        RTC_LOG(LS_INFO) << StringFormat("OnFrameSizeChanges width:%d height:%d", width, height).c_str();
     }
 };
 TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
@@ -143,7 +142,7 @@ TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
     context->RemoveRefPtr(source);
 }
 
-INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, ContextTest, testing::ValuesIn(VALUES_TEST_ENV));
+INSTANTIATE_TEST_SUITE_P(GraphicsDeviceParameters, ContextTest, testing::ValuesIn(VALUES_TEST_ENV));
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -67,7 +67,7 @@ TEST_P(GraphicsDeviceTest, ConvertRGBToI420) {
 }
 #endif
 
-INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters, GraphicsDeviceTest, testing::ValuesIn(VALUES_TEST_ENV));
+INSTANTIATE_TEST_SUITE_P(GraphicsDeviceParameters, GraphicsDeviceTest, testing::ValuesIn(VALUES_TEST_ENV));
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -357,8 +357,9 @@ IUnityInterface* CreateUnityInterface(UnityGfxRenderer renderer) {
     case kUnityGfxRendererMetal:
         return nullptr;
 #endif
+    default:
+        return nullptr;
     }
-    return nullptr;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -387,8 +388,9 @@ void* CreateGfxDevice(UnityGfxRenderer renderer)
     case kUnityGfxRendererMetal:
         return CreateDeviceMetal();
 #endif
+    default:
+        return nullptr;
     }
-    return nullptr;
 }
 //---------------------------------------------------------------------------------------------------------------------
 
@@ -417,6 +419,8 @@ void DestroyGfxDevice(void* pGfxDevice, UnityGfxRenderer renderer)
     case kUnityGfxRendererMetal:
         return;
 #endif
+    default:
+        return;
     }
 }
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -158,7 +158,7 @@ int32_t GetPhysicalDeviceIndex(
     VkInstance instance, std::vector<VkPhysicalDevice>& list, bool* found)
 {
     std::array<uint8_t, VK_UUID_SIZE> deviceUUID;
-    for(int i = 0; i < list.size(); ++i)
+    for(size_t i = 0; i < list.size(); ++i)
     {
         VkPhysicalDevice physicalDevice = list[i];
         if (!VulkanUtility::GetPhysicalDeviceUUIDInto(

--- a/Plugin~/WebRTCPluginTest/NvCodec/CudaDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/CudaDeviceTest.cpp
@@ -17,7 +17,7 @@ TEST_P(CudaDeviceTest, IsNvSupported) {
     EXPECT_TRUE(m_device->IsCudaSupport());
 }
 
-INSTANTIATE_TEST_CASE_P(GraphicsDeviceParameters,
+INSTANTIATE_TEST_SUITE_P(GraphicsDeviceParameters,
     CudaDeviceTest, testing::ValuesIn(VALUES_TEST_ENV));
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderTest.cpp
@@ -49,7 +49,7 @@ TEST_P(NvEncoderTest, EncodeFrame) {
     EXPECT_EQ(before + 1, after);
 }
 
-INSTANTIATE_TEST_CASE_P( GraphicsDeviceParameters, NvEncoderTest, testing::ValuesIn(VALUES_TEST_ENV));
+INSTANTIATE_TEST_SUITE_P( GraphicsDeviceParameters, NvEncoderTest, testing::ValuesIn(VALUES_TEST_ENV));
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -106,7 +106,7 @@ TEST_P(VideoRendererTest, ConvertVideoFrameToTexture)
     EXPECT_NE(nullptr, data);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GraphicsDeviceParameters,
     VideoRendererTest,
     testing::ValuesIn(VALUES_TEST_ENV));

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -65,7 +65,6 @@ protected:
 
     static void OnFrameSizeChange(UnityVideoRenderer* renderer, int width, int height)
     {
-        RTC_LOG(LS_INFO) << StringFormat("OnFrameSizeChanges width:%d height:%d", width, height).c_str();
     }
 
     void SendTestFrame(int width, int height)

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -98,7 +98,7 @@ TEST_P(VideoTrackSourceTest, SendTestFrame)
 }
 #endif
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     GraphicsDeviceParameters,
     VideoTrackSourceTest,
     testing::ValuesIn(VALUES_TEST_ENV));

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -51,7 +51,15 @@ namespace Unity.WebRTC
         public RTCRtpTransceiverDirection Direction
         {
             get { return NativeMethods.TransceiverGetDirection(GetSelfOrThrow()); }
-            set { NativeMethods.TransceiverSetDirection(GetSelfOrThrow(), value); }
+            set
+            {
+                RTCErrorType errorType = NativeMethods.TransceiverSetDirection(GetSelfOrThrow(), value);
+                if (errorType != RTCErrorType.None)
+                {
+                    var error = new RTCError { errorType = errorType };
+                    throw new RTCErrorException(ref error);
+                }
+            }
         }
 
         /// <summary>

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -986,7 +986,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern RTCRtpTransceiverDirection TransceiverGetDirection(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]
-        public static extern void TransceiverSetDirection(IntPtr transceiver, RTCRtpTransceiverDirection direction);
+        public static extern RTCErrorType TransceiverSetDirection(IntPtr transceiver, RTCRtpTransceiverDirection direction);
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType TransceiverSetCodecPreferences(IntPtr transceiver, IntPtr capabilities, long length);
         [DllImport(WebRTC.Lib)]


### PR DESCRIPTION
This change enforce the feature of clang compiler warning to prevent mistakes of c/c++.
Use `SYSTEM` keyword for `target_include_directories` command in CMake to suppress warnings in external headers.
However, Visual Studio Generator of CMake has not been supported suppression warnings of external headers yet. So MSVC don't take warnings as errors. 
https://gitlab.kitware.com/cmake/cmake/-/issues/17904