### PR TITLE
fix: crash perfectnegotiation using nvcodec

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -128,6 +128,10 @@ namespace webrtc
         : context_(context)
         , format_(format)
     {
+        // Some NVIDIA GPUs have a limited Encode Session count.
+        // refer: https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new
+        // It consumes a session to check the encoder capability.
+        // Therefore, we check encoder capability only once in the constructor and cache it.
         m_cachedSupportedFormats = SupportedNvEncoderCodecs(context_);
     }
     NvEncoderFactory::~NvEncoderFactory() = default;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -128,14 +128,14 @@ namespace webrtc
         : context_(context)
         , format_(format)
     {
+        m_cachedSupportedFormats = SupportedNvEncoderCodecs(context_);
     }
     NvEncoderFactory::~NvEncoderFactory() = default;
 
     std::vector<SdpVideoFormat> NvEncoderFactory::GetSupportedFormats() const
     {
         // If NvCodec Encoder is not supported, return empty vector.
-        auto codecs = SupportedNvEncoderCodecs(context_);
-        if(codecs.empty())
+        if (m_cachedSupportedFormats.empty())
             return std::vector<SdpVideoFormat>();
 
         // In RTCRtpTransceiver.SetCodecPreferences, the codec passed must be supported by both encoder and decoder.

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
@@ -55,6 +55,9 @@ namespace webrtc
     private:
         CUcontext context_;
         NV_ENC_BUFFER_FORMAT format_;
+
+        // Cache of capability to reduce calling SessionOpenAPI of NvEncoder
+        std::vector<SdpVideoFormat> m_cachedSupportedFormats;
     };
 
     class NvDecoderFactory : public VideoDecoderFactory

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -100,6 +100,7 @@ namespace webrtc
         }
         catch (const NVENCException& e)
         {
+            // todo: If Encoder initialization fails, need to notify for Managed side.
             RTC_LOG(LS_ERROR) << "Failed Initialize NvEncoder " << e.what();
             return WEBRTC_VIDEO_CODEC_ERROR;
         }

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -79,17 +79,29 @@ namespace webrtc
             return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
         }
 
-        if (m_memoryType == CU_MEMORYTYPE_DEVICE)
+        // Some NVIDIA GPUs have a limited Encode Session count.
+        // We can't get the Session count, so catching NvEncThrow to avoid the crash.
+        // refer: https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new
+        try
         {
-            m_encoder = std::make_unique<NvEncoderCuda>(m_context, codec->width, codec->height, m_format, 0);
+            if (m_memoryType == CU_MEMORYTYPE_DEVICE)
+            {
+                m_encoder = std::make_unique<NvEncoderCuda>(m_context, codec->width, codec->height, m_format, 0);
+            }
+            else if (m_memoryType == CU_MEMORYTYPE_ARRAY)
+            {
+                m_encoder =
+                    std::make_unique<NvEncoderCudaWithCUarray>(m_context, codec->width, codec->height, m_format, 0);
+            }
+            else
+            {
+                RTC_CHECK_NOTREACHED();
+            }
         }
-        else if (m_memoryType == CU_MEMORYTYPE_ARRAY)
+        catch (const NVENCException& e)
         {
-            m_encoder = std::make_unique<NvEncoderCudaWithCUarray>(m_context, codec->width, codec->height, m_format, 0);
-        }
-        else
-        {
-            RTC_CHECK_NOTREACHED();
+            RTC_LOG(LS_ERROR) << "Failed Initialize NvEncoder " << e.what();
+            return WEBRTC_VIDEO_CODEC_ERROR;
         }
 
         m_bitrateAdjuster = std::make_unique<BitrateAdjuster>(0.5f, 0.95f);


### PR DESCRIPTION
Cache NvEnc Capability on `NvEncoderFactory`, it reduce calling `NvEncOpenSessionEx` api.
and implement TryCatch on initialize `NvEncoder` (include calling `NvEncOpenSessionEx`) for avoid crash when session limitation.