### PR TITLE
Fix: avoid crash invalid resolution on NvCodec

### DIFF
--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
@@ -49,6 +49,37 @@ namespace webrtc
         EXPECT_EQ(WEBRTC_VIDEO_CODEC_OK, encoder.InitEncode(&codec_settings, kSettings()));
     }
 
+    TEST_P(NvEncoderImplTest, CanInitializeWithProfileLevel51Resolution3840x2160)
+    {
+        H264ProfileLevelId profileLevelId(H264Profile::kProfileBaseline, H264Level::kLevel5_1);
+
+        cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+        codec.SetParam(cricket::kH264FmtpProfileLevelId, *H264ProfileLevelIdToString(profileLevelId));
+        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB);
+
+        VideoCodec codec_settings;
+        SetDefaultSettings(&codec_settings);
+        codec_settings.width = 3840;
+        codec_settings.height = 2160;
+        EXPECT_EQ(WEBRTC_VIDEO_CODEC_OK, encoder.InitEncode(&codec_settings, kSettings()));
+    }
+
+    TEST_P(NvEncoderImplTest, ThrowInitializeWithProfileLevel51Resolution4000x4000)
+    {
+        H264ProfileLevelId profileLevelId(H264Profile::kProfileBaseline, H264Level::kLevel5_1);
+
+        cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+        codec.SetParam(cricket::kH264FmtpProfileLevelId, *H264ProfileLevelIdToString(profileLevelId));
+        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB);
+
+        VideoCodec codec_settings;
+        SetDefaultSettings(&codec_settings);
+        codec_settings.width = 4000;
+        codec_settings.height = 4000;
+      
+        EXPECT_THROW(encoder.InitEncode(&codec_settings, kSettings()), NVENCException);
+    }
+
     INSTANTIATE_TEST_SUITE_P(GfxDevice, NvEncoderImplTest, testing::ValuesIn(supportedGfxDevices));
 
 } // end namespace webrtc

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -466,6 +466,23 @@ namespace Unity.WebRTC
                 return new RTCError {errorType = RTCErrorType.None};
             }
 
+            const int maxPixelCount = 3840 * 2160;
+
+            // Using codec is determined when the Encoder initialization process.
+            // Therefore, it is not possible to limit the resolution before that. (supported resolutions depend on the codec and its profile.)
+            // For workaround, all 4k resolutions and above are considered as errors.
+            // (Because under 4k resolution is almost supported by the supported codecs.)
+            // todo: Resize the texture size when encoder initialization process, or fall back to another encoder.
+            if (width * height > maxPixelCount)
+            {
+                return new RTCError
+                {
+                    errorType = RTCErrorType.InvalidRange,
+                    message = $"Texture pixel count is invalid. " +
+                              $"width:{width} x height:{height} is over 4k pixel count ({maxPixelCount})."
+                };
+            }
+
             // Check NVCodec capabilities
             // todo(kazuki):: The constant values should be replaced by values that are got from NvCodec API.
             // Use "nvEncGetEncodeCaps" function which is provided by the NvCodec API.

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -65,11 +65,26 @@ namespace Unity.WebRTC.RuntimeTest
         [TestCase(640, 360)]
         [TestCase(1280, 720)]
         [TestCase(1920, 1080)]
+        [TestCase(3840, 2160)]
+        [TestCase(360, 640)]
+        [TestCase(720, 1280)]
+        [TestCase(1080, 1920)]
+        [TestCase(2160, 3840)]
         public void ValidateTextureSize(int width, int height)
         {
             var platform = Application.platform;
             var error = WebRTC.ValidateTextureSize(width, height, platform);
             Assert.That(error.errorType, Is.EqualTo(RTCErrorType.None));
+        }
+
+        [Test]
+        [TestCase(2500, 3500)]
+        [TestCase(4000, 4000)]
+        public void ErrorOnValidateTextureSize(int width, int height)
+        {
+            var platform = Application.platform;
+            var error = WebRTC.ValidateTextureSize(width, height, platform);
+            Assert.That(error.errorType, Is.EqualTo(RTCErrorType.InvalidRange));
         }
 
         [Test]


### PR DESCRIPTION
NvEncoder raises an exception if Width and Height are not supported by specified H264ProfileLevel.
However, the codec and its profile are determined when the encoder is initialized.
Therefore, when creating a VideoTrack, if the pixel count is uniformly 4k resolution or higher, `ValidateTextureSize` returns error.

- Add test about `NvEncoder` raises an exception if Width and Height are not supported by specified H264ProfileLevel.
- Add workaround on `ValidateTextureSize`
- Add more test about `ValidateTextureSize`