### PR TITLE
fix: Add lock object into the VideoFrameAdapter class

### DIFF
--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -14,4 +14,4 @@ echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
 cmake --preset=x64-windows-clang
-cmake --build --preset=release-windows-clang
+cmake --build --preset=release-windows-clang --target=WebRTCPlugin

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -102,12 +102,14 @@ void* UnityVideoRenderer::ConvertVideoFrameToTextureAndWriteToBuffer(
     if (m_needFlipVertical)
         height = -height;
 
-    if(0 > libyuv::ConvertFromI420(
+    int result = libyuv::ConvertFromI420(
         i420_buffer->DataY(), i420_buffer->StrideY(), i420_buffer->DataU(),
         i420_buffer->StrideU(), i420_buffer->DataV(), i420_buffer->StrideV(),
-        tempBuffer.data(), 0, width, height, format))
+        tempBuffer.data(), 0, width, height, format);
+
+    if(result)
     {
-        RTC_LOG(LS_INFO) << "failed libyuv::ConvertFromI420";
+        RTC_LOG(LS_INFO) << "libyuv::ConvertFromI420 failed. error:" << result;
     }
     return tempBuffer.data();
 }

--- a/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
+++ b/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
@@ -98,6 +98,7 @@ namespace webrtc
     rtc::scoped_refptr<I420BufferInterface>
     VideoFrameAdapter::ConvertToVideoFrameBuffer(rtc::scoped_refptr<VideoFrame> video_frame) const
     {
+        std::unique_lock<std::mutex> guard(frameLock_);
         if (i420Buffer_)
             return i420Buffer_;
 

--- a/Plugin~/WebRTCPlugin/VideoFrameAdapter.h
+++ b/Plugin~/WebRTCPlugin/VideoFrameAdapter.h
@@ -77,6 +77,7 @@ namespace webrtc
         mutable rtc::scoped_refptr<I420BufferInterface> i420Buffer_;
         const rtc::scoped_refptr<VideoFrame> frame_;
         const Size size_;
+        mutable std::mutex frameLock_;
     };
 }
 }

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -375,7 +375,9 @@ namespace Unity.WebRTC.RuntimeTest
             instance.Dispose();
         }
 
+        // todo(kazuki):There are bugs some platforms. Remove exclude platform.
         [UnityTest]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public IEnumerator CallVideoEncoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -421,10 +423,15 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.GetUpdateTextureFunc(IntPtr.Zero);
         }
 
+        // todo(kazuki):There are bugs some platforms. Remove exclude platform.
         [UnityTest]
         [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoDecoderMethods.UpdateRendererTexture is not supported on Direct3D12.")]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer })]
+        [UnityPlatform(exclude = new[] {
+            RuntimePlatform.LinuxEditor,
+            RuntimePlatform.LinuxPlayer,
+            RuntimePlatform.WindowsPlayer,
+        })]
         public IEnumerator CallVideoDecoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -377,7 +377,12 @@ namespace Unity.WebRTC.RuntimeTest
 
         // todo(kazuki):There are bugs some platforms. Remove exclude platform.
         [UnityTest]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
+        [UnityPlatform(exclude = new[] {
+            RuntimePlatform.LinuxEditor,
+            RuntimePlatform.LinuxPlayer,
+            RuntimePlatform.WindowsEditor,
+            RuntimePlatform.WindowsPlayer,
+        })]
         public IEnumerator CallVideoEncoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -430,6 +435,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] {
             RuntimePlatform.LinuxEditor,
             RuntimePlatform.LinuxPlayer,
+            RuntimePlatform.WindowsEditor,
             RuntimePlatform.WindowsPlayer,
         })]
         public IEnumerator CallVideoDecoderMethods()

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -375,14 +375,7 @@ namespace Unity.WebRTC.RuntimeTest
             instance.Dispose();
         }
 
-        // todo(kazuki):There are bugs some platforms. Remove exclude platform.
         [UnityTest]
-        [UnityPlatform(exclude = new[] {
-            RuntimePlatform.LinuxEditor,
-            RuntimePlatform.LinuxPlayer,
-            RuntimePlatform.WindowsEditor,
-            RuntimePlatform.WindowsPlayer,
-        })]
         public IEnumerator CallVideoEncoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -428,16 +421,9 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.GetUpdateTextureFunc(IntPtr.Zero);
         }
 
-        // todo(kazuki):There are bugs some platforms. Remove exclude platform.
         [UnityTest]
         [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoDecoderMethods.UpdateRendererTexture is not supported on Direct3D12.")]
-        [UnityPlatform(exclude = new[] {
-            RuntimePlatform.LinuxEditor,
-            RuntimePlatform.LinuxPlayer,
-            RuntimePlatform.WindowsEditor,
-            RuntimePlatform.WindowsPlayer,
-        })]
         public IEnumerator CallVideoDecoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);


### PR DESCRIPTION
This pull request fixes the crash occurring when using **MultiPeer** sample.

`VideoFrameAdapter::ConvertToVideoFrameBuffer` method changes the state of the `VideoFrameAdapter` instance. Moreover, multiple threads call this method at the same time.
So we need to protect the status with the synchronous object.