### PR TITLE
Fix build errors when using M96 libwebrtc.

### DIFF
--- a/.yamato/meta/environments.yml
+++ b/.yamato/meta/environments.yml
@@ -2,4 +2,4 @@ upm:
   registry_url: https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
   package_version: stable
 webrtc_version:
-  name: M92
+  name: M96

--- a/.yamato/upm-ci-libwebrtc.yml
+++ b/.yamato/upm-ci-libwebrtc.yml
@@ -23,7 +23,11 @@ platforms:
     build_command: BuildScripts~/build_libwebrtc_android.sh
   - name: ios
     type: Unity::VM::osx
-    image: package-ci/mac:latest
+    # `package-ci/mac:latest` is using xcode 12.2, but occurring the build error below.
+    # clang: error: unknown argument: '-ffile-compilation-dir=.'
+    # This option is available for clang 13 but not clang 11.
+    # https://bugs.chromium.org/p/chromium/issues/detail?id=1263993
+    image: slough-ops/macos-12-base:stable
     flavor: m1.mac  
     build_command: BuildScripts~/build_libwebrtc_ios.sh
 projects:

--- a/.yamato/upm-ci-libwebrtc.yml
+++ b/.yamato/upm-ci-libwebrtc.yml
@@ -23,11 +23,7 @@ platforms:
     build_command: BuildScripts~/build_libwebrtc_android.sh
   - name: ios
     type: Unity::VM::osx
-    # `package-ci/mac:latest` is using xcode 12.2, but occurring the build error below.
-    # clang: error: unknown argument: '-ffile-compilation-dir=.'
-    # This option is available for clang 13 but not clang 11.
-    # https://bugs.chromium.org/p/chromium/issues/detail?id=1263993
-    image: slough-ops/macos-12-base:stable
+    image: renderstreaming/macos-12-xcode:latest
     flavor: m1.mac  
     build_command: BuildScripts~/build_libwebrtc_ios.sh
 projects:

--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -62,7 +62,7 @@ pushd src
 
 for is_debug in "true" "false"
 do
-  python tools_webrtc/android/build_aar.py \
+  python3 tools_webrtc/android/build_aar.py \
     --build-dir $OUTPUT_DIR \
     --output $OUTPUT_DIR/libwebrtc.aar \
     --arch arm64-v8a \
@@ -88,7 +88,7 @@ popd
 patch -N "./src/tools_webrtc/libs/generate_licenses.py" < \
   "$COMMAND_DIR/patches/generate_licenses.patch"
 
-python "./src/tools_webrtc/libs/generate_licenses.py" \
+python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target //:default "$OUTPUT_DIR" "$OUTPUT_DIR"
 
 cd src

--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=4515
+export WEBRTC_VERSION=4664
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -28,6 +28,12 @@ patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 
+# embed bitcode
+# https://source.chromium.org/chromium/chromium/src/+/e93b60e2bf9bcbf45a5eebccb062da15c5a26bfd
+pushd src/build
+patch -p1 < "$COMMAND_DIR/patches/embed_bitcode.patch"
+popd
+
 # use included python
 export PATH="$(pwd)/depot_tools/bootstrap-3.8.0.chromium.8_bin/python/bin:$PATH"
 

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=4515
+export WEBRTC_VERSION=4664
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -44,15 +44,13 @@ do
     #       See below for details.
     #       https://bugs.chromium.org/p/webrtc/issues/detail?id=11729
     #
-    # note: `use_xcode_clang=true` is for using bitcode.
-    #
     gn gen "$OUTPUT_DIR" --root="src" \
       --args="is_debug=${is_debug}    \
       target_os=\"ios\"               \
       target_cpu=\"${target_cpu}\"    \
       rtc_use_h264=false              \
       treat_warnings_as_errors=false  \
-      use_xcode_clang=true            \
+      use_xcode_clang=false           \
       enable_ios_bitcode=true         \
       ios_enable_code_signing=false   \
       rtc_include_tests=false         \

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -50,13 +50,15 @@ do
     #       See below for details.
     #       https://bugs.chromium.org/p/webrtc/issues/detail?id=11729
     #
+    # note: `use_xcode_clang=true` is for using bitcode.
+    #
     gn gen "$OUTPUT_DIR" --root="src" \
       --args="is_debug=${is_debug}    \
       target_os=\"ios\"               \
       target_cpu=\"${target_cpu}\"    \
       rtc_use_h264=false              \
       treat_warnings_as_errors=false  \
-      use_xcode_clang=false           \
+      use_xcode_clang=true            \
       enable_ios_bitcode=true         \
       ios_enable_code_signing=false   \
       rtc_include_tests=false         \

--- a/BuildScripts~/build_libwebrtc_linux.sh
+++ b/BuildScripts~/build_libwebrtc_linux.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=4515
+export WEBRTC_VERSION=4664
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=4515
+export WEBRTC_VERSION=4664
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 

--- a/BuildScripts~/build_libwebrtc_win.cmd
+++ b/BuildScripts~/build_libwebrtc_win.cmd
@@ -6,7 +6,7 @@ if not exist depot_tools (
 
 set COMMAND_DIR=%~dp0
 set PATH=%cd%\depot_tools;%PATH%
-set WEBRTC_VERSION=4515
+set WEBRTC_VERSION=4664
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 set CPPFLAGS=/WX-
 set GYP_GENERATORS=ninja,msvs-ninja

--- a/BuildScripts~/build_plugin_android.sh
+++ b/BuildScripts~/build_plugin_android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-android.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-android.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export PLUGIN_DIR=$(pwd)/Runtime/Plugins/Android
 export ARCH_ABI=arm64-v8a

--- a/BuildScripts~/build_plugin_ios.sh
+++ b/BuildScripts~/build_plugin_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-ios.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export WEBRTC_FRAMEWORK_DIR=$(pwd)/Runtime/Plugins/iOS
 export WEBRTC_ARCHIVE_DIR=build/webrtc.xcarchive

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-linux.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 # Download LibWebRTC 

--- a/BuildScripts~/build_plugin_mac.sh
+++ b/BuildScripts~/build_plugin_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-mac.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-mac.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export DYLIB_FILE=$(pwd)/Runtime/Plugins/macOS/libwebrtc.dylib
 

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-win.zip
+set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-win.zip
 set SOLUTION_DIR=%cd%\Plugin~
 
 echo -------------------

--- a/BuildScripts~/patches/embed_bitcode.patch
+++ b/BuildScripts~/patches/embed_bitcode.patch
@@ -1,0 +1,99 @@
+diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
+index 512662994..64e5235cf 100644
+--- a/config/compiler/BUILD.gn
++++ b/config/compiler/BUILD.gn
+@@ -1264,7 +1264,7 @@ config("compiler_deterministic") {
+     } else {
+       # -ffile-compilation-dir is an alias for both -fdebug-compilation-dir=
+       # and -fcoverage-compilation-dir=.
+-      cflags += [ "-ffile-compilation-dir=." ]
++      cflags += [ "-fdebug-compilation-dir=." ]
+     }
+     if (!is_win) {
+       # We don't use clang -cc1as on Windows (yet? https://crbug.com/762167)
+@@ -2407,13 +2407,17 @@ config("symbols") {
+       cflags += [ "-g2" ]
+     }
+ 
+-    if (!is_nacl && is_clang && !is_tsan && !is_asan) {
++    if (!is_nacl && is_clang && !is_tsan && !is_asan &&
++        !(is_ios && enable_ios_bitcode)) {
+       # gcc generates dwarf-aranges by default on -g1 and -g2. On clang it has
+       # to be manually enabled.
+       #
+       # It is skipped in tsan and asan because enabling it causes some
+       # formatting changes in the output which would require fixing bunches
+       # of expectation regexps.
++      #
++      # It is skipped when generating bitcode is enabled as -gdwars-aranges
++      # is incompatible with -fembed-bitcode/-fembed-bitcode-marker.
+       cflags += [ "-gdwarf-aranges" ]
+     }
+ 
+@@ -2518,9 +2522,19 @@ config("minimal_symbols") {
+       cflags += [ "-g1" ]
+     }
+ 
+-    if (!is_nacl && is_clang && !is_tsan && !is_asan) {
+-      # See comment for -gdwarf-aranges in config("symbols").
+-      cflags += [ "-gdwarf-aranges" ]
++    # Since only one of the build options -gdwarf-aranges and -fembed-bitcode
++    # can be specified, -gdwarf-aranges is not given under the condition that
++    # -fembed-bitcode is specified.
++    if (!(is_ios && use_xcode_clang && enable_ios_bitcode)) {
++      if (!is_nacl && is_clang && !is_tsan && !is_asan) {
++        # gcc generates dwarf-aranges by default on -g1 and -g2. On clang it has
++        # to be manually enabled.
++        #
++        # It is skipped in tsan and asan because enabling it causes some
++        # formatting changes in the output which would require fixing bunches
++        # of expectation regexps.
++        cflags += [ "-gdwarf-aranges" ]
++      }
+     }
+ 
+     ldflags = []
+diff --git a/config/ios/BUILD.gn b/config/ios/BUILD.gn
+index 6d63abf33..4a6050582 100644
+--- a/config/ios/BUILD.gn
++++ b/config/ios/BUILD.gn
+@@ -7,18 +7,6 @@ import("//build/toolchain/goma.gni")
+ import("//build/toolchain/toolchain.gni")
+ import("//build_overrides/build.gni")
+ 
+-declare_args() {
+-  # Enabling this option makes clang compile to an intermediate
+-  # representation ("bitcode"), and not to native code. This is preferred
+-  # when including WebRTC in the apps that will be sent to Apple's App Store
+-  # and mandatory for the apps that run on watchOS or tvOS.
+-  # The option only works when building with Xcode (use_xcode_clang = true).
+-  # Mimicking how Xcode handles it, the production builds (is_debug = false)
+-  # get real bitcode sections added, while the debug builds (is_debug = true)
+-  # only get bitcode-section "markers" added in them.
+-  enable_ios_bitcode = false
+-}
+-
+ # This is included by reference in the //build/config/compiler config that
+ # is applied to all targets. It is here to separate out the logic.
+ config("compiler") {
+diff --git a/config/ios/ios_sdk.gni b/config/ios/ios_sdk.gni
+index 1d0f5dc09..b251cb02b 100644
+--- a/config/ios/ios_sdk.gni
++++ b/config/ios/ios_sdk.gni
+@@ -65,6 +65,16 @@ declare_args() {
+ 
+   # Set to true if all test apps should use the same bundle id.
+   ios_use_shared_bundle_id_for_test_apps = false
++
++  # Enabling this option makes clang compile to an intermediate
++  # representation ("bitcode"), and not to native code. This is preferred
++  # when including WebRTC in the apps that will be sent to Apple's App Store
++  # and mandatory for the apps that run on watchOS or tvOS.
++  #
++  # Mimicking how Xcode handles it, the production builds (is_debug = false)
++  # get real bitcode sections added, while the debug builds (is_debug = true)
++  # only get bitcode-section "markers" added in them.
++  enable_ios_bitcode = false  
+ }
+ 
+ declare_args() {

--- a/BuildScripts~/test_plugin_android.sh
+++ b/BuildScripts~/test_plugin_android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-android.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-android.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export ARCH_ABI=arm64-v8a
 

--- a/BuildScripts~/test_plugin_ios.sh
+++ b/BuildScripts~/test_plugin_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-ios.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 # Install cmake

--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-linux.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export ASAN_OPTIONS=protect_shadow_gap=0:detect_leaks=1
 export LSAN_OPTIONS=suppressions=$(pwd)/Plugin~/tools/lsan/lsan_suppressions.txt

--- a/BuildScripts~/test_plugin_mac.sh
+++ b/BuildScripts~/test_plugin_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-mac.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-mac.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 # Download LibWebRTC 

--- a/BuildScripts~/test_plugin_win.cmd
+++ b/BuildScripts~/test_plugin_win.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-win.zip
+set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M96/webrtc-win.zip
 set SOLUTION_DIR=%cd%\Plugin~
 
 echo -------------------

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -86,7 +86,7 @@ namespace webrtc
 #pragma region open an encode session
     uint32_t Context::s_encoderId = 0;
     uint32_t Context::GenerateUniqueId() { return s_encoderId++; }
-#pragma endregion 
+#pragma endregion
 
     bool Convert(const std::string& str, webrtc::PeerConnectionInterface::RTCConfiguration& config)
     {
@@ -449,14 +449,14 @@ namespace webrtc
     DataChannelInterface* Context::CreateDataChannel(
         PeerConnectionObject* obj, const char* label, const DataChannelInit& options)
     {
-        const rtc::scoped_refptr<DataChannelInterface> channel =
-            obj->connection->CreateDataChannel(label, &options);
+        const RTCErrorOr<rtc::scoped_refptr<DataChannelInterface>> channel =
+            obj->connection->CreateDataChannelOrError(label, &options);
 
-        if (channel == nullptr)
+        if (channel.ok())
             return nullptr;
 
-        AddDataChannel(channel, *obj);
-        return channel;
+        AddDataChannel(channel.value(), *obj);
+        return channel.value();
     }
 
     void Context::AddDataChannel(

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -452,7 +452,7 @@ namespace webrtc
         const RTCErrorOr<rtc::scoped_refptr<DataChannelInterface>> channel =
             obj->connection->CreateDataChannelOrError(label, &options);
 
-        if (channel.ok())
+        if (!channel.ok())
             return nullptr;
 
         AddDataChannel(channel.value(), *obj);

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
@@ -7,13 +7,14 @@ namespace webrtc
 {
 
     MediaStreamObserver::MediaStreamObserver(webrtc::MediaStreamInterface* stream, Context* context)
-        : webrtc::MediaStreamObserver(stream)
+        : webrtc::MediaStreamObserver(
+            stream,
+            [this](webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnAudioTrackAdded(track, stream); },
+            [this](webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnAudioTrackRemoved(track, stream); },
+            [this](webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnVideoTrackAdded(track, stream); },
+            [this](webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnVideoTrackRemoved(track, stream); })
         , m_context(context)
     {
-        this->SignalVideoTrackAdded.connect(this, &MediaStreamObserver::OnVideoTrackAdded);
-        this->SignalAudioTrackAdded.connect(this, &MediaStreamObserver::OnAudioTrackAdded);
-        this->SignalVideoTrackRemoved.connect(this, &MediaStreamObserver::OnVideoTrackRemoved);
-        this->SignalAudioTrackRemoved.connect(this, &MediaStreamObserver::OnAudioTrackRemoved);
     }
 
     void MediaStreamObserver::OnVideoTrackAdded(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.h
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.h
@@ -6,7 +6,7 @@ namespace unity
 namespace webrtc
 {
 
-    class MediaStreamObserver : public webrtc::MediaStreamObserver, public sigslot::has_slots<>
+    class MediaStreamObserver : public webrtc::MediaStreamObserver
     {
     public:
         explicit MediaStreamObserver(webrtc::MediaStreamInterface* stream, Context* context);

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -12,7 +12,7 @@
 using namespace ::webrtc::H264;
 
 namespace unity
-{    
+{
 namespace webrtc
 {
 
@@ -22,9 +22,7 @@ namespace webrtc
     {
         for (const webrtc::SdpVideoFormat& supported_format : supported_formats)
         {
-            if (cricket::IsSameCodec(format.name, format.parameters,
-                supported_format.name,
-                supported_format.parameters))
+            if (supported_format.IsSameCodec(format))
             {
                 return true;
             }
@@ -50,7 +48,7 @@ namespace webrtc
     {
         m_observer = observer;
     }
-    
+
     UnityVideoEncoderFactory::~UnityVideoEncoderFactory() = default;
 
     std::vector<webrtc::SdpVideoFormat> UnityVideoEncoderFactory::GetHardwareEncoderFormats() const


### PR DESCRIPTION
The webrtc.zip for the M96 version also needs to be updated to include these missing files. (For testing, I used the files locally from the M92 version)
api/video_track_source_proxy.h
api/proxy.h
media/base/h264_profile_level_id.h

Testing:
- Built webrtc plugin on Mac.
- Verified that PeerConnection & Data channel samples work on Mac.