### PR TITLE
fix: Set enable fpic option for NvCodec library on Linux

### DIFF
--- a/Plugin~/NvCodec/CMakeLists.txt
+++ b/Plugin~/NvCodec/CMakeLists.txt
@@ -40,10 +40,18 @@ else ()
   find_library(NVENCODEAPI_LIB nvidia-encode)
 endif()
 
-if(WIN32)
+if(Windows)
   # Select runtime library (MT, MTD) on windows platform
   set_target_properties(NvCodec
     PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+endif()
+
+if(Linux)
+  # enable -fPIC option
+  set_target_properties(NvCodec
+    PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
   )
 endif()
 

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -73,7 +73,6 @@ target_compile_definitions(WebRTCLib
     $<$<CONFIG:Debug>:DEBUG>
 )
 
-
 if(iOS OR macOS)
   target_sources(WebRTCLib
     PRIVATE
@@ -190,6 +189,7 @@ elseif(Linux)
     PRIVATE
       ${WEBRTC_LIBRARY}
       ${OPENGL_opengl_LIBRARY}
+      ${NVCODEC_LIBRARIES}
       ${Vulkan_LIBRARY}
       ${GLIB_LIBRARIES}
   )


### PR DESCRIPTION
Fixed cmake code to set enable fpic option of clang compiler for NvCodec library.