### PR TITLE
fix: Fix crach when using Android GLES3

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLContext.cpp
@@ -22,6 +22,12 @@ namespace webrtc
         : created_(false)
         {
             RTC_DCHECK(display);
+
+            // Return if the context is already created.
+            context_ = eglGetCurrentContext();
+            if(context_ != nullptr)
+                return;
+
             int count = 0;
             if(!eglGetConfigs(display, 0, 0, &count))
             {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLContext.cpp
@@ -42,17 +42,8 @@ namespace webrtc
             };
             context_ = eglCreateContext(display, configs[0], sharedCtx, contextAttr);
             RTC_DCHECK(context_);
-
-            EGLint surfaceAttr[] =
-            {
-                EGL_WIDTH, 1,
-                EGL_HEIGHT, 1,
-                EGL_NONE
-            };
-            surface_ = eglCreatePbufferSurface(display, configs[0], surfaceAttr);
-            RTC_DCHECK(surface_);
-
-            if(!eglMakeCurrent(display, surface_, surface_, context_))
+            
+            if(!eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, context_))
             {
                 RTC_LOG(LS_ERROR) << "eglMakeCurrent failed:" << eglGetError();
                 throw;


### PR DESCRIPTION
Fixed the crash bug caused by not returning the `EGLContext` which already created.