### PR TITLE
Fix build errors when using M96 version of libwebrtc

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -86,7 +86,7 @@ namespace webrtc
 #pragma region open an encode session
     uint32_t Context::s_encoderId = 0;
     uint32_t Context::GenerateUniqueId() { return s_encoderId++; }
-#pragma endregion 
+#pragma endregion
 
     bool Convert(const std::string& str, webrtc::PeerConnectionInterface::RTCConfiguration& config)
     {
@@ -449,14 +449,14 @@ namespace webrtc
     DataChannelInterface* Context::CreateDataChannel(
         PeerConnectionObject* obj, const char* label, const DataChannelInit& options)
     {
-        const rtc::scoped_refptr<DataChannelInterface> channel =
-            obj->connection->CreateDataChannel(label, &options);
+        const RTCErrorOr<rtc::scoped_refptr<DataChannelInterface>> channel =
+            obj->connection->CreateDataChannelOrError(label, &options);
 
-        if (channel == nullptr)
+        if (channel.ok())
             return nullptr;
 
-        AddDataChannel(channel, *obj);
-        return channel;
+        AddDataChannel(channel.value(), *obj);
+        return channel.value();
     }
 
     void Context::AddDataChannel(

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -452,7 +452,7 @@ namespace webrtc
         const RTCErrorOr<rtc::scoped_refptr<DataChannelInterface>> channel =
             obj->connection->CreateDataChannelOrError(label, &options);
 
-        if (channel.ok())
+        if (!channel.ok())
             return nullptr;
 
         AddDataChannel(channel.value(), *obj);

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
@@ -7,13 +7,14 @@ namespace webrtc
 {
 
     MediaStreamObserver::MediaStreamObserver(webrtc::MediaStreamInterface* stream, Context* context)
-        : webrtc::MediaStreamObserver(stream)
+        : webrtc::MediaStreamObserver(
+            stream,
+            [this](webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnAudioTrackAdded(track, stream); },
+            [this](webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnAudioTrackRemoved(track, stream); },
+            [this](webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnVideoTrackAdded(track, stream); },
+            [this](webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream) { this->OnVideoTrackRemoved(track, stream); })
         , m_context(context)
     {
-        this->SignalVideoTrackAdded.connect(this, &MediaStreamObserver::OnVideoTrackAdded);
-        this->SignalAudioTrackAdded.connect(this, &MediaStreamObserver::OnAudioTrackAdded);
-        this->SignalVideoTrackRemoved.connect(this, &MediaStreamObserver::OnVideoTrackRemoved);
-        this->SignalAudioTrackRemoved.connect(this, &MediaStreamObserver::OnAudioTrackRemoved);
     }
 
     void MediaStreamObserver::OnVideoTrackAdded(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.h
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.h
@@ -6,7 +6,7 @@ namespace unity
 namespace webrtc
 {
 
-    class MediaStreamObserver : public webrtc::MediaStreamObserver, public sigslot::has_slots<>
+    class MediaStreamObserver : public webrtc::MediaStreamObserver
     {
     public:
         explicit MediaStreamObserver(webrtc::MediaStreamInterface* stream, Context* context);

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -12,7 +12,7 @@
 using namespace ::webrtc::H264;
 
 namespace unity
-{    
+{
 namespace webrtc
 {
 
@@ -22,9 +22,7 @@ namespace webrtc
     {
         for (const webrtc::SdpVideoFormat& supported_format : supported_formats)
         {
-            if (cricket::IsSameCodec(format.name, format.parameters,
-                supported_format.name,
-                supported_format.parameters))
+            if (supported_format.IsSameCodec(format))
             {
                 return true;
             }
@@ -50,7 +48,7 @@ namespace webrtc
     {
         m_observer = observer;
     }
-    
+
     UnityVideoEncoderFactory::~UnityVideoEncoderFactory() = default;
 
     std::vector<webrtc::SdpVideoFormat> UnityVideoEncoderFactory::GetHardwareEncoderFormats() const


### PR DESCRIPTION
The webrtc.zip for the M96 version also needs to be updated to include these missing files. (For testing, I used the files locally from the M92 version)
api/video_track_source_proxy.h
api/proxy.h
media/base/h264_profile_level_id.h

Testing:
- Built webrtc plugin on Mac.
- Verified that PeerConnection & Data channel samples work on Mac.