### PR TITLE
fix: Fix using NV_ENC_BUFFER_FORMAT on OpenGLCore

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
@@ -36,7 +36,7 @@ public:
 #if CUDA_PLATFORM
     bool IsCudaSupport() override { return m_isCudaSupport; }
     CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
-    NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
+    NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ABGR; }
 #endif
 
 private:


### PR DESCRIPTION
Created texture with RGBA format with OpenGLCore 
https://github.com/Unity-Technologies/com.unity.webrtc/blob/develop/Runtime/Scripts/WebRTC.cs#L588

So, NV_ENC_BUFFER_FORMAT needs same same alignment. 