### PR TITLE
fix: Update the Linux image to test the native code without cuda runtime

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -19,8 +19,8 @@ platforms:
   - name: linux
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/ubuntu-18.04:v0.2.17-948399
-    gpu_image: renderstreaming/ubuntu-18.04:v0.2.17-895145
+    image: renderstreaming/ubuntu:latest
+    gpu_image: renderstreaming/ubuntu:latest
     flavor: b1.large
     model: rtx2080
     build_command: BuildScripts~/build_plugin_linux.sh
@@ -78,7 +78,7 @@ test_targets:
         platform: standalone
   - name: linux
     type: Unity::VM
-    image: renderstreaming/ubuntu-18.04:v0.2.17-948399
+    image: renderstreaming/ubuntu:latest
     flavor: b1.large
     is_gpu: false
     gfx_types:
@@ -119,7 +119,7 @@ test_targets:
         platform: standalone
   - name: linux-gpu
     type: Unity::VM::GPU
-    image: renderstreaming/ubuntu-18.04:v0.2.17-895145
+    image: renderstreaming/ubuntu:latest
     flavor: b1.large
     model: rtx2080
     is_gpu: true
@@ -322,7 +322,7 @@ pack_{{ package.name }}:
   name: Pack {{ package.packagename }}
   agent:
     type: Unity::VM
-    image: renderstreaming/ubuntu-18.04:v0.2.17-948399
+    image: renderstreaming/ubuntu:latest
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
@@ -49,10 +49,11 @@ bool LoadModule()
         s_hModule = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_GLOBAL);
         if(!s_hModule)
             return false;
-        
+
         // Close handle immediately because going to call `dlopen` again
         // in the implib module when cuda api called.
         dlclose(s_hModule);
+        s_hModule = nullptr;
 #endif
     }
     return true;


### PR DESCRIPTION
This pull request update Linux image for testing native code.
This package doesn't require the CUDA runtime but it occurred crash when launching the app without CUDA library. 