### PR TITLE
fix: Add the testing platforms which GPU is not installed

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -252,7 +252,7 @@ test_webrtc_plugin_{{ platform.name }}:
 {% endfor %}
 
 {% for platform in platforms %}
-{% if platform.name == "windows" or platform.name == "linux" %}
+{% if platform.name == "win" or platform.name == "linux" %}
 test_webrtc_plugin_{{ platform.name }}_gpu:
   name: Test webrtc plugin {{ platform.name }} with GPU
   agent:
@@ -305,15 +305,15 @@ build_webrtc_plugin_test_android:
       paths:
         - "build/WebRTCLibTest"
 
-test_webrtc_plugin_all_platform:
-  name: Test webrtc plugin for all platforms
+trigger_webrtc_plugin_all_platform:
+  name: Trigger webrtc plugin for all platforms
   dependencies:
     {% for platform in platforms %}
     # todo(kazuki) native plugin test is not supported on iOS
     {% if platform.name != "ios" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_webrtc_plugin_{{ platform.name }}
     {% endif %}
-    {% if platform.name == "windows" or platform.name == "linux" %}
+    {% if platform.name == "win" or platform.name == "linux" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_webrtc_plugin_{{ platform.name }}_gpu
     {% endif %}
     {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -252,8 +252,8 @@ test_webrtc_plugin_{{ platform.name }}:
 {% endfor %}
 
 {% for platform in platforms %}
-{% if platform.name != "android" and platform.name != "ios" %}
-test_webrtc_plugin_{{ platform.name }}_GPU:
+{% if platform.name == "windows" or platform.name == "linux" %}
+test_webrtc_plugin_{{ platform.name }}_gpu:
   name: Test webrtc plugin {{ platform.name }} with GPU
   agent:
     type: {{ platform.gpu_type }}
@@ -313,10 +313,9 @@ test_webrtc_plugin_all_platform:
     {% if platform.name != "ios" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_webrtc_plugin_{{ platform.name }}
     {% endif %}
-    {% if platform.name != "android" and platform.name != "ios" %}
+    {% if platform.name == "windows" or platform.name == "linux" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_webrtc_plugin_{{ platform.name }}_gpu
     {% endif %}
-
     {% endfor %}
 
 pack_{{ package.name }}:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -243,6 +243,19 @@ build_webrtc_plugin_{{ platform.name }}:
 test_webrtc_plugin_{{ platform.name }}:
   name: Test webrtc plugin {{ platform.name }}
   agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor }}
+  commands:
+    - {{ platform.test_command }}
+{% endif %}
+{% endfor %}
+
+{% for platform in platforms %}
+{% if platform.name != "android" and platform.name != "ios" %}
+test_webrtc_plugin_{{ platform.name }}_GPU:
+  name: Test webrtc plugin {{ platform.name }} with GPU
+  agent:
     type: {{ platform.gpu_type }}
     image: {{ platform.gpu_image }}
     flavor: {{ platform.flavor }}
@@ -253,6 +266,7 @@ test_webrtc_plugin_{{ platform.name }}:
     - {{ platform.test_command }}
 {% endif %}
 {% endfor %}
+
 
 #todo(kazuki): test it on Android mobile device
 test_webrtc_plugin_android:
@@ -299,6 +313,10 @@ test_webrtc_plugin_all_platform:
     {% if platform.name != "ios" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_webrtc_plugin_{{ platform.name }}
     {% endif %}
+    {% if platform.name != "android" and platform.name != "ios" %}
+    - .yamato/upm-ci-{{ package.name }}-packages.yml#test_webrtc_plugin_{{ platform.name }}_gpu
+    {% endif %}
+
     {% endfor %}
 
 pack_{{ package.name }}:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -305,8 +305,8 @@ build_webrtc_plugin_test_android:
       paths:
         - "build/WebRTCLibTest"
 
-trigger_webrtc_plugin_all_platform:
-  name: Trigger webrtc plugin for all platforms
+trigger_test_webrtc_plugin_all_platform:
+  name: Trigger test for webrtc plugin for all platforms
   dependencies:
     {% for platform in platforms %}
     # todo(kazuki) native plugin test is not supported on iOS

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -46,10 +46,15 @@ namespace webrtc
         texture_.reset(device_->CreateDefaultTextureV(size.width(), size.height(), format));
         textureCpuRead_.reset(device_->CreateCPUReadTextureV(size.width(), size.height(), format));
 
-        // IGraphicsDevice::Map method is too heavy and stop the graphics process,
-        // so must not call this method on the worker thread instead of the render thread.
-        handle_ = device_->Map(texture_.get());
-
+// todo(kazuki): need to refactor
+#if CUDA_PLATFORM
+        if(device_->IsCudaSupport())
+        {
+            // IGraphicsDevice::Map method is too heavy and stop the graphics process,
+            // so must not call this method on the worker thread instead of the render thread.
+            handle_ = device_->Map(texture_.get());
+        }
+#endif
         CopyBuffer(ptr);
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
@@ -30,15 +30,14 @@ CudaContext::CudaContext()
 //---------------------------------------------------------------------------------------------------------------------
 CUresult LoadModule()
 {
-    // dll check
-    if (s_hModule == nullptr)
+    if (!s_hModule)
     {
-        // dll delay load
 #if defined(_WIN32)
+        // dll delay load
         HMODULE module = LoadLibrary(TEXT("nvcuda.dll"));
-        if (module == nullptr)
+        if (!module)
         {
-            LogPrint("nvcuda.dll is not found. Please be sure the environment supports CUDA API.");
+            RTC_LOG(LS_INFO) << "nvcuda.dll is not found.";
             return CUDA_ERROR_NOT_FOUND;
         }
         s_hModule = module;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -61,7 +61,12 @@ ITexture2D* D3D11GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, U
     desc.Usage = D3D11_USAGE_DEFAULT;
     desc.BindFlags = 0;
     desc.CPUAccessFlags = 0;
-    HRESULT r = m_d3d11Device->CreateTexture2D(&desc, NULL, &texture);
+    HRESULT result = m_d3d11Device->CreateTexture2D(&desc, NULL, &texture);
+    if (result != S_OK)
+    {
+        RTC_LOG(LS_INFO) << "CreateTexture2D failed. error:" << result;
+        return nullptr;
+    }
     return new D3D11Texture2D(w,h,texture);
 }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -152,6 +152,9 @@ rtc::scoped_refptr<I420Buffer> D3D11GraphicsDevice::ConvertRGBToI420(ITexture2D*
 
     std::unique_ptr<GpuMemoryBufferHandle> D3D11GraphicsDevice::Map(ITexture2D* texture)
     {
+        if(!IsCudaSupport())
+            return nullptr;
+
         CUarray mappedArray;
         CUgraphicsResource resource;
         ID3D11Resource* pResource = static_cast<ID3D11Resource*>(texture->GetNativeTexturePtrV());

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -284,6 +284,9 @@ rtc::scoped_refptr<webrtc::I420Buffer> D3D12GraphicsDevice::ConvertRGBToI420(
 
     std::unique_ptr<GpuMemoryBufferHandle> D3D12GraphicsDevice::Map(ITexture2D* texture)
     {
+        if(!IsCudaSupport())
+            return nullptr;
+
         D3D12Texture2D* d3d12Texure = static_cast<D3D12Texture2D*>(texture);
 
         // set context on the thread.

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -184,25 +184,37 @@ D3D12Texture2D* D3D12GraphicsDevice::CreateSharedD3D12Texture(uint32_t w, uint32
     const D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_SHARED;
     const D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_COPY_DEST;
 
-    ID3D12Resource* nativeTex = nullptr;
-    ThrowIfFailed(m_d3d12Device->CreateCommittedResource(
+    ID3D12Resource* resource = nullptr;
+    HRESULT result = m_d3d12Device->CreateCommittedResource(
         &D3D12_DEFAULT_HEAP_PROPS, flags, &desc, initialState,
-        nullptr, IID_PPV_ARGS(&nativeTex)));
+        nullptr, IID_PPV_ARGS(&resource));
 
-    if (nativeTex == nullptr)
+    if (result != S_OK)
+    {
+        RTC_LOG(LS_INFO) << "CreateCommittedResource failed. error:" << result;
         return nullptr;
+    }
 
-    ID3D11Texture2D* sharedTex = nullptr;
     HANDLE handle = nullptr;
+    result = m_d3d12Device->CreateSharedHandle(
+        resource, nullptr, GENERIC_ALL, nullptr, &handle);
+    if (result != S_OK)
+    {
+        RTC_LOG(LS_INFO) << "CreateSharedHandle failed. error:" << result;
+        return nullptr;
+    }
 
-    ThrowIfFailed(m_d3d12Device->CreateSharedHandle(
-        nativeTex, nullptr, GENERIC_ALL, nullptr, &handle));
+    // ID3D11Device::OpenSharedHandle() doesn't accept handles created by d3d12.
+    // OpenSharedResource1() is needed.
+    ID3D11Texture2D* sharedTex = nullptr;
+    result = m_d3d11Device->OpenSharedResource1(handle, IID_PPV_ARGS(&sharedTex));
+    if (result != S_OK)
+    {
+        RTC_LOG(LS_INFO) << "OpenSharedResource1 failed. error:" << result;
+        return nullptr;
+    }
 
-    //ID3D11Device::OpenSharedHandle() doesn't accept handles created by d3d12. OpenSharedHandle1() is needed.
-    ThrowIfFailed(m_d3d11Device->OpenSharedResource1(
-        handle, IID_PPV_ARGS(&sharedTex)));
-
-    return new D3D12Texture2D(w, h, nativeTex, handle, sharedTex);
+    return new D3D12Texture2D(w, h, resource, handle, sharedTex);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -237,6 +237,9 @@ rtc::scoped_refptr<webrtc::I420Buffer> OpenGLGraphicsDevice::ConvertRGBToI420(IT
     std::unique_ptr<GpuMemoryBufferHandle> OpenGLGraphicsDevice::Map(ITexture2D* texture)
     {
 #if CUDA_PLATFORM
+        if(!IsCudaSupport())
+            return nullptr;
+
         if(!OpenGLContext::CurrentContext())
             contexts_.push_back(OpenGLContext::CreateGLContext(mainContext_.get()));
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -32,7 +32,8 @@ VulkanGraphicsDevice::VulkanGraphicsDevice( IUnityGraphicsVulkan* unityVulkan, c
 bool VulkanGraphicsDevice::InitV()
 {
 #if CUDA_PLATFORM
-    m_isCudaSupport = CUDA_SUCCESS == m_cudaContext.Init(m_instance, m_physicalDevice);
+    CUresult result = m_cudaContext.Init(m_instance, m_physicalDevice);
+    m_isCudaSupport = CUDA_SUCCESS == result;
 #endif
     return VK_SUCCESS == CreateCommandPool();
 }
@@ -251,6 +252,9 @@ rtc::scoped_refptr<webrtc::I420Buffer> VulkanGraphicsDevice::ConvertRGBToI420(
     std::unique_ptr<GpuMemoryBufferHandle> VulkanGraphicsDevice::Map(ITexture2D* texture)
     {
 #if CUDA_PLATFORM
+        if(!IsCudaSupport())
+            return nullptr;
+
         // set context on the thread.
         cuCtxPushCurrent(GetCUcontext());
 

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -28,10 +28,12 @@ namespace webrtc
 #elif UNITY_ANDROID
         if (IsVMInitialized())
             return CreateAndroidDecoderFactory().release();
-        return nullptr;
 #elif CUDA_PLATFORM
-        CUcontext context = gfxDevice->GetCUcontext();
-        return new NvDecoderFactory(context);
+        if(gfxDevice->IsCudaSupport())
+        {
+            CUcontext context = gfxDevice->GetCUcontext();
+            return new NvDecoderFactory(context);
+        }
 #endif
         return nullptr;
     }

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -30,11 +30,13 @@ namespace webrtc
 #elif UNITY_ANDROID
         if (IsVMInitialized())
             return CreateAndroidEncoderFactory().release();
-        return nullptr;
 #elif CUDA_PLATFORM
-        CUcontext context = gfxDevice->GetCUcontext();
-        NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();
-        return new NvEncoderFactory(context, format);
+        if(gfxDevice->IsCudaSupport())
+        {
+            CUcontext context = gfxDevice->GetCUcontext();
+            NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();
+            return new NvEncoderFactory(context, format);
+        }
 #endif
         return nullptr;
     }

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -128,6 +128,7 @@ if(Windows)
       wmcodecdspuuid
       WebRTCLib
       Strmiids
+      delayimp.lib
   )
   target_include_directories(WebRTCLibTest
     PRIVATE
@@ -141,8 +142,8 @@ if(Windows)
       COMPILE_FLAGS "/Yc /Ycpch.h"
   )
   set_target_properties(WebRTCLibTest
-    PROPERTIES
-      LINK_FLAGS "/DELAYLOAD:nvcuda.dll /DELAYLOAD:vulkan-1.dll"
+    PROPERTIES    
+      LINK_FLAGS "-delayload:nvcuda.dll -delayload:nvEncodeAPI64.dll -delayload:nvcuvid.dll -delayload:vulkan-1.dll"
       MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
   )
 elseif(macOS)

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -19,8 +19,10 @@ using namespace ::webrtc;
 class ContextTest : public testing::TestWithParam<UnityGfxRenderer>
 {
 protected:
-    const int width = 256;
-    const int height = 256;
+    const uint32_t kWidth = 256;
+    const uint32_t kHeight = 256;
+    const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
+
     std::unique_ptr<GraphicsDeviceContainer> container_;
     std::unique_ptr<Context> context;
     IGraphicsDevice* device_;
@@ -37,6 +39,11 @@ protected:
     {
         if (!device_)
             GTEST_SKIP() << "The graphics driver is not installed on the device.";
+        std::unique_ptr<ITexture2D> texture(device_->CreateDefaultTextureV(kWidth, kHeight, kFormat));
+        if (!texture)
+            GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
+
+
         context = std::make_unique<Context>(device_);
     }
 
@@ -45,7 +52,7 @@ protected:
     }
 };
 TEST_P(ContextTest, InitializeAndFinalizeEncoder) {
-    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(width, height, kUnityRenderingExtFormatR8G8B8A8_SRGB));
+    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(kWidth, kHeight, kFormat));
     EXPECT_NE(nullptr, tex);
     const auto source = context->CreateVideoSource();
     const auto track = context->CreateVideoTrack("video", source);
@@ -61,7 +68,7 @@ TEST_P(ContextTest, CreateAndDeleteMediaStream) {
 
 
 TEST_P(ContextTest, CreateAndDeleteVideoTrack) {
-    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(width, height, kUnityRenderingExtFormatR8G8B8A8_SRGB));
+    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(kWidth, kHeight, kFormat));
     EXPECT_NE(nullptr, tex.get());
     const auto source = context->CreateVideoSource();
     const auto track = context->CreateVideoTrack("video", source);
@@ -91,7 +98,7 @@ TEST_P(ContextTest, AddAndRemoveAudioTrackToMediaStream) {
 }
 
 TEST_P(ContextTest, AddAndRemoveVideoTrackToMediaStream) {
-    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(width, height, kUnityRenderingExtFormatR8G8B8A8_SRGB));
+    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(kWidth, kHeight, kFormat));
     const auto stream = context->CreateMediaStream("videostream");
     const auto source = context->CreateVideoSource();
     const auto track = context->CreateVideoTrack("video", source);
@@ -135,7 +142,7 @@ TEST_P(ContextTest, EqualRendererGetById) {
 }
 
 TEST_P(ContextTest, AddAndRemoveVideoRendererToVideoTrack) {
-    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(width, height, kUnityRenderingExtFormatR8G8B8A8_SRGB));
+    const std::unique_ptr<ITexture2D> tex(container_->device()->CreateDefaultTextureV(kWidth, kHeight, kFormat));
     const auto source = context->CreateVideoSource();
     const auto track = context->CreateVideoTrack("video", source);
     const auto renderer = context->CreateVideoRenderer(callback_videoframeresize, true);

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -37,9 +37,6 @@ protected:
     {
         if (!device_)
             GTEST_SKIP() << "The graphics driver is not installed on the device.";
-        if (!device_->IsCudaSupport())
-            GTEST_SKIP() << "CUDA is not supported on this device.";
-
         context = std::make_unique<Context>(device_);
     }
 

--- a/Plugin~/WebRTCPluginTest/ContextTest.cpp
+++ b/Plugin~/WebRTCPluginTest/ContextTest.cpp
@@ -23,13 +23,24 @@ protected:
     const int height = 256;
     std::unique_ptr<GraphicsDeviceContainer> container_;
     std::unique_ptr<Context> context;
+    IGraphicsDevice* device_;
     DelegateVideoFrameResize callback_videoframeresize;
 
     explicit ContextTest()
         : container_(CreateGraphicsDeviceContainer(GetParam()))
+        , device_(container_->device())
     {
-        context = std::make_unique<Context>(container_->device());
         callback_videoframeresize = &OnFrameSizeChange;
+    }
+
+    void SetUp() override
+    {
+        if (!device_)
+            GTEST_SKIP() << "The graphics driver is not installed on the device.";
+        if (!device_->IsCudaSupport())
+            GTEST_SKIP() << "CUDA is not supported on this device.";
+
+        context = std::make_unique<Context>(device_);
     }
 
     static void OnFrameSizeChange(UnityVideoRenderer* renderer, int width, int height)

--- a/Plugin~/WebRTCPluginTest/GpuMemoryBufferPoolTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GpuMemoryBufferPoolTest.cpp
@@ -24,6 +24,10 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            std::unique_ptr<ITexture2D> texture(device_->CreateDefaultTextureV(kWidth, kHeight, kFormat));
+            if (!texture)
+                GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
+
             bufferPool_ = std::make_unique<GpuMemoryBufferPool>(device_);
             timestamp_ = Clock::GetRealTimeClock()->TimeInMicroseconds();
         }
@@ -38,12 +42,14 @@ namespace webrtc
         IGraphicsDevice* device_;
         std::unique_ptr<GpuMemoryBufferPool> bufferPool_;
         int64_t timestamp_;
+        const uint32_t kWidth = 256;
+        const uint32_t kHeight = 256;
+        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
     };
 
     TEST_P(GpuMemoryBufferPoolTest, CreateFrame)
     {
-        const Size kSize(256, 256);
-        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
+        const Size kSize(kWidth, kHeight);
         auto tex = CreateTexture(kSize, kFormat);
         void* ptr = tex->GetNativeTexturePtrV();
 
@@ -55,8 +61,7 @@ namespace webrtc
 
     TEST_P(GpuMemoryBufferPoolTest, ReuseFirstResource)
     {
-        const Size kSize(256, 256);
-        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
+        const Size kSize(kWidth, kHeight);
         auto tex = CreateTexture(kSize, kFormat);
         void* ptr = tex->GetNativeTexturePtrV();
 
@@ -76,8 +81,7 @@ namespace webrtc
 
     TEST_P(GpuMemoryBufferPoolTest, DropResourceWhenSizeIsDifferent)
     {
-        const Size kSize1(256, 256);
-        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
+        const Size kSize1(kWidth, kHeight);
         auto tex1 = CreateTexture(kSize1, kFormat);
         void* ptr1 = tex1->GetNativeTexturePtrV();
 

--- a/Plugin~/WebRTCPluginTest/GpuMemoryBufferPoolTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GpuMemoryBufferPoolTest.cpp
@@ -24,9 +24,6 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device_->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
-
             bufferPool_ = std::make_unique<GpuMemoryBufferPool>(device_);
             timestamp_ = Clock::GetRealTimeClock()->TimeInMicroseconds();
         }

--- a/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
@@ -18,11 +18,20 @@ namespace webrtc
     public:
         explicit GpuMemoryBufferTest()
             : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
         }
 
     protected:
+        void SetUp() override
+        {
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+        }
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(GpuMemoryBufferTest, WidthAndHeight)

--- a/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
@@ -27,15 +27,21 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
+
+            std::unique_ptr<ITexture2D> texture(device_->CreateDefaultTextureV(kWidth, kHeight, kFormat));
+            if (!texture)
+                GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
         }
         std::unique_ptr<GraphicsDeviceContainer> container_;
         IGraphicsDevice* device_;
+        const uint32_t kWidth = 256;
+        const uint32_t kHeight = 256;
+        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
     };
 
     TEST_P(GpuMemoryBufferTest, WidthAndHeight)
     {
         const Size kSize(1280, 960);
-        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
         IGraphicsDevice* device = container_->device();
         std::unique_ptr<const ITexture2D> texture(
             device->CreateDefaultTextureV(kSize.width(), kSize.height(), kFormat));

--- a/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
@@ -27,8 +27,6 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device_->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
         }
         std::unique_ptr<GraphicsDeviceContainer> container_;
         IGraphicsDevice* device_;

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -17,6 +17,7 @@
 #if SUPPORT_OPENGL_CORE
 #include "GraphicsDevice/OpenGL/OpenGLContext.h"
 #include <GL/glut.h>
+#include <sanitizer/lsan_interface.h>
 #endif
 
 #if SUPPORT_OPENGL_ES
@@ -371,6 +372,7 @@ namespace webrtc
 #if SUPPORT_OPENGL_CORE
 
     static bool s_glutInitialized;
+    static int s_window;
 
     void* CreateDeviceGLCore()
     {
@@ -378,8 +380,10 @@ namespace webrtc
         {
             int argc = 0;
             glutInit(&argc, nullptr);
+            __lsan_disable();
+            s_window = glutCreateWindow("test");
+            __lsan_enable();
             s_glutInitialized = true;
-            glutCreateWindow("test");
         }
         OpenGLContext::Init();
         std::unique_ptr<OpenGLContext> context = OpenGLContext::CreateGLContext();

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -459,8 +459,8 @@ namespace webrtc
     }
 
     GraphicsDeviceContainer::GraphicsDeviceContainer(UnityGfxRenderer renderer)
-        : nativeGfxDevice_(nullptr)
-        , device_(nullptr)
+        : device_(nullptr)
+        , nativeGfxDevice_(nullptr)
     {
         nativeGfxDevice_ = CreateNativeGfxDevice(renderer);
         renderer_ = renderer;

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainerTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainerTest.cpp
@@ -13,7 +13,7 @@ namespace webrtc
     TEST_P(GraphicsDeviceContainerTest, Instantiate)
     {
         auto container = CreateGraphicsDeviceContainer(GetParam());
-        EXPECT_NE(container->device(), nullptr);
+        EXPECT_NE(container, nullptr);
     }
 
     INSTANTIATE_TEST_SUITE_P(GfxDevice, GraphicsDeviceContainerTest, testing::ValuesIn(supportedGfxDevices));

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -17,8 +17,6 @@ protected:
     {
         if (!device())
             GTEST_SKIP() << "The graphics driver is not installed on the device.";
-        if (!device()->IsCudaSupport())
-            GTEST_SKIP() << "CUDA is not supported on this device.";
     }
 };
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -102,7 +102,10 @@ TEST_P(GraphicsDeviceTest, Map)
     std::unique_ptr<GpuMemoryBufferHandle> handle = device()->Map(src.get());
 
 #if CUDA_PLATFORM
-    EXPECT_NE(handle, nullptr);
+    if(device()->IsCudaSupport())
+        EXPECT_NE(handle, nullptr);
+    else
+        EXPECT_EQ(handle, nullptr);
 #else
     EXPECT_EQ(handle, nullptr);
 #endif
@@ -114,7 +117,7 @@ TEST_P(GraphicsDeviceTest, MapWithCPUReadTexture)
     // which creating for reading from CPU.
     // It is unclear whether this is the bug or the specification of CUDA.
     if (device()->GetGfxRenderer() == kUnityGfxRendererVulkan)
-        GTEST_SKIP_SUCCESS() << "The Map method throw exception on vulkan platform";
+        GTEST_SKIP() << "The Map method throw exception on vulkan platform";
 
     const uint32_t width = 256;
     const uint32_t height = 256;

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -12,6 +12,14 @@ namespace webrtc
 
 class GraphicsDeviceTest : public GraphicsDeviceTestBase
 {
+protected:
+    void SetUp() override
+    {
+        if (!device())
+            GTEST_SKIP() << "The graphics driver is not installed on the device.";
+        if (!device()->IsCudaSupport())
+            GTEST_SKIP() << "CUDA is not supported on this device.";
+    }
 };
 
 TEST_P(GraphicsDeviceTest, GraphicsDeviceIsNotNull) { EXPECT_NE(nullptr, device()); }
@@ -20,7 +28,7 @@ TEST_P(GraphicsDeviceTest, CreateDefaultTextureV)
 {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> tex(device()->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> tex(device()->CreateDefaultTextureV(width, height, format()));
     EXPECT_TRUE(tex->IsSize(width, height));
     EXPECT_NE(nullptr, tex->GetNativeTexturePtrV());
     EXPECT_FALSE(tex->IsSize(0, 0));
@@ -30,7 +38,7 @@ TEST_P(GraphicsDeviceTest, CreateCPUReadTextureV)
 {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> tex(device()->CreateCPUReadTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> tex(device()->CreateCPUReadTextureV(width, height, format()));
     EXPECT_TRUE(tex->IsSize(width, height));
     EXPECT_NE(nullptr, tex->GetNativeTexturePtrV());
     EXPECT_FALSE(tex->IsSize(0, 0));
@@ -43,7 +51,7 @@ TEST_P(GraphicsDeviceTest, ReleaseTextureOnOtherThread)
 
     std::unique_ptr<rtc::Thread> thread = rtc::Thread::CreateWithSocketServer();
     thread->Start();
-    std::unique_ptr<ITexture2D> texture(device()->CreateDefaultTextureV(width, height, m_textureFormat));
+    std::unique_ptr<ITexture2D> texture(device()->CreateDefaultTextureV(width, height, format()));
 
     thread->Invoke<void>(
         RTC_FROM_HERE,
@@ -58,8 +66,8 @@ TEST_P(GraphicsDeviceTest, CopyResourceV)
 {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, m_textureFormat));
-    const std::unique_ptr<ITexture2D> dst(device()->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, format()));
+    const std::unique_ptr<ITexture2D> dst(device()->CreateDefaultTextureV(width, height, format()));
     EXPECT_TRUE(device()->CopyResourceV(dst.get(), src.get()));
 }
 
@@ -67,8 +75,8 @@ TEST_P(GraphicsDeviceTest, CopyResourceVFromCPURead)
 {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> src(device()->CreateCPUReadTextureV(width, height, m_textureFormat));
-    const std::unique_ptr<ITexture2D> dst(device()->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> src(device()->CreateCPUReadTextureV(width, height, format()));
+    const std::unique_ptr<ITexture2D> dst(device()->CreateDefaultTextureV(width, height, format()));
     EXPECT_TRUE(device()->CopyResourceV(dst.get(), src.get()));
 }
 
@@ -76,8 +84,8 @@ TEST_P(GraphicsDeviceTest, CopyResourceNativeV)
 {
     const auto width = 256;
     const auto height = 256;
-    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, m_textureFormat));
-    const std::unique_ptr<ITexture2D> dst(device()->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, format()));
+    const std::unique_ptr<ITexture2D> dst(device()->CreateDefaultTextureV(width, height, format()));
     EXPECT_TRUE(device()->CopyResourceFromNativeV(dst.get(), src->GetNativeTexturePtrV()));
 }
 
@@ -85,8 +93,8 @@ TEST_P(GraphicsDeviceTest, ConvertRGBToI420)
 {
     const uint32_t width = 256;
     const uint32_t height = 256;
-    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, m_textureFormat));
-    const std::unique_ptr<ITexture2D> dst(device()->CreateCPUReadTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, format()));
+    const std::unique_ptr<ITexture2D> dst(device()->CreateCPUReadTextureV(width, height, format()));
     EXPECT_TRUE(device()->CopyResourceFromNativeV(dst.get(), src->GetNativeTexturePtrV()));
     const auto frameBuffer = device()->ConvertRGBToI420(dst.get());
     EXPECT_NE(nullptr, frameBuffer);
@@ -98,7 +106,7 @@ TEST_P(GraphicsDeviceTest, Map)
 {
     const uint32_t width = 256;
     const uint32_t height = 256;
-    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> src(device()->CreateDefaultTextureV(width, height, format()));
     std::unique_ptr<GpuMemoryBufferHandle> handle = device()->Map(src.get());
 
 #if CUDA_PLATFORM
@@ -121,7 +129,7 @@ TEST_P(GraphicsDeviceTest, MapWithCPUReadTexture)
 
     const uint32_t width = 256;
     const uint32_t height = 256;
-    const std::unique_ptr<ITexture2D> src2(device()->CreateCPUReadTextureV(width, height, m_textureFormat));
+    const std::unique_ptr<ITexture2D> src2(device()->CreateCPUReadTextureV(width, height, format()));
     std::unique_ptr<GpuMemoryBufferHandle> handle2 = device()->Map(src2.get());
 }
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -17,7 +17,13 @@ protected:
     {
         if (!device())
             GTEST_SKIP() << "The graphics driver is not installed on the device.";
+
+        std::unique_ptr<ITexture2D> texture(device()->CreateDefaultTextureV(kWidth, kHeight, format()));
+        if (!texture)
+            GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
     }
+    const uint32_t kWidth = 256;
+    const uint32_t kHeight = 256;
 };
 
 TEST_P(GraphicsDeviceTest, GraphicsDeviceIsNotNull) { EXPECT_NE(nullptr, device()); }

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.cpp
@@ -9,17 +9,17 @@ namespace unity
 namespace webrtc
 {
 
-    //---------------------------------------------------------------------------------------------------------------------
-
     GraphicsDeviceTestBase::GraphicsDeviceTestBase()
     {
         std::tie(m_unityGfxRenderer, m_textureFormat) = GetParam();
         container_ = std::make_unique<GraphicsDeviceContainer>(m_unityGfxRenderer);
+        device_ = container_->device();
     }
 
     GraphicsDeviceTestBase::~GraphicsDeviceTestBase() { }
 
-    IGraphicsDevice* GraphicsDeviceTestBase::device() { return container_->device(); }
+    IGraphicsDevice* GraphicsDeviceTestBase::device() { return device_; }
+    UnityRenderingExtTextureFormat GraphicsDeviceTestBase::format() { return m_textureFormat; }
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTestBase.h
@@ -23,11 +23,12 @@ namespace webrtc
         explicit GraphicsDeviceTestBase();
         virtual ~GraphicsDeviceTestBase();
         IGraphicsDevice* device();
-
-    protected:
+        UnityRenderingExtTextureFormat format();
+    private:
         UnityGfxRenderer m_unityGfxRenderer;
         UnityRenderingExtTextureFormat m_textureFormat;
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     static tuple<UnityGfxRenderer, UnityRenderingExtTextureFormat> VALUES_TEST_ENV[] = {

--- a/Plugin~/WebRTCPluginTest/InternalCodecsTest.cpp
+++ b/Plugin~/WebRTCPluginTest/InternalCodecsTest.cpp
@@ -2,6 +2,8 @@
 
 #include "FrameGenerator.h"
 #include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/ITexture2D.h"
+
 #include "GraphicsDeviceContainer.h"
 #include "VideoCodecTest.h"
 
@@ -14,6 +16,7 @@ namespace webrtc
 {
     constexpr int kWidth = 172;
     constexpr int kHeight = 144;
+    constexpr UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
 
     using testing::Values;
 
@@ -37,6 +40,10 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            std::unique_ptr<ITexture2D> texture(device_->CreateDefaultTextureV(kWidth, kHeight, kFormat));
+            if (!texture)
+                GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
+
             VideoCodecTest::SetUp();
         }
 

--- a/Plugin~/WebRTCPluginTest/InternalCodecsTest.cpp
+++ b/Plugin~/WebRTCPluginTest/InternalCodecsTest.cpp
@@ -37,9 +37,6 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device_->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
-
             VideoCodecTest::SetUp();
         }
 

--- a/Plugin~/WebRTCPluginTest/InternalCodecsTest.cpp
+++ b/Plugin~/WebRTCPluginTest/InternalCodecsTest.cpp
@@ -5,8 +5,8 @@
 #include "GraphicsDeviceContainer.h"
 #include "VideoCodecTest.h"
 
-#include "test/video_codec_settings.h"
 #include "modules/video_coding/utility/vp8_header_parser.h"
+#include "test/video_codec_settings.h"
 
 namespace unity
 {
@@ -20,7 +20,12 @@ namespace webrtc
     class InternalCodecsTest : public VideoCodecTest
     {
     public:
-        InternalCodecsTest() { container_ = CreateGraphicsDeviceContainer(GetParam()); }
+        InternalCodecsTest()
+            : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
+        {
+            
+        }
         ~InternalCodecsTest() override
         {
             if (encoder_)
@@ -28,6 +33,17 @@ namespace webrtc
         }
 
     protected:
+        void SetUp() override
+        {
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+
+            VideoCodecTest::SetUp();
+        }
+
+
         SdpVideoFormat FindFormat(std::string name, const std::vector<SdpVideoFormat>& formats)
         {
             auto result =
@@ -98,6 +114,7 @@ namespace webrtc
         InternalEncoderFactory encoderFactory;
         InternalDecoderFactory decoderFactory;
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(InternalCodecsTest, EncodeFrameAndRelease)

--- a/Plugin~/WebRTCPluginTest/NvCodec/CudaDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/CudaDeviceTest.cpp
@@ -16,13 +16,19 @@ namespace webrtc
         {
             container_ = CreateGraphicsDeviceContainer(GetParam());
         }
+
+        void SetUp() override
+        {
+            if(!container_->device()->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+        }
     protected:
         std::unique_ptr<GraphicsDeviceContainer> container_;
     };
 
     TEST_P(CudaDeviceTest, GetCUcontext) { EXPECT_NE(container_->device()->GetCUcontext(), nullptr); }
 
-    TEST_P(CudaDeviceTest, IsNvSupported) { EXPECT_TRUE(container_->device()->IsCudaSupport()); }
+    TEST_P(CudaDeviceTest, IsCudaSupport) { EXPECT_TRUE(container_->device()->IsCudaSupport()); }
 
     INSTANTIATE_TEST_SUITE_P(GfxDevice, CudaDeviceTest, testing::ValuesIn(supportedGfxDevices));
 

--- a/Plugin~/WebRTCPluginTest/NvCodec/CudaDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/CudaDeviceTest.cpp
@@ -13,22 +13,27 @@ namespace webrtc
     {
     public:
         CudaDeviceTest()
+            : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
-            container_ = CreateGraphicsDeviceContainer(GetParam());
         }
 
+    protected:
         void SetUp() override
         {
-            if(!container_->device()->IsCudaSupport())
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if(!device_->IsCudaSupport())
                 GTEST_SKIP() << "CUDA is not supported on this device.";
         }
-    protected:
+
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
-    TEST_P(CudaDeviceTest, GetCUcontext) { EXPECT_NE(container_->device()->GetCUcontext(), nullptr); }
+    TEST_P(CudaDeviceTest, GetCUcontext) { EXPECT_NE(device_->GetCUcontext(), nullptr); }
 
-    TEST_P(CudaDeviceTest, IsCudaSupport) { EXPECT_TRUE(container_->device()->IsCudaSupport()); }
+    TEST_P(CudaDeviceTest, IsCudaSupport) { EXPECT_TRUE(device_->IsCudaSupport()); }
 
     INSTANTIATE_TEST_SUITE_P(GfxDevice, CudaDeviceTest, testing::ValuesIn(supportedGfxDevices));
 

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
@@ -32,6 +32,8 @@ namespace webrtc
             if(!container_->device()->IsCudaSupport())
                 GTEST_SKIP() << "CUDA is not supported on this device.";
             context_ = container_->device()->GetCUcontext();
+
+            VideoCodecTest::SetUp();
         }
     protected:
         std::unique_ptr<VideoEncoder> CreateEncoder() override

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
@@ -19,7 +19,6 @@ namespace webrtc
         NvCodecTest()
         {
             container_ = CreateGraphicsDeviceContainer(GetParam());
-            context_ = container_->device()->GetCUcontext();
         }
         ~NvCodecTest() override
         {
@@ -27,9 +26,13 @@ namespace webrtc
                 encoder_ = nullptr;
             if (decoder_)
                 decoder_ = nullptr;
-            EXPECT_TRUE(ck(cuCtxDestroy(context_)));
         }
-
+        void SetUp() override
+        {
+            if(!container_->device()->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+            context_ = container_->device()->GetCUcontext();
+        }
     protected:
         std::unique_ptr<VideoEncoder> CreateEncoder() override
         {

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvDecoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvDecoderImplTest.cpp
@@ -19,10 +19,14 @@ namespace webrtc
         NvDecoderImplTest()
         {
             container_ = CreateGraphicsDeviceContainer(GetParam());
-            context_ = container_->device()->GetCUcontext();
         }
         ~NvDecoderImplTest() override { }
-
+        void SetUp() override
+        {
+            if(!container_->device()->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+            context_ = container_->device()->GetCUcontext();
+        }
     protected:
         CUcontext context_;
         std::unique_ptr<GraphicsDeviceContainer> container_;

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvDecoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvDecoderImplTest.cpp
@@ -17,19 +17,25 @@ namespace webrtc
     {
     public:
         NvDecoderImplTest()
+            : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
-            container_ = CreateGraphicsDeviceContainer(GetParam());
         }
+
         ~NvDecoderImplTest() override { }
         void SetUp() override
         {
-            if(!container_->device()->IsCudaSupport())
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
                 GTEST_SKIP() << "CUDA is not supported on this device.";
-            context_ = container_->device()->GetCUcontext();
+
+            context_ = device_->GetCUcontext();
         }
     protected:
         CUcontext context_;
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(NvDecoderImplTest, CanInitializeWithDefaultParameters)

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
@@ -19,10 +19,15 @@ namespace webrtc
         NvEncoderImplTest()
         {
             container_ = CreateGraphicsDeviceContainer(GetParam());
-            context_ = container_->device()->GetCUcontext();
         }
         ~NvEncoderImplTest() override { }
 
+        void SetUp() override
+        {
+            if(!container_->device()->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+            context_ = container_->device()->GetCUcontext();
+        }
     protected:
         CUcontext context_;
         std::unique_ptr<GraphicsDeviceContainer> container_;

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
@@ -17,20 +17,25 @@ namespace webrtc
     {
     public:
         NvEncoderImplTest()
+            : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
-            container_ = CreateGraphicsDeviceContainer(GetParam());
         }
         ~NvEncoderImplTest() override { }
 
+    protected:
         void SetUp() override
         {
-            if(!container_->device()->IsCudaSupport())
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
                 GTEST_SKIP() << "CUDA is not supported on this device.";
+
             context_ = container_->device()->GetCUcontext();
         }
-    protected:
         CUcontext context_;
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(NvEncoderImplTest, CanInitializeWithDefaultParameters)

--- a/Plugin~/WebRTCPluginTest/UnityVideoDecoderFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/UnityVideoDecoderFactoryTest.cpp
@@ -22,8 +22,6 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device_->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
         }
         std::unique_ptr<GraphicsDeviceContainer> container_;
         IGraphicsDevice* device_;

--- a/Plugin~/WebRTCPluginTest/UnityVideoDecoderFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/UnityVideoDecoderFactoryTest.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "GraphicsDeviceContainer.h"
+#include "GraphicsDevice/IGraphicsDevice.h"
 #include "UnityVideoDecoderFactory.h"
 
 namespace unity
@@ -12,11 +13,20 @@ namespace webrtc
     public:
         UnityVideoDecoderFactoryTest()
             : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
         }
 
     protected:
+        void SetUp() override
+        {
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+        }
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(UnityVideoDecoderFactoryTest, GetSupportedFormats)

--- a/Plugin~/WebRTCPluginTest/UnityVideoEncoderFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/UnityVideoEncoderFactoryTest.cpp
@@ -22,8 +22,6 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device_->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
         }
         std::unique_ptr<GraphicsDeviceContainer> container_;
         IGraphicsDevice* device_;

--- a/Plugin~/WebRTCPluginTest/UnityVideoEncoderFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/UnityVideoEncoderFactoryTest.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "GraphicsDeviceContainer.h"
+#include "GraphicsDevice/IGraphicsDevice.h"
 #include "UnityVideoEncoderFactory.h"
 
 namespace unity
@@ -12,11 +13,20 @@ namespace webrtc
     public:
         UnityVideoEncoderFactoryTest()
             : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
         }
 
     protected:
+        void SetUp() override
+        {
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+        }
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(UnityVideoEncoderFactoryTest, GetSupportedFormats)

--- a/Plugin~/WebRTCPluginTest/VideoFrameTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoFrameTest.cpp
@@ -25,8 +25,6 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device_->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
         }
         std::unique_ptr<GraphicsDeviceContainer> container_;
         IGraphicsDevice* device_;

--- a/Plugin~/WebRTCPluginTest/VideoFrameTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoFrameTest.cpp
@@ -17,10 +17,19 @@ namespace webrtc
     public:
         explicit VideoFrameTest()
             : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
         {
         }
     protected:
+        void SetUp() override
+        {
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device_->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+        }
         std::unique_ptr<GraphicsDeviceContainer> container_;
+        IGraphicsDevice* device_;
     };
 
     TEST_P(VideoFrameTest, WrapExternalGpuMemoryBuffer)

--- a/Plugin~/WebRTCPluginTest/VideoFrameTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoFrameTest.cpp
@@ -25,15 +25,21 @@ namespace webrtc
         {
             if (!device_)
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
+
+            std::unique_ptr<ITexture2D> texture(device_->CreateDefaultTextureV(kWidth, kHeight, kFormat));
+            if (!texture)
+                GTEST_SKIP() << "The graphics driver cannot create a texture resource.";
         }
         std::unique_ptr<GraphicsDeviceContainer> container_;
         IGraphicsDevice* device_;
+        const uint32_t kWidth = 256;
+        const uint32_t kHeight = 256;
+        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
     };
 
     TEST_P(VideoFrameTest, WrapExternalGpuMemoryBuffer)
     {
-        const Size kSize(256, 256);
-        const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
+        const Size kSize(kWidth, kHeight);
         std::unique_ptr<ITexture2D> tex = std::unique_ptr<ITexture2D>(
             container_->device()->CreateDefaultTextureV(kSize.width(), kSize.height(), kFormat));
         rtc::scoped_refptr<VideoFrame> videoFrame = CreateTestFrame(container_->device(), tex.get(), kFormat);

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -22,7 +22,6 @@ namespace webrtc
     {
     public:
         VideoRendererTest()
-            : m_texture(device()->CreateDefaultTextureV(width, height, m_textureFormat))
         {
             m_trackSource = UnityVideoTrackSource::Create(
                 /*is_screencast=*/false,
@@ -30,14 +29,20 @@ namespace webrtc
             m_callback = &OnFrameSizeChange;
             m_renderer = std::make_unique<UnityVideoRenderer>(1, m_callback, true);
             m_trackSource->AddOrUpdateSink(m_renderer.get(), rtc::VideoSinkWants());
-
-            EXPECT_NE(nullptr, device());
-
-            context = std::make_unique<Context>(device());
         }
         ~VideoRendererTest() override { m_trackSource->RemoveSink(m_renderer.get()); }
 
     protected:
+        void SetUp() override
+        {
+            if (!device())
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+            if (!device()->IsCudaSupport())
+                GTEST_SKIP() << "CUDA is not supported on this device.";
+
+            m_texture.reset(device()->CreateDefaultTextureV(width, height, format()));
+            context = std::make_unique<Context>(device());
+        }
         std::unique_ptr<Context> context;
         std::unique_ptr<ITexture2D> m_texture;
 

--- a/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoRendererTest.cpp
@@ -37,9 +37,6 @@ namespace webrtc
         {
             if (!device())
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
-            if (!device()->IsCudaSupport())
-                GTEST_SKIP() << "CUDA is not supported on this device.";
-
             m_texture.reset(device()->CreateDefaultTextureV(width, height, format()));
             context = std::make_unique<Context>(device());
         }

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -44,8 +44,6 @@ protected:
     {
         if (!device())
             GTEST_SKIP() << "The graphics driver is not installed on the device.";
-        if (!device()->IsCudaSupport())
-            GTEST_SKIP() << "CUDA is not supported on this device.";
 
         m_texture.reset(device()->CreateDefaultTextureV(width, height, format()));
         context = std::make_unique<Context>(device());

--- a/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/VideoTrackSourceTest.cpp
@@ -29,19 +29,27 @@ const int height = 720;
 class VideoTrackSourceTest : public GraphicsDeviceTestBase
 {
 public:
-    VideoTrackSourceTest() : m_texture(device()->CreateDefaultTextureV(width, height, m_textureFormat))
+    VideoTrackSourceTest()
+        : m_texture(nullptr)
     {
         m_trackSource = UnityVideoTrackSource::Create(false, absl::nullopt);
         m_trackSource->AddOrUpdateSink(&mock_sink_, rtc::VideoSinkWants());
-
-        EXPECT_NE(nullptr, device());
-        context = std::make_unique<Context>(device());
     }
     ~VideoTrackSourceTest() override
     {
         m_trackSource->RemoveSink(&mock_sink_);
     }
 protected:
+    void SetUp() override
+    {
+        if (!device())
+            GTEST_SKIP() << "The graphics driver is not installed on the device.";
+        if (!device()->IsCudaSupport())
+            GTEST_SKIP() << "CUDA is not supported on this device.";
+
+        m_texture.reset(device()->CreateDefaultTextureV(width, height, format()));
+        context = std::make_unique<Context>(device());
+    }
     std::unique_ptr<Context> context;
     std::unique_ptr<ITexture2D> m_texture;
 

--- a/Plugin~/WebRTCPluginTest/pch.h
+++ b/Plugin~/WebRTCPluginTest/pch.h
@@ -12,8 +12,3 @@
 #if defined(LEAK_SANITIZER)
 #include <sanitizer/lsan_interface.h>
 #endif
-
-// workaround:
-// Visual Studio Test Adapter treats Skip type as a error.
-#define GTEST_SKIP_SUCCESS() \
-    return GTEST_MESSAGE_("Skipped", ::testing::TestPartResult::kSuccess)

--- a/Plugin~/tools/sanitizer/lsan_suppressions.txt
+++ b/Plugin~/tools/sanitizer/lsan_suppressions.txt
@@ -3,3 +3,4 @@
 # Leaks in Nvidia's library
 leak:libcuda.so
 leak:libnvidia-glcore.so
+leak:libGLX_nvidia.so


### PR DESCRIPTION
We are using google test for C/C++ testing and running tests automatically on CI. This pull request adds the type of instance for testing. The instances have no GPUs, so auto testing can check the features of fallback when nothing graphics device. 

Also, testcases are skipped when the testing environment don't meet the requirements.