### PR TITLE
feat: Profiling codec CPU performance on Unity Profiler window

### DIFF
--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(WebRTCLib
     PeerConnectionStatsCollectorCallback.cpp
     PeerConnectionStatsCollectorCallback.h
     PlatformBase.h
+    ProfilerMarkerFactory.cpp
+    ProfilerMarkerFactory.h
     SetSessionDescriptionObserver.cpp
     SetSessionDescriptionObserver.h
     ScopedProfiler.h
@@ -352,6 +354,7 @@ target_sources(WebRTCPlugin
     pch.cpp
     pch.h
     WebRTCPlugin.cpp
+    WebRTCPlugin.h
     UnityRenderEvent.cpp
     UnityVulkanInterfaceFunctions.h
 )

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvDecoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvDecoderImpl.cpp
@@ -28,7 +28,7 @@ namespace webrtc
     VideoDecoder::DecoderInfo NvDecoderImpl::GetDecoderInfo() const
     {
         VideoDecoder::DecoderInfo info;
-        info.implementation_name = "UnityNvDecoder";
+        info.implementation_name = "NvCodec";
         info.is_hardware_accelerated = true;
         return info;
     }

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -107,7 +107,7 @@ namespace webrtc
     VideoEncoder::EncoderInfo NvEncoderImpl::GetEncoderInfo() const
     {
         VideoEncoder::EncoderInfo info;
-        info.implementation_name = "UnityNvEncoder";
+        info.implementation_name = "NvCodec";
         info.is_hardware_accelerated = true;
         return info;
     }

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -104,6 +104,14 @@ namespace webrtc
 
     NvEncoderImpl::~NvEncoderImpl() { Release(); }
 
+    VideoEncoder::EncoderInfo NvEncoderImpl::GetEncoderInfo() const
+    {
+        VideoEncoder::EncoderInfo info;
+        info.implementation_name = "UnityNvEncoder";
+        info.is_hardware_accelerated = true;
+        return info;
+    }
+
     int NvEncoderImpl::InitEncode(const VideoCodec* codec, const VideoEncoder::Settings& settings)
     {
         if (!codec || codec->codecType != kVideoCodecH264)

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
@@ -61,6 +61,8 @@ namespace webrtc
         int32_t Encode(const ::webrtc::VideoFrame& frame, const std::vector<VideoFrameType>* frame_types) override;
         // Default fallback: Just use the sum of bitrates as the single target rate.
         void SetRates(const RateControlParameters& parameters) override;
+        // Returns meta-data about the encoder, such as implementation name.
+        EncoderInfo GetEncoderInfo() const override;
 
     protected:
         int32_t ProcessEncodedFrame(std::vector<uint8_t>& packet, const ::webrtc::VideoFrame& inputFrame);

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -51,7 +51,7 @@ namespace webrtc
         return nullptr;
     }
 
-    Context* ContextManager::CreateContext(int uid, IGraphicsDevice* gfxDevice)
+    Context* ContextManager::CreateContext(int uid, ContextDependencies& dependencies)
     {
         auto it = s_instance->m_contexts.find(uid);
         if (it != s_instance->m_contexts.end())
@@ -59,7 +59,7 @@ namespace webrtc
             DebugLog("Using already created context with ID %d", uid);
             return nullptr;
         }
-        s_instance->m_contexts[uid] = std::make_unique<Context>(gfxDevice);
+        s_instance->m_contexts[uid] = std::make_unique<Context>(dependencies);
         return s_instance->m_contexts[uid].get();
     }
 
@@ -184,7 +184,7 @@ namespace webrtc
         throw std::invalid_argument("Unknown SdpType");
     }
 
-    Context::Context(IGraphicsDevice* gfxDevice)
+    Context::Context(ContextDependencies& dependencies)
         : m_workerThread(rtc::Thread::CreateWithSocketServer())
         , m_signalingThread(rtc::Thread::CreateWithSocketServer())
         , m_taskQueueFactory(CreateDefaultTaskQueueFactory())
@@ -198,10 +198,10 @@ namespace webrtc
             RTC_FROM_HERE, [&]() { return new rtc::RefCountedObject<DummyAudioDevice>(m_taskQueueFactory.get()); });
 
         std::unique_ptr<webrtc::VideoEncoderFactory> videoEncoderFactory =
-            std::make_unique<UnityVideoEncoderFactory>(gfxDevice);
+            std::make_unique<UnityVideoEncoderFactory>(dependencies.device, dependencies.profiler);
 
         std::unique_ptr<webrtc::VideoDecoderFactory> videoDecoderFactory =
-            std::make_unique<UnityVideoDecoderFactory>(gfxDevice);
+            std::make_unique<UnityVideoDecoderFactory>(dependencies.device);
 
         rtc::scoped_refptr<AudioEncoderFactory> audioEncoderFactory = CreateAudioEncoderFactory();
         rtc::scoped_refptr<AudioDecoderFactory> audioDecoderFactory = CreateAudioDecoderFactory();

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -201,7 +201,7 @@ namespace webrtc
             std::make_unique<UnityVideoEncoderFactory>(dependencies.device, dependencies.profiler);
 
         std::unique_ptr<webrtc::VideoDecoderFactory> videoDecoderFactory =
-            std::make_unique<UnityVideoDecoderFactory>(dependencies.device);
+            std::make_unique<UnityVideoDecoderFactory>(dependencies.device, dependencies.profiler);
 
         rtc::scoped_refptr<AudioEncoderFactory> audioEncoderFactory = CreateAudioEncoderFactory();
         rtc::scoped_refptr<AudioDecoderFactory> audioDecoderFactory = CreateAudioDecoderFactory();

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -15,8 +15,15 @@ namespace webrtc
 {
     using namespace ::webrtc;
 
-    class Context;
     class IGraphicsDevice;
+    class ProfilerMarkerFactory;
+    struct ContextDependencies
+    {
+        IGraphicsDevice* device;
+        ProfilerMarkerFactory* profiler;
+    };
+
+    class Context;
     class MediaStreamObserver;
     class SetSessionDescriptionObserver;
     class ContextManager
@@ -26,7 +33,7 @@ namespace webrtc
         ~ContextManager();
 
         Context* GetContext(int uid) const;
-        Context* CreateContext(int uid, IGraphicsDevice* gfxDevice);
+        Context* CreateContext(int uid, ContextDependencies& dependencies);
         void DestroyContext(int uid);
         void SetCurContext(Context*);
         bool Exists(Context* context);
@@ -42,7 +49,7 @@ namespace webrtc
     class Context
     {
     public:
-        explicit Context(IGraphicsDevice* gfxDevice = nullptr);
+        explicit Context(ContextDependencies& dependencies);
         ~Context();
 
         bool ExistsRefPtr(const rtc::RefCountInterface* ptr) const

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
@@ -12,8 +12,6 @@ namespace webrtc
     public:
         static rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420Buffer(
             const uint32_t width, const uint32_t height, const uint32_t rowToRowInBytes, const uint8_t* srcData);
-        static IGraphicsDevice* GetGraphicsDevice();
-        static UnityGfxRenderer GetGfxRenderer();
         static void*
         TextureHandleToNativeGraphicsPtr(void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer);
     };

--- a/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.cpp
+++ b/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.cpp
@@ -1,0 +1,57 @@
+#include "pch.h"
+
+#include "IUnityInterface.h"
+#include "ProfilerMarkerFactory.h"
+#include "ScopedProfiler.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    std::unique_ptr<ProfilerMarkerFactory> ProfilerMarkerFactory::Create(IUnityInterfaces* unityInterfaces)
+    {
+        IUnityProfiler* profiler = unityInterfaces->Get<IUnityProfiler>();
+        if (!profiler)
+            return nullptr;
+        return std::unique_ptr<ProfilerMarkerFactory>(new ProfilerMarkerFactory(profiler));
+    }
+
+    ProfilerMarkerFactory::ProfilerMarkerFactory(IUnityProfiler* profiler)
+        : profiler_(profiler)
+    {
+    }
+    ProfilerMarkerFactory::~ProfilerMarkerFactory() { }
+
+    const UnityProfilerMarkerDesc* ProfilerMarkerFactory::CreateMarker(
+        const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount)
+    {
+        const UnityProfilerMarkerDesc* desc = nullptr;
+        int result = profiler_->CreateMarker(&desc, name, category, flags, eventDataCount);
+        if (result)
+        {
+            RTC_LOG(LS_ERROR) << "IUnityProfiler::CreateMarker error" << result;
+            throw;
+        }
+        return desc;
+    }
+
+    UnityProfilerCategoryId ProfilerMarkerFactory::CreateCategory(const char* name)
+    {
+        // todo(kazuki):
+        // return profiler_->CreateCategory(&desc, name, category, flags, eventDataCount);
+        return kUnityProfilerCategoryRender;
+    }
+
+    std::unique_ptr<const ScopedProfiler>
+    ProfilerMarkerFactory::CreateScopedProfiler(const UnityProfilerMarkerDesc& desc)
+    {
+        return std::make_unique<const ScopedProfiler>(profiler_, desc);
+    }
+
+    std::unique_ptr<const ScopedProfilerThread>
+    ProfilerMarkerFactory::CreateScopedProfilerThread(const char* groupName, const char* name)
+    {
+        return std::make_unique<const ScopedProfilerThread>(profiler_, groupName, name);
+    }
+}
+}

--- a/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.h
+++ b/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "IUnityProfiler.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    class ScopedProfiler;
+    class ScopedProfilerThread;
+    class ProfilerMarkerFactory
+    {
+    public:
+        static std::unique_ptr<ProfilerMarkerFactory> Create(IUnityInterfaces* unityInterfaces);
+
+        const UnityProfilerMarkerDesc* CreateMarker(
+            const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount);
+
+        // todo(kazuki):: support Unity2021.1 above
+        UnityProfilerCategoryId CreateCategory(const char* name);
+
+        std::unique_ptr<const ScopedProfiler> CreateScopedProfiler(const UnityProfilerMarkerDesc& desc);
+        std::unique_ptr<const ScopedProfilerThread> CreateScopedProfilerThread(const char* groupName, const char* name);
+
+        virtual ~ProfilerMarkerFactory();
+
+    protected:
+        ProfilerMarkerFactory(IUnityProfiler* profiler_);
+
+    private:
+        IUnityProfiler* profiler_;
+    };
+}
+}

--- a/Plugin~/WebRTCPlugin/ScopedProfiler.h
+++ b/Plugin~/WebRTCPlugin/ScopedProfiler.h
@@ -10,16 +10,29 @@ namespace webrtc
     class ScopedProfiler
     {
     public:
-        static IUnityProfiler* UnityProfiler;
-
-        ScopedProfiler(const UnityProfilerMarkerDesc& desc);
+        ScopedProfiler(IUnityProfiler* profiler, const UnityProfilerMarkerDesc& desc);
         ~ScopedProfiler();
 
     private:
         void operator=(const ScopedProfiler& src) const { }
         ScopedProfiler(const ScopedProfiler& src) { }
 
+        IUnityProfiler* profiler_;
         const UnityProfilerMarkerDesc* m_desc;
+    };
+
+    class ScopedProfilerThread
+    {
+    public:
+        ScopedProfilerThread(IUnityProfiler* profiler, const char* groupName, const char* name);
+        ~ScopedProfilerThread();
+
+    private:
+        void operator=(const ScopedProfilerThread& src) const { }
+        ScopedProfilerThread(const ScopedProfilerThread& src) { }
+
+        IUnityProfiler* profiler_;
+        UnityProfilerThreadId threadId_;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -281,7 +281,7 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         IGraphicsDevice* device = Plugin::GraphicsDevice();
         UnityGfxRenderer gfxRenderer = device->GetGfxRenderer();
         void* ptr = GraphicsUtility::TextureHandleToNativeGraphicsPtr(encodeData->texture, device, gfxRenderer);
-        Size size(encodeData->width, encodeData->height);
+        unity::webrtc::Size size(encodeData->width, encodeData->height);
         {
             std::unique_ptr<const ScopedProfiler> profiler;
             if (s_ProfilerMarkerFactory)

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -3,6 +3,8 @@
 #include <media/engine/internal_decoder_factory.h>
 
 #include "GraphicsDevice/GraphicsUtility.h"
+#include "ProfilerMarkerFactory.h"
+#include "ScopedProfiler.h"
 #include "UnityVideoDecoderFactory.h"
 
 #if CUDA_PLATFORM
@@ -21,6 +23,53 @@ namespace unity
 {
 namespace webrtc
 {
+    class UnityVideoDecoder : public VideoDecoder
+    {
+    public:
+        UnityVideoDecoder(std::unique_ptr<VideoDecoder> decoder, ProfilerMarkerFactory* profiler)
+            : decoder_(std::move(decoder))
+            , profiler_(profiler)
+            , marker_(nullptr)
+            , profilerThread_(nullptr)
+        {
+            if (profiler)
+                marker_ = profiler->CreateMarker(
+                    "UnityVideoDecoder.Decode", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
+        }
+        ~UnityVideoDecoder() override { }
+
+        int32_t InitDecode(const VideoCodec* codec_settings, int32_t number_of_cores) override
+        {
+            return decoder_->InitDecode(codec_settings, number_of_cores);
+        }
+        int32_t Decode(const EncodedImage& input_image, bool missing_frames, int64_t render_time_ms) override
+        {
+            if (!profilerThread_)
+                profilerThread_ = profiler_->CreateScopedProfilerThread("WebRTC", "VideoDecoder");
+
+            int32_t result;
+            {
+                std::unique_ptr<const ScopedProfiler> profiler;
+                if (profiler_)
+                    profiler = profiler_->CreateScopedProfiler(*marker_);
+                result = decoder_->Decode(input_image, missing_frames, render_time_ms);
+            }
+            return result;
+        }
+        int32_t RegisterDecodeCompleteCallback(DecodedImageCallback* callback) override
+        {
+            return decoder_->RegisterDecodeCompleteCallback(callback);
+        }
+        int32_t Release() override { return decoder_->Release(); }
+        DecoderInfo GetDecoderInfo() const override { return decoder_->GetDecoderInfo(); }
+
+    private:
+        std::unique_ptr<VideoDecoder> decoder_;
+        ProfilerMarkerFactory* profiler_;
+        const UnityProfilerMarkerDesc* marker_;
+        std::unique_ptr<const ScopedProfilerThread> profilerThread_;
+    };
+
     static webrtc::VideoDecoderFactory* CreateNativeDecoderFactory(IGraphicsDevice* gfxDevice)
     {
 #if UNITY_OSX || UNITY_IOS
@@ -38,8 +87,9 @@ namespace webrtc
         return nullptr;
     }
 
-    UnityVideoDecoderFactory::UnityVideoDecoderFactory(IGraphicsDevice* gfxDevice)
-        : internal_decoder_factory_(new webrtc::InternalDecoderFactory())
+    UnityVideoDecoderFactory::UnityVideoDecoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler)
+        : profiler_(profiler)
+        , internal_decoder_factory_(new webrtc::InternalDecoderFactory())
         , native_decoder_factory_(CreateNativeDecoderFactory(gfxDevice))
     {
     }
@@ -60,11 +110,20 @@ namespace webrtc
     std::unique_ptr<webrtc::VideoDecoder>
     UnityVideoDecoderFactory::CreateVideoDecoder(const webrtc::SdpVideoFormat& format)
     {
+        std::unique_ptr<webrtc::VideoDecoder> decoder;
         if (native_decoder_factory_ && format.IsCodecInList(native_decoder_factory_->GetSupportedFormats()))
         {
-            return native_decoder_factory_->CreateVideoDecoder(format);
+            decoder = native_decoder_factory_->CreateVideoDecoder(format);
         }
-        return internal_decoder_factory_->CreateVideoDecoder(format);
+        else
+        {
+            decoder = internal_decoder_factory_->CreateVideoDecoder(format);
+        }
+        if (!profiler_)
+            return decoder;
+
+        // Use Unity Profiler for measuring decoding process.
+        return std::make_unique<UnityVideoDecoder>(std::move(decoder), profiler_);
     }
 
 } // namespace webrtc

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -45,7 +45,7 @@ namespace webrtc
             if (result >= WEBRTC_VIDEO_CODEC_OK && !profilerThread_)
             {
                 std::stringstream ss;
-                ss << "Decoder:";
+                ss << "Decoder ";
                 ss
                     << (decoder_->GetDecoderInfo().implementation_name.empty()
                             ? "VideoDecoder"

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.h
@@ -7,20 +7,21 @@ namespace unity
 {
 namespace webrtc
 {
-    class IGraphicsDevice;
     using namespace ::webrtc;
 
-    // This class is only used for status testing.
+    class IGraphicsDevice;
+    class ProfilerMarkerFactory;
     class UnityVideoDecoderFactory : public VideoDecoderFactory
     {
     public:
         virtual std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
         virtual std::unique_ptr<webrtc::VideoDecoder> CreateVideoDecoder(const webrtc::SdpVideoFormat& format) override;
 
-        UnityVideoDecoderFactory(IGraphicsDevice* gfxDevice);
+        UnityVideoDecoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler);
         ~UnityVideoDecoderFactory() override;
 
     private:
+        ProfilerMarkerFactory* profiler_;
         const std::unique_ptr<VideoDecoderFactory> internal_decoder_factory_;
         const std::unique_ptr<VideoDecoderFactory> native_decoder_factory_;
     };

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -3,6 +3,8 @@
 #include <media/engine/internal_encoder_factory.h>
 
 #include "GraphicsDevice/GraphicsUtility.h"
+#include "ProfilerMarkerFactory.h"
+#include "ScopedProfiler.h"
 #include "UnityVideoEncoderFactory.h"
 
 #if CUDA_PLATFORM
@@ -21,7 +23,72 @@ namespace unity
 {
 namespace webrtc
 {
-    webrtc::VideoEncoderFactory* CreateNativeEncoderFactory(IGraphicsDevice* gfxDevice)
+    class UnityVideoEncoder : public VideoEncoder
+    {
+    public:
+        UnityVideoEncoder(std::unique_ptr<VideoEncoder> encoder, ProfilerMarkerFactory* profiler)
+            : encoder_(std::move(encoder))
+            , profiler_(profiler)
+            , marker_(nullptr)
+            , profilerThread_(nullptr)
+        {
+            if (profiler)
+                marker_ = profiler->CreateMarker(
+                    "UnityVideoEncoder.Encode", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
+        }
+        ~UnityVideoEncoder() override { }
+
+        void SetFecControllerOverride(FecControllerOverride* fec_controller_override) override
+        {
+            encoder_->SetFecControllerOverride(fec_controller_override);
+        }
+        int32_t InitEncode(const VideoCodec* codec_settings, int32_t number_of_cores, size_t max_payload_size) override
+        {
+            return encoder_->InitEncode(codec_settings, number_of_cores, max_payload_size);
+        }
+        int InitEncode(const VideoCodec* codec_settings, const VideoEncoder::Settings& settings) override
+        {
+            return encoder_->InitEncode(codec_settings, settings);
+        }
+        int32_t RegisterEncodeCompleteCallback(EncodedImageCallback* callback) override
+        {
+            return encoder_->RegisterEncodeCompleteCallback(callback);
+        }
+        int32_t Release() override { return encoder_->Release(); }
+        int32_t Encode(const VideoFrame& frame, const std::vector<VideoFrameType>* frame_types) override
+        {
+            if (!profilerThread_)
+                profilerThread_ = profiler_->CreateScopedProfilerThread("WebRTC", "VideoEncoder");
+
+            int32_t result;
+            {
+                std::unique_ptr<const ScopedProfiler> profiler;
+                if (profiler_)
+                    profiler = profiler_->CreateScopedProfiler(*marker_);
+                result = encoder_->Encode(frame, frame_types);
+            }
+            return result;
+        }
+        void SetRates(const RateControlParameters& parameters) override { encoder_->SetRates(parameters); }
+        void OnPacketLossRateUpdate(float packet_loss_rate) override
+        {
+            encoder_->OnPacketLossRateUpdate(packet_loss_rate);
+        }
+        void OnRttUpdate(int64_t rtt_ms) override { encoder_->OnRttUpdate(rtt_ms); }
+        void OnLossNotification(const LossNotification& loss_notification) override
+        {
+            encoder_->OnLossNotification(loss_notification);
+        }
+        EncoderInfo GetEncoderInfo() const override { return encoder_->GetEncoderInfo(); }
+
+    private:
+        std::unique_ptr<VideoEncoder> encoder_;
+        ProfilerMarkerFactory* profiler_;
+        const UnityProfilerMarkerDesc* marker_;
+        std::unique_ptr<const ScopedProfilerThread> profilerThread_;
+    };
+
+    static webrtc::VideoEncoderFactory* CreateNativeEncoderFactory(IGraphicsDevice* gfxDevice)
     {
 #if UNITY_OSX || UNITY_IOS
         return webrtc::ObjCToNativeVideoEncoderFactory([[RTCDefaultVideoEncoderFactory alloc] init]).release();
@@ -39,8 +106,9 @@ namespace webrtc
         return nullptr;
     }
 
-    UnityVideoEncoderFactory::UnityVideoEncoderFactory(IGraphicsDevice* gfxDevice)
-        : internal_encoder_factory_(new webrtc::InternalEncoderFactory())
+    UnityVideoEncoderFactory::UnityVideoEncoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler)
+        : profiler_(profiler)
+        , internal_encoder_factory_(new webrtc::InternalEncoderFactory())
         , native_encoder_factory_(CreateNativeEncoderFactory(gfxDevice))
     {
     }
@@ -66,7 +134,7 @@ namespace webrtc
             auto it = std::find(std::begin(sortOrder), std::end(sortOrder), format.name);
             if (it == std::end(sortOrder))
                 return LONG_MAX;
-            return std::distance(std::begin(sortOrder), it);
+            return static_cast<long>(std::distance(std::begin(sortOrder), it));
         };
         std::sort(
             supported_codecs.begin(),
@@ -89,11 +157,20 @@ namespace webrtc
     std::unique_ptr<webrtc::VideoEncoder>
     UnityVideoEncoderFactory::CreateVideoEncoder(const webrtc::SdpVideoFormat& format)
     {
+        std::unique_ptr<webrtc::VideoEncoder> encoder;
         if (native_encoder_factory_ && format.IsCodecInList(native_encoder_factory_->GetSupportedFormats()))
         {
-            return native_encoder_factory_->CreateVideoEncoder(format);
+            encoder = native_encoder_factory_->CreateVideoEncoder(format);
         }
-        return internal_encoder_factory_->CreateVideoEncoder(format);
+        else
+        {
+            encoder = internal_encoder_factory_->CreateVideoEncoder(format);
+        }
+        if (!profiler_)
+            return encoder;
+
+        // Use Unity Profiler for measuring encoding process.
+        return std::make_unique<UnityVideoEncoder>(std::move(encoder), profiler_);
     }
 }
 }

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -49,7 +49,7 @@ namespace webrtc
             if (result >= WEBRTC_VIDEO_CODEC_OK && !profilerThread_)
             {
                 std::stringstream ss;
-                ss << "Encoder:";
+                ss << "Encoder ";
                 ss
                     << (encoder_->GetEncoderInfo().implementation_name.empty()
                             ? "VideoEncoder"
@@ -66,7 +66,7 @@ namespace webrtc
             if (result >= WEBRTC_VIDEO_CODEC_OK && !profilerThread_)
             {
                 std::stringstream ss;
-                ss << "Encoder:";
+                ss << "Encoder ";
                 ss
                     << (encoder_->GetEncoderInfo().implementation_name.empty()
                             ? "VideoEncoder"

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.h
@@ -7,9 +7,10 @@ namespace unity
 {
 namespace webrtc
 {
-    class IGraphicsDevice;
     using namespace ::webrtc;
 
+    class IGraphicsDevice;
+    class ProfilerMarkerFactory;
     class UnityVideoEncoderFactory : public VideoEncoderFactory
     {
     public:
@@ -23,10 +24,11 @@ namespace webrtc
         // Creates a VideoEncoder for the specified format.
         virtual std::unique_ptr<VideoEncoder> CreateVideoEncoder(const SdpVideoFormat& format) override;
 
-        UnityVideoEncoderFactory(IGraphicsDevice* gfxDevice);
+        UnityVideoEncoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler);
         ~UnityVideoEncoderFactory() override;
 
     private:
+        ProfilerMarkerFactory* profiler_;
         const std::unique_ptr<VideoEncoderFactory> internal_encoder_factory_;
         const std::unique_ptr<VideoEncoderFactory> native_encoder_factory_;
     };

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -3,6 +3,8 @@
 #include <api/media_stream_interface.h>
 #include <api/rtc_error.h>
 
+struct IUnityInterfaces;
+
 namespace unity
 {
 namespace webrtc
@@ -147,6 +149,15 @@ namespace webrtc
     {
         bool iceRestart;
         bool voiceActivityDetection;
+    };
+
+    class IGraphicsDevice;
+    class ProfilerMarkerFactory;
+    class Plugin
+    {
+    public:
+        static IGraphicsDevice* GraphicsDevice();
+        static ProfilerMarkerFactory* ProfilerMarkerFactory();
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -31,6 +31,10 @@ namespace webrtc
             : container_(CreateGraphicsDeviceContainer(GetParam()))
             , device_(container_->device())
         {
+            ContextDependencies dependencies;
+            dependencies.device = container_->device();
+            dependencies.profiler = nullptr;
+            context = std::make_unique<Context>(dependencies);
             callback_videoframeresize = &OnFrameSizeChange;
         }
 
@@ -42,7 +46,9 @@ namespace webrtc
             if (!texture)
                 GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
 
-            context = std::make_unique<Context>(device_);
+            ContextDependencies dependencies;
+            dependencies.device = device_;
+            context = std::make_unique<Context>(dependencies);
         }
 
         static void OnFrameSizeChange(UnityVideoRenderer* renderer, int width, int height) { }

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -31,10 +31,6 @@ namespace webrtc
             : container_(CreateGraphicsDeviceContainer(GetParam()))
             , device_(container_->device())
         {
-            ContextDependencies dependencies;
-            dependencies.device = container_->device();
-            dependencies.profiler = nullptr;
-            context = std::make_unique<Context>(dependencies);
             callback_videoframeresize = &OnFrameSizeChange;
         }
 

--- a/Plugin~/WebRTCPluginTest/UnityVideoDecoderFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/UnityVideoDecoderFactoryTest.cpp
@@ -29,7 +29,7 @@ namespace webrtc
 
     TEST_P(UnityVideoDecoderFactoryTest, GetSupportedFormats)
     {
-        auto factory = std::make_unique<UnityVideoDecoderFactory>(container_->device());
+        auto factory = std::make_unique<UnityVideoDecoderFactory>(container_->device(), nullptr);
         EXPECT_NE(factory, nullptr);
         auto formats = factory->GetSupportedFormats();
         EXPECT_GT(formats.size(), 0);

--- a/Plugin~/WebRTCPluginTest/UnityVideoEncoderFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/UnityVideoEncoderFactoryTest.cpp
@@ -29,7 +29,7 @@ namespace webrtc
 
     TEST_P(UnityVideoEncoderFactoryTest, GetSupportedFormats)
     {
-        auto factory = std::make_unique<UnityVideoEncoderFactory>(container_->device());
+        auto factory = std::make_unique<UnityVideoEncoderFactory>(container_->device(), nullptr);
         auto formats = factory->GetSupportedFormats();
         EXPECT_GT(formats.size(), 0);
     }

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -27,12 +27,6 @@ namespace webrtc
         {
             m_callback = &OnFrameSizeChange;
             m_renderer = std::make_unique<UnityVideoRenderer>(1, m_callback, true);
-
-            EXPECT_NE(nullptr, device());
-
-            ContextDependencies dependencies;
-            dependencies.device = device();
-            context = std::make_unique<Context>(dependencies);
         }
         ~VideoRendererTest() override = default;
 

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -27,6 +27,12 @@ namespace webrtc
         {
             m_callback = &OnFrameSizeChange;
             m_renderer = std::make_unique<UnityVideoRenderer>(1, m_callback, true);
+
+            EXPECT_NE(nullptr, device());
+
+            ContextDependencies dependencies;
+            dependencies.device = device();
+            context = std::make_unique<Context>(dependencies);
         }
         ~VideoRendererTest() override = default;
 
@@ -36,7 +42,10 @@ namespace webrtc
             if (!device())
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
             m_texture.reset(device()->CreateDefaultTextureV(kWidth, kHeight, format()));
-            context = std::make_unique<Context>(device());
+
+            ContextDependencies dependencies;
+            dependencies.device = device();
+            context = std::make_unique<Context>(dependencies);
         }
         std::unique_ptr<Context> context;
         std::unique_ptr<ITexture2D> m_texture;

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -38,6 +38,12 @@ namespace webrtc
         {
             m_trackSource = UnityVideoTrackSource::Create(false, absl::nullopt, m_taskQueueFactory.get());
             m_trackSource->AddOrUpdateSink(&sink_, rtc::VideoSinkWants());
+
+            EXPECT_NE(nullptr, device());
+
+            ContextDependencies dependencies;
+            dependencies.device = device();
+            context = std::make_unique<Context>(dependencies);
         }
         ~VideoTrackSourceTest() override { m_trackSource->RemoveSink(&sink_); }
 
@@ -51,8 +57,11 @@ namespace webrtc
             if (!m_texture)
                 GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
 
-            context = std::make_unique<Context>(device());
+            ContextDependencies dependencies;
+            dependencies.device = device();
+            context = std::make_unique<Context>(dependencies);
         }
+
         std::unique_ptr<Context> context;
         std::unique_ptr<ITexture2D> m_texture;
         std::unique_ptr<TaskQueueFactory> m_taskQueueFactory;

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -38,13 +38,8 @@ namespace webrtc
         {
             m_trackSource = UnityVideoTrackSource::Create(false, absl::nullopt, m_taskQueueFactory.get());
             m_trackSource->AddOrUpdateSink(&sink_, rtc::VideoSinkWants());
-
-            EXPECT_NE(nullptr, device());
-
-            ContextDependencies dependencies;
-            dependencies.device = device();
-            context = std::make_unique<Context>(dependencies);
         }
+
         ~VideoTrackSourceTest() override { m_trackSource->RemoveSink(&sink_); }
 
     protected:

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -66,11 +66,6 @@ namespace Unity.WebRTC.RuntimeTest
             var audioTrack = receiver.Track as AudioStreamTrack;
             Assert.That(audioTrack, Is.Not.Null);
 
-            yield return new WaitUntil(() => audioTrack.Source != null);
-            Assert.That(audioTrack.Source, Is.Not.Null);
-            Assert.That(audioTrack.Source.clip.channels, Is.EqualTo(channels));
-
-
             // second track
             var track2 = new AudioStreamTrack(source);
             var sender2 = test.component.AddTrack(0, track2);
@@ -82,10 +77,6 @@ namespace Unity.WebRTC.RuntimeTest
             receiver = receivers.Last();
             audioTrack = receiver.Track as AudioStreamTrack;
             Assert.That(audioTrack, Is.Not.Null);
-
-            yield return new WaitUntil(() => audioTrack.Source != null);
-            Assert.That(audioTrack.Source, Is.Not.Null);
-            Assert.That(audioTrack.Source.clip.channels, Is.EqualTo(channels));
 
             test.component.Dispose();
             UnityEngine.Object.DestroyImmediate(test.gameObject);


### PR DESCRIPTION
Show the CPU duration of video encoder thread on Unity Profiler window.
![image](https://user-images.githubusercontent.com/1132081/160079992-1be1ef2f-5b47-4ff6-ac27-70aec15a2b23.png)
