### PR TITLE
fix: Fix the bug which the frame of receiving video is wrong when using OpenGL API

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -25,6 +25,17 @@ namespace webrtc
 GLuint fbo[2];
 #endif
 
+Size glTexSize(GLenum target, GLuint texture, GLint mipLevel)
+{
+    int width = 0, height = 0;
+    glBindTexture(target, texture);
+    glGetTexLevelParameteriv(target, mipLevel, GL_TEXTURE_WIDTH, &width);
+    glGetTexLevelParameteriv(target, mipLevel, GL_TEXTURE_HEIGHT, &height);
+    glBindTexture(target, 0);
+    return Size(width, height);
+}
+
+
 OpenGLGraphicsDevice::OpenGLGraphicsDevice(
     UnityGfxRenderer renderer)
     : IGraphicsDevice(renderer)
@@ -102,24 +113,26 @@ ITexture2D* OpenGLGraphicsDevice::CreateCPUReadTextureV(
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool OpenGLGraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src) {
-    const uint32_t width = dest->GetWidth();
-    const uint32_t height  = dest->GetHeight();
-    const GLuint dstName = reinterpret_cast<uintptr_t>(dest->GetNativeTexturePtrV());
-    const GLuint srcName = reinterpret_cast<uintptr_t>(src->GetNativeTexturePtrV());
-    return CopyResource(dstName, srcName, width, height);
+bool OpenGLGraphicsDevice::CopyResourceV(ITexture2D* dst, ITexture2D* src)
+{
+    OpenGLTexture2D* srcTexture = static_cast<OpenGLTexture2D*>(src);
+    OpenGLTexture2D* dstTexture = static_cast<OpenGLTexture2D*>(dst);
+    const GLuint srcName = srcTexture->GetTexture();
+    const GLuint dstName = dstTexture->GetTexture();
+    return CopyResource(dstName, srcName);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool OpenGLGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) {
-    const uint32_t width = dest->GetWidth();
-    const uint32_t height  = dest->GetHeight();
-    const GLuint dstName = reinterpret_cast<uintptr_t>(dest->GetNativeTexturePtrV());
+bool OpenGLGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dst, void* nativeTexturePtr)
+{
+    OpenGLTexture2D* dstTexture = static_cast<OpenGLTexture2D*>(dst);
     const GLuint srcName = reinterpret_cast<uintptr_t>(nativeTexturePtr);
-    return CopyResource(dstName, srcName, width, height);
+    const GLuint dstName = dstTexture->GetTexture();
+    return CopyResource(dstName, srcName);
 }
 
-bool OpenGLGraphicsDevice::CopyResource(GLuint dstName, GLuint srcName, uint32 width, uint32 height) {
+bool OpenGLGraphicsDevice::CopyResource(GLuint dstName, GLuint srcName)
+{
     if(srcName == dstName)
     {
         RTC_LOG(LS_INFO) << "Same texture";
@@ -136,24 +149,31 @@ bool OpenGLGraphicsDevice::CopyResource(GLuint dstName, GLuint srcName, uint32 w
         return false;
     }
 
+    Size srcSize = glTexSize(GL_TEXTURE_2D, srcName, 0);
+    Size dstSize = glTexSize(GL_TEXTURE_2D, dstName, 0);
+
+    if(srcSize.width() == 0 || srcSize.height() == 0)
+    {
+        RTC_LOG(LS_INFO) << "texture size is not valid";
+        return false;
+    }
+    if(srcSize != dstSize)
+    {
+        RTC_LOG(LS_INFO) << "texture size is not same";
+        return false;
+    }
+
     // todo(kazuki): "glCopyImageSubData" is available since OpenGL ES 3.2 on Android platform.
     // OpenGL ES 3.2 is needed to use API level 24.
-//#if SUPPORT_OPENGL_CORE
     glCopyImageSubData(
         srcName, GL_TEXTURE_2D, 0, 0, 0, 0,
         dstName, GL_TEXTURE_2D, 0, 0, 0, 0,
-        width, height, 1);
-// #elif SUPPORT_OPENGL_ES
-//     glBindTexture(GL_TEXTURE_2D, srcName);
-//     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo[1]);
-//     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER,
-//         GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, srcName, 0);
+        dstSize.width(), dstSize.height(), 1);
 
-//     glBindTexture(GL_TEXTURE_2D, dstName);
-//     glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width, height);
-//     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-//     glBindTexture(GL_TEXTURE_2D, 0);
-// #endif
+    // todo(kazuki): "glFinish" is used to sync GPU for waiting to copy the texture buffer.
+    // But this command affects graphics performance.
+    glFinish();
+
     return true;
 }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
@@ -40,7 +40,7 @@ public:
 #endif
 
 private:
-    bool CopyResource(GLuint dstName, GLuint srcName, uint32 width, uint32 height);
+    bool CopyResource(GLuint dstName, GLuint srcName);
     void ReleaseTexture(OpenGLTexture2D* texture);
 #if CUDA_PLATFORM
     CudaContext m_cudaContext;


### PR DESCRIPTION
This bug is able to reproduced using `MultiVideoRecv` sample. This sample is for testing multi video tracks. The problem is displaying received video frames are wrong sometimes.

I fixed the bug by using `glFinish` function at the end of `OpenGL Graphics Device::CopyResource` method. I am checking whether there is another way because the function affects graphics performance.