### PR TITLE
fix: Use IUnityGraphicsVulkanV2 to intercept Vulkan initialization process of Unity

### DIFF
--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -9,7 +9,7 @@ source ~/.profile
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
 
-# Install libc++, libc++abi clang glut
+# Install glfw3
 sudo apt install -y libglfw3-dev
 
 # Install glad2

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -10,9 +10,7 @@ curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
 
 # Install libc++, libc++abi clang glut
-# TODO:: Remove this install process from here and recreate an image to build the plugin.
-sudo apt update
-sudo apt install -y clang-10 libc++-10-dev libc++abi-10-dev freeglut3-dev
+sudo apt install -y libglfw3-dev
 
 # Install glad2
 pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad

--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -14,10 +14,8 @@ source ~/.profile
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
 
-# Install libc++, libc++abi googletest clang glut
-# TODO:: Remove this install process from here and recreate an image to build the plugin.
-sudo apt update
-sudo apt install -y clang-10 libc++-10-dev libc++abi-10-dev freeglut3-dev
+# Install libglfw3-dev
+sudo apt install -y libglfw3-dev
 
 # Install glad2
 pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad

--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -14,7 +14,7 @@ source ~/.profile
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
 
-# Install libglfw3-dev
+# Install glfw3
 sudo apt install -y libglfw3-dev
 
 # Install glad2

--- a/Plugin~/.clang-format
+++ b/Plugin~/.clang-format
@@ -1,5 +1,6 @@
 BasedOnStyle: WebKit
 AlignAfterOpenBracket: AlwaysBreak
+AlwaysBreakTemplateDeclarations: true
 NamespaceIndentation: Inner
 BreakBeforeBraces: Allman
 BreakBeforeBinaryOperators: None

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -350,6 +350,7 @@ target_sources(WebRTCPlugin
     pch.h
     WebRTCPlugin.cpp
     UnityRenderEvent.cpp
+    UnityVulkanInterfaceFunctions.h
 )
 
 # rename dll/framework filename

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
@@ -160,7 +160,7 @@ CUresult CudaContext::Init(const VkInstance instance, VkPhysicalDevice physicalD
 #if defined(SUPPORT_D3D11)
 CUresult CudaContext::Init(ID3D11Device* device)
 {
-    bool found = LoadModule();
+    bool found = FindModule();
     if (!found)
     {
         return CUDA_ERROR_NOT_FOUND;
@@ -204,7 +204,7 @@ CUresult CudaContext::Init(ID3D11Device* device)
 CUresult CudaContext::Init(ID3D12Device* device)
 {
 
-    bool found = LoadModule();
+    bool found = FindModule();
     if (!found)
     {
         return CUDA_ERROR_NOT_FOUND;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.h
@@ -18,7 +18,7 @@ public:
     ~CudaContext() = default;
 
     CUresult Init(const VkInstance instance, VkPhysicalDevice physicalDevice);
-    static CUresult FindCudaDevice(const uint8_t* uuid, CUdevice* cuDevice);
+    void Shutdown();
 
 #if defined(UNITY_WIN)
     CUresult Init(ID3D11Device* device);
@@ -28,10 +28,11 @@ public:
     CUresult InitGL();
 #endif
 
-    void Shutdown();
 
     // This method returns context for the thread which called the method.
     CUcontext GetContext() const;
+
+    static CUresult FindCudaDevice(const uint8_t* uuid, CUdevice* cuDevice);
 private:
     CUcontext m_context;
 };

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/UnityVulkanInitCallback.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/UnityVulkanInitCallback.cpp
@@ -52,13 +52,20 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateDevice(
         std::inserter(newExtensions, std::end(newExtensions))
         );
 
+    RTC_LOG(LS_INFO) << "WebRTC plugin intercepts vkCreateDevice.";
+
+    for (auto extension : newExtensions)
+    {
+        RTC_LOG(LS_INFO) << "[Vulkan init intercept] extensions: name=" << extension;
+    }
+
     // replace extension name list
     newCreateInfo.ppEnabledExtensionNames = newExtensions.data();
     newCreateInfo.enabledExtensionCount = static_cast<uint32_t>(newExtensions.size());
     VkResult result = vkCreateDevice(physicalDevice, &newCreateInfo, pAllocator, pDevice);
     if(result != VK_SUCCESS)
     {
-        RTC_LOG(LS_ERROR) << "vkCreateDevice:" << result;
+        RTC_LOG(LS_ERROR) << "vkCreateDevice failed. error:" << result;
         return result;
     }
     if (!LoadDeviceVulkanFunction(*pDevice))
@@ -70,7 +77,6 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateDevice(
 static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateInstance(
     const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance)
 {
-
     if (!LoadGlobalVulkanFunction())
         return VK_ERROR_INITIALIZATION_FAILED;
 
@@ -93,6 +99,13 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateInstance(
         std::inserter(newExtensions, std::end(newExtensions))
     );
 
+    RTC_LOG(LS_INFO) << "WebRTC plugin intercepts vkCreateInstance.";
+
+    for (auto extension : newExtensions)
+    {
+        RTC_LOG(LS_INFO) << "[Vulkan init intercept] extensions: name=" << extension;
+    }
+
     // replace extension name list
     newCreateInfo.ppEnabledExtensionNames = newExtensions.data();
     newCreateInfo.enabledExtensionCount = static_cast<uint32_t>(newExtensions.size());
@@ -100,7 +113,8 @@ static VKAPI_ATTR VkResult VKAPI_CALL Hook_vkCreateInstance(
     VkResult result = vkCreateInstance(&newCreateInfo, pAllocator, pInstance);
     if (result != VK_SUCCESS)
     {
-        RTC_LOG(LS_ERROR) << "vkCreateInstance:" << result;
+        RTC_LOG(LS_ERROR) << "vkCreateInstance failed. error:" << result;
+        return result;
     }
 
     if (!LoadInstanceVulkanFunction(*pInstance))

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -29,6 +29,7 @@ VulkanGraphicsDevice::VulkanGraphicsDevice( IUnityGraphicsVulkan* unityVulkan, c
     , m_allocator(nullptr)
 #if CUDA_PLATFORM
     , m_instance(instance)
+    , m_isCudaSupport(false)
 #endif
 {
 }
@@ -37,11 +38,24 @@ VulkanGraphicsDevice::VulkanGraphicsDevice( IUnityGraphicsVulkan* unityVulkan, c
 bool VulkanGraphicsDevice::InitV()
 {
 #if CUDA_PLATFORM
-    CUresult result = m_cudaContext.Init(m_instance, m_physicalDevice);
-    m_isCudaSupport = CUDA_SUCCESS == result;
+    m_isCudaSupport = InitCudaContext();
 #endif
     return VK_SUCCESS == CreateCommandPool();
 }
+
+#if CUDA_PLATFORM
+bool VulkanGraphicsDevice::InitCudaContext()
+{
+    if (!VulkanUtility::LoadInstanceFunctions(m_instance))
+        return false;
+    if (!VulkanUtility::LoadDeviceFunctions(m_device))
+        return false;
+    CUresult result = m_cudaContext.Init(m_instance, m_physicalDevice);
+    if (CUDA_SUCCESS != result)
+        return false;
+    return true;
+}
+#endif
 
 //---------------------------------------------------------------------------------------------------------------------
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -65,6 +65,7 @@ private:
     uint32_t m_queueFamilyIndex;
     VkAllocationCallbacks* m_allocator;
 #if CUDA_PLATFORM
+    bool InitCudaContext();
     VkInstance m_instance;
     CudaContext m_cudaContext;
     bool m_isCudaSupport;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.cpp
@@ -19,7 +19,9 @@ namespace unity
 namespace webrtc
 {
 
+#ifdef _WIN32
     static PFN_vkGetMemoryWin32HandleKHR vkGetMemoryWin32HandleKHR = nullptr;
+#endif
     static PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR = nullptr;
     static PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR = nullptr;
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.cpp
@@ -19,7 +19,10 @@ namespace unity
 namespace webrtc
 {
 
-//
+    static PFN_vkGetMemoryWin32HandleKHR vkGetMemoryWin32HandleKHR = nullptr;
+    static PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR = nullptr;
+    static PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR = nullptr;
+
 bool VulkanUtility::FindMemoryTypeInto(
     const VkPhysicalDevice physicalDevice, uint32_t typeFilter,
         VkMemoryPropertyFlags properties, uint32_t* memoryTypeIndex)
@@ -219,19 +222,43 @@ bool VulkanUtility::GetPhysicalDeviceUUIDInto(VkInstance instance, VkPhysicalDev
     props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
     props.pNext = &deviceIDProps;
 
-    PFN_vkGetPhysicalDeviceProperties2KHR func = (PFN_vkGetPhysicalDeviceProperties2KHR) 
-        vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
-    if (func == nullptr) {
-        return false;
-    }
-
-    func(phyDevice, &props);
+    vkGetPhysicalDeviceProperties2KHR(phyDevice, &props);
     std::memcpy(deviceUUID->data(), deviceIDProps.deviceUUID, VK_UUID_SIZE);
 
     return true;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+bool VulkanUtility::LoadDeviceFunctions(const VkDevice device)
+{
+#ifndef _WIN32
+    vkGetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)vkGetDeviceProcAddr(device, "vkGetMemoryFdKHR");
+    if (!vkGetMemoryFdKHR)
+    {
+        RTC_LOG(LS_INFO) << "Failed to retrieve vkGetMemoryFdKHR";
+        return false;
+    }
+#else
+    vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)vkGetDeviceProcAddr(device, "vkGetMemoryWin32HandleKHR");
+    if (!vkGetMemoryWin32HandleKHR)
+    {
+        RTC_LOG(LS_INFO) << "Failed to retrieve vkGetMemoryWin32HandleKHR";
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool VulkanUtility::LoadInstanceFunctions(const VkInstance instance)
+{
+    vkGetPhysicalDeviceProperties2KHR =
+        (PFN_vkGetPhysicalDeviceProperties2KHR)vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2KHR");
+    if (vkGetPhysicalDeviceProperties2KHR == nullptr)
+    {
+        RTC_LOG(LS_INFO) << "Failed to retrieve vkGetPhysicalDeviceProperties2KHR";
+        return false;
+    }
+    return true;
+}
 
 #ifndef _WIN32
 void* VulkanUtility::GetExportHandle(const VkDevice device, const VkDeviceMemory memory)
@@ -243,11 +270,10 @@ void* VulkanUtility::GetExportHandle(const VkDevice device, const VkDeviceMemory
     fdInfo.memory = memory;
     fdInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 
-    auto func = (PFN_vkGetMemoryFdKHR) \
-        vkGetDeviceProcAddr(device, "vkGetMemoryFdKHR");
-
-    if (!func ||
-        func(device, &fdInfo, &fd) != VK_SUCCESS) {
+    VkResult result = vkGetMemoryFdKHR(device, &fdInfo, &fd);
+    if (result != VK_SUCCESS)
+    {
+        RTC_LOG(LS_ERROR) << "vkGetMemoryFdKHR error" << result;
         return nullptr;
     }
 
@@ -263,16 +289,7 @@ void* VulkanUtility::GetExportHandle(const VkDevice device, const VkDeviceMemory
     handleInfo.memory = memory;
     handleInfo.handleType = EXTERNAL_MEMORY_HANDLE_SUPPORTED_TYPE;
 
-    PFN_vkGetMemoryWin32HandleKHR fpGetMemoryWin32HandleKHR =
-        (PFN_vkGetMemoryWin32HandleKHR) vkGetDeviceProcAddr(device, "vkGetMemoryWin32HandleKHR");
-
-    if (!fpGetMemoryWin32HandleKHR)
-    {
-        RTC_LOG(LS_ERROR) << "Failed to retrieve vkGetMemoryWin32HandleKHR";
-        return nullptr;
-    }
-
-    VkResult result = fpGetMemoryWin32HandleKHR(device, &handleInfo, &handle);
+    VkResult result = vkGetMemoryWin32HandleKHR(device, &handleInfo, &handle);
     if (result != VK_SUCCESS)
     {
         RTC_LOG(LS_ERROR) << "vkGetMemoryWin32HandleKHR error" << result;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.h
@@ -35,6 +35,8 @@ public:
         std::array<uint8_t, VK_UUID_SIZE>* deviceUUID
     );
 
+    static bool LoadDeviceFunctions(const VkDevice device);
+    static bool LoadInstanceFunctions(const VkInstance instance);
     static void* GetExportHandle(const VkDevice device, const VkDeviceMemory memory);
 
     static VkResult BeginOneTimeCommandBufferInto(const VkDevice device, const VkCommandPool commandPool,

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -13,6 +13,7 @@
 #include "GpuMemoryBufferPool.h"
 
 #if defined(SUPPORT_VULKAN)
+#include "UnityVulkanInterfaceFunctions.h"
 #include "GraphicsDevice/Vulkan/UnityVulkanInitCallback.h"
 #endif
 
@@ -209,10 +210,6 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 }
 #endif
 
-template<typename T> void InterceptInitialization(T& vulkan, UnityVulkanInitCallback func, void* userdata)
-{
-    vulkan.InterceptInitialization(InterceptVulkanInitialization, nullptr);
-}
 
 // Unity plugin load event
 void PluginLoad(IUnityInterfaces* unityInterfaces)
@@ -227,12 +224,13 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
     s_clock.reset(Clock::GetRealTimeClock());
 
 #if defined(SUPPORT_VULKAN)
-    IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
-    if(vulkan != nullptr)
-    {
-        //InterceptInitialization(*vulkan, InterceptVulkanInitialization, nullptr);
-        vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
-    }
+    //IUnityGraphicsVulkanV2* vulkan = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
+    auto vulkan = UnityGraphicsVulkan::Get(unityInterfaces);
+    vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
+    //if (vulkan != nullptr)
+    //{
+    //    vulkan.InterceptInitialization(InterceptVulkanInitialization, nullptr);
+    //}
 #endif
 
     IUnityProfiler* unityProfiler = unityInterfaces->Get<IUnityProfiler>();

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -209,6 +209,11 @@ extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload()
 }
 #endif
 
+template<typename T> void InterceptInitialization(T& vulkan, UnityVulkanInitCallback func, void* userdata)
+{
+    vulkan.InterceptInitialization(InterceptVulkanInitialization, nullptr);
+}
+
 // Unity plugin load event
 void PluginLoad(IUnityInterfaces* unityInterfaces)
 {
@@ -225,7 +230,8 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
     IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
     if(vulkan != nullptr)
     {
-        vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
+        InterceptInitialization(*vulkan, InterceptVulkanInitialization, nullptr);
+        //vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
     }
 #endif
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -133,14 +133,12 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
 #if defined(SUPPORT_VULKAN)
         if (renderer == kUnityGfxRendererVulkan)
         {
-            IUnityGraphicsVulkan* vulkan = s_UnityInterfaces->Get<IUnityGraphicsVulkan>();
-            if (vulkan != nullptr)
+            std::unique_ptr<UnityGraphicsVulkan> vulkan = UnityGraphicsVulkan::Get(s_UnityInterfaces);
+            UnityVulkanInstance instance = vulkan->Instance();
+            if (!LoadVulkanFunctions(instance))
             {
-                UnityVulkanInstance instance = vulkan->Instance();
-                if (!LoadVulkanFunctions(instance))
-                {
-                    return;
-                }
+                RTC_LOG(LS_INFO) << "LoadVulkanFunctions failed";
+                return;
             }
         }
 #endif
@@ -224,13 +222,8 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
     s_clock.reset(Clock::GetRealTimeClock());
 
 #if defined(SUPPORT_VULKAN)
-    //IUnityGraphicsVulkanV2* vulkan = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
-    auto vulkan = UnityGraphicsVulkan::Get(unityInterfaces);
+    auto vulkan = UnityGraphicsVulkan::Get(s_UnityInterfaces);
     vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
-    //if (vulkan != nullptr)
-    //{
-    //    vulkan.InterceptInitialization(InterceptVulkanInitialization, nullptr);
-    //}
 #endif
 
     IUnityProfiler* unityProfiler = unityInterfaces->Get<IUnityProfiler>();

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -223,9 +223,9 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
 
 #if defined(SUPPORT_VULKAN)
     auto vulkan = UnityGraphicsVulkan::Get(s_UnityInterfaces);
-    if (!vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr))
+    if (!vulkan->AddInterceptInitialization(InterceptVulkanInitialization, nullptr, 0))
     {
-        RTC_LOG(LS_INFO) << "InterceptInitialization failed.";
+        RTC_LOG(LS_INFO) << "AddInterceptInitialization failed.";
     }
 #endif
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -230,8 +230,8 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
     IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
     if(vulkan != nullptr)
     {
-        InterceptInitialization(*vulkan, InterceptVulkanInitialization, nullptr);
-        //vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
+        //InterceptInitialization(*vulkan, InterceptVulkanInitialization, nullptr);
+        vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
     }
 #endif
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -223,7 +223,10 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
 
 #if defined(SUPPORT_VULKAN)
     auto vulkan = UnityGraphicsVulkan::Get(s_UnityInterfaces);
-    vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr);
+    if (!vulkan->InterceptInitialization(InterceptVulkanInitialization, nullptr))
+    {
+        RTC_LOG(LS_INFO) << "InterceptInitialization failed.";
+    }
 #endif
 
     IUnityProfiler* unityProfiler = unityInterfaces->Get<IUnityProfiler>();

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -1,11 +1,44 @@
-//#include <vulkan/vulkan.h>
 #include <IUnityGraphicsVulkan.h>
-//#include <IUnityProfiler.h>
-//#include <IUnityRenderingExtensions.h>
 
-template<typename T>
-void InterceptInitialization(T& vulkan, UnityVulkanInitCallback func, void* userdata)
+namespace unity
 {
-    vulkan.InterceptInitialization(func, nullptr);
-}
+namespace webrtc
+{
+    class UnityGraphicsVulkan
+    {
+    public:
+        virtual void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) = 0;
 
+        static std::unique_ptr<UnityGraphicsVulkan> Get(IUnityInterfaces* unityInterfaces)
+        {
+            IUnityGraphicsVulkanV2* vulkanV2 = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
+            if (vulkanV2)
+                return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkanV2>>(vulkanV2);
+            IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
+            if (vulkan)
+                return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkan>>(vulkan);
+            return nullptr;
+        }
+    };
+
+
+    template<class T>
+    class UnityGraphicsVulkanImpl : public UnityGraphicsVulkan
+    {
+    public:
+        UnityGraphicsVulkanImpl(T* vulkanInterface)
+            : vulkanInterface_(vulkanInterface)
+        {
+        }
+        ~UnityGraphicsVulkan() = default;
+
+        void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) override
+        {
+            vulkan.InterceptInitialization(func, nullptr);
+        }
+
+    private:
+        T* vulkanInterface_;
+    };
+}
+}

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -8,21 +8,12 @@ namespace webrtc
     {
     public:
         virtual void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) = 0;
+        virtual UnityVulkanInstance Instance() = 0;
 
-        static std::unique_ptr<UnityGraphicsVulkan> Get(IUnityInterfaces* unityInterfaces)
-        {
-            IUnityGraphicsVulkanV2* vulkanV2 = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
-            if (vulkanV2)
-                return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkanV2>>(vulkanV2);
-            IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
-            if (vulkan)
-                return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkan>>(vulkan);
-            return nullptr;
-        }
+        static std::unique_ptr<UnityGraphicsVulkan> Get(IUnityInterfaces* unityInterfaces);
     };
 
-
-    template<class T>
+    template<typename T>
     class UnityGraphicsVulkanImpl : public UnityGraphicsVulkan
     {
     public:
@@ -30,15 +21,29 @@ namespace webrtc
             : vulkanInterface_(vulkanInterface)
         {
         }
-        ~UnityGraphicsVulkan() = default;
+        ~UnityGraphicsVulkanImpl() = default;
 
         void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) override
         {
-            vulkan.InterceptInitialization(func, nullptr);
+            vulkanInterface_->InterceptInitialization(func, userdata);
         }
+
+        UnityVulkanInstance Instance() override { return vulkanInterface_->Instance(); }
 
     private:
         T* vulkanInterface_;
     };
+
+    std::unique_ptr<UnityGraphicsVulkan> UnityGraphicsVulkan::Get(IUnityInterfaces* unityInterfaces)
+    {
+        IUnityGraphicsVulkanV2* vulkanV2 = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
+        if (vulkanV2)
+            return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkanV2>>(vulkanV2);
+        IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
+        if (vulkan)
+            return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkan>>(vulkan);
+        return nullptr;
+    }
+
 }
 }

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -4,10 +4,25 @@ namespace unity
 {
 namespace webrtc
 {
+    template<typename T>
+    inline bool AddInterceptInitialization(T* instance, UnityVulkanInitCallback func, void* userdata, int priority)
+    {
+        return instance->AddInterceptInitialization(func, userdata, priority);
+    }
+
+    template<>
+    inline bool AddInterceptInitialization(IUnityGraphicsVulkan* instance, UnityVulkanInitCallback func, void* userdata, int priority)
+    {
+        // IUnityGraphicsVulkan is not supported AddInterceptInitialization.
+        return instance->InterceptInitialization(func, userdata);
+    }
+
     class UnityGraphicsVulkan
     {
     public:
         virtual bool InterceptInitialization(UnityVulkanInitCallback func, void* userdata) = 0;
+        virtual PFN_vkVoidFunction InterceptVulkanAPI(const char* name, PFN_vkVoidFunction func) = 0;
+        virtual bool AddInterceptInitialization(UnityVulkanInitCallback func, void* userdata, int priority) = 0;
         virtual UnityVulkanInstance Instance() = 0;
         virtual ~UnityGraphicsVulkan() = default;
 
@@ -27,6 +42,16 @@ namespace webrtc
         bool InterceptInitialization(UnityVulkanInitCallback func, void* userdata) override
         {
             return vulkanInterface_->InterceptInitialization(func, userdata);
+        }
+
+        PFN_vkVoidFunction InterceptVulkanAPI(const char* name, PFN_vkVoidFunction func) override
+        {
+            return vulkanInterface_->InterceptVulkanAPI(name, func);
+        }
+
+        bool AddInterceptInitialization(UnityVulkanInitCallback func, void* userdata, int priority) override
+        {
+            return unity::webrtc::AddInterceptInitialization(vulkanInterface_, func, userdata, priority);
         }
 
         UnityVulkanInstance Instance() override { return vulkanInterface_->Instance(); }

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -9,6 +9,7 @@ namespace webrtc
     public:
         virtual void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) = 0;
         virtual UnityVulkanInstance Instance() = 0;
+        virtual ~UnityGraphicsVulkan() = default;
 
         static std::unique_ptr<UnityGraphicsVulkan> Get(IUnityInterfaces* unityInterfaces);
     };

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -1,0 +1,7 @@
+#include
+
+template<typename T> void InterceptInitialization(T& vulkan, UnityVulkanInitCallback func, void* userdata)
+{
+    vulkan.InterceptInitialization(InterceptVulkanInitialization, nullptr);
+}
+

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -7,7 +7,7 @@ namespace webrtc
     class UnityGraphicsVulkan
     {
     public:
-        virtual void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) = 0;
+        virtual bool InterceptInitialization(UnityVulkanInitCallback func, void* userdata) = 0;
         virtual UnityVulkanInstance Instance() = 0;
         virtual ~UnityGraphicsVulkan() = default;
 
@@ -24,9 +24,9 @@ namespace webrtc
         }
         ~UnityGraphicsVulkanImpl() = default;
 
-        void InterceptInitialization(UnityVulkanInitCallback func, void* userdata) override
+        bool InterceptInitialization(UnityVulkanInitCallback func, void* userdata) override
         {
-            vulkanInterface_->InterceptInitialization(func, userdata);
+            return vulkanInterface_->InterceptInitialization(func, userdata);
         }
 
         UnityVulkanInstance Instance() override { return vulkanInterface_->Instance(); }

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -1,7 +1,11 @@
-#include
+//#include <vulkan/vulkan.h>
+#include <IUnityGraphicsVulkan.h>
+//#include <IUnityProfiler.h>
+//#include <IUnityRenderingExtensions.h>
 
-template<typename T> void InterceptInitialization(T& vulkan, UnityVulkanInitCallback func, void* userdata)
+template<typename T>
+void InterceptInitialization(T& vulkan, UnityVulkanInitCallback func, void* userdata)
 {
-    vulkan.InterceptInitialization(InterceptVulkanInitialization, nullptr);
+    vulkan.InterceptInitialization(func, nullptr);
 }
 

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -170,7 +170,7 @@ elseif(macOS)
       ${WEBRTC_OBJC_INCLUDE_DIR}
   )
 elseif(Linux)
-  find_package(GLUT REQUIRED)
+  find_package(glfw3 REQUIRED)
 
   target_compile_options(WebRTCLibTest
     PUBLIC
@@ -191,9 +191,9 @@ elseif(Linux)
 
   target_link_libraries(WebRTCLibTest
     PRIVATE
-      ${GLUT_LIBRARY}
       ${CMAKE_DL_LIBS}
       ${CMAKE_THREAD_LIBS_INIT}
+      glfw
       gtest
       gmock
       gtest_main

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -393,7 +393,9 @@ namespace webrtc
 
             const GLuint kWidth = 320;
             const GLuint kHeight = 240;
+            __lsan_disable();
             s_window = glfwCreateWindow(kWidth, kHeight, "test", nullptr, nullptr);
+            __lsan_enable();
             glfwMakeContextCurrent(s_window);
             s_glfwInitialized = true;
         }

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -16,7 +16,7 @@
 
 #if SUPPORT_OPENGL_CORE
 #include "GraphicsDevice/OpenGL/OpenGLContext.h"
-#include <GL/glut.h>
+#include <GLFW/glfw3.h>
 #include <sanitizer/lsan_interface.h>
 #endif
 
@@ -162,7 +162,7 @@ namespace webrtc
         return LoadGlobalVulkanFunction();
     }
 
-    int32_t GetPhysicalDeviceIndex(VkInstance instance, std::vector<VkPhysicalDevice>& list, bool* found)
+    int32_t GetPhysicalDeviceIndex(VkInstance instance, std::vector<VkPhysicalDevice>& list, bool findCudaDevice, bool* found)
     {
         std::array<uint8_t, VK_UUID_SIZE> deviceUUID;
         for (size_t i = 0; i < list.size(); ++i)
@@ -173,7 +173,7 @@ namespace webrtc
                 continue;
             }
 #if CUDA_PLATFORM
-            if (CudaContext::FindCudaDevice(deviceUUID.data(), nullptr) != CUDA_SUCCESS)
+            if (findCudaDevice && CudaContext::FindCudaDevice(deviceUUID.data(), nullptr) != CUDA_SUCCESS)
             {
                 continue;
             }
@@ -268,7 +268,9 @@ namespace webrtc
         }
 
         bool found = false;
-        int32_t physicalDeviceIndex = GetPhysicalDeviceIndex(instance, physicalDeviceList, &found);
+        // todo:: Add test pattern for HWA codecs.
+        bool findCudaDevice = false;
+        int32_t physicalDeviceIndex = GetPhysicalDeviceIndex(instance, physicalDeviceList, findCudaDevice, &found);
         if (!found)
         {
             RTC_LOG(LS_INFO) << "GetPhysicalDeviceIndex device not found.";
@@ -377,19 +379,23 @@ namespace webrtc
 
 #if SUPPORT_OPENGL_CORE
 
-    static bool s_glutInitialized;
-    static int s_window;
+    static bool s_glfwInitialized;
+    static GLFWwindow* s_window;
 
     void* CreateDeviceGLCore()
     {
-        if (!s_glutInitialized)
+        if (!s_glfwInitialized)
         {
-            int argc = 0;
-            glutInit(&argc, nullptr);
-            __lsan_disable();
-            s_window = glutCreateWindow("test");
-            __lsan_enable();
-            s_glutInitialized = true;
+            glfwInit();
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+            const GLuint kWidth = 320;
+            const GLuint kHeight = 240;
+            s_window = glfwCreateWindow(kWidth, kHeight, "test", nullptr, nullptr);
+            glfwMakeContextCurrent(s_window);
+            s_glfwInitialized = true;
         }
         OpenGLContext::Init();
         std::unique_ptr<OpenGLContext> context = OpenGLContext::CreateGLContext();
@@ -400,6 +406,10 @@ namespace webrtc
     {
         OpenGLContext* context = static_cast<OpenGLContext*>(pGfxDevice);
         delete context;
+
+        glfwSetWindowShouldClose(s_window, GL_TRUE);
+        glfwTerminate();
+        s_glfwInitialized = false;
     }
 #endif
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -261,6 +261,12 @@ namespace webrtc
             RTC_LOG(LS_INFO) << "vkEnumeratePhysicalDevices failed. error:" << result;
             return nullptr;
         }
+
+        if (!VulkanUtility::LoadInstanceFunctions(instance))
+        {
+            return nullptr;
+        }
+
         bool found = false;
         int32_t physicalDeviceIndex = GetPhysicalDeviceIndex(instance, physicalDeviceList, &found);
         if (!found)


### PR DESCRIPTION
This pull request contains two main fixes below.
- Replace Vulkan instance initialization
- Replace **glut** to **glfw3**

Replace `IUnityGraphicsVulkan` to `IUnityGraphicsVulkanV2` as an interface of Unity and use `AddInterceptInitialization` instead of `InterceptInitialization`. This fix multiple packages can customize the initialization process of vulkan instance.
And the Vulkan initialization process contains loading Vulkan extensions for CUDA interoperability. Even if the process for CUDA is failed, it works without HWA codec features.

Replace **glut** to **glfw3** for c++ testing because glut library occurs crash issues on some Linux platform. 