### PR TITLE
fix: release GpuMemoryHandle on RenderThread

### DIFF
--- a/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.cpp
@@ -71,8 +71,6 @@ namespace webrtc
         RTC_DCHECK(result != resourcesPool_.end());
         
         (*result)->MarkUnused(clock_->CurrentTime());
-
-      //  ReleaseStaleBuffers(clock_->CurrentTime());
     }
 
     void GpuMemoryBufferPool::ReleaseStaleBuffers(Timestamp now)

--- a/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.cpp
@@ -72,7 +72,7 @@ namespace webrtc
         
         (*result)->MarkUnused(clock_->CurrentTime());
 
-        ReleaseStaleBuffers(clock_->CurrentTime());
+      //  ReleaseStaleBuffers(clock_->CurrentTime());
     }
 
     void GpuMemoryBufferPool::ReleaseStaleBuffers(Timestamp now)

--- a/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.h
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.h
@@ -18,9 +18,6 @@ namespace webrtc
 
         rtc::scoped_refptr<VideoFrame>
         CreateFrame(NativeTexPtr ptr, const Size& size, UnityRenderingExtTextureFormat format, Timestamp timestamp);
-
-        // define friend class for test
-        friend class GpuMemoryBufferPoolTest;
         void ReleaseStaleBuffers(Timestamp timestamp);
 
         size_t bufferCount() { return resourcesPool_.size(); }

--- a/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.h
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.h
@@ -19,6 +19,10 @@ namespace webrtc
         rtc::scoped_refptr<VideoFrame>
         CreateFrame(NativeTexPtr ptr, const Size& size, UnityRenderingExtTextureFormat format, Timestamp timestamp);
 
+        // define friend class for test
+        friend class GpuMemoryBufferPoolTest;
+        void ReleaseStaleBuffers(Timestamp timestamp);
+
         size_t bufferCount() { return resourcesPool_.size(); }
 
     private:
@@ -48,10 +52,6 @@ namespace webrtc
         rtc::scoped_refptr<GpuMemoryBufferInterface>
         GetOrCreateFrameResources(NativeTexPtr ptr, const Size& size, UnityRenderingExtTextureFormat format);
         void OnReturnBuffer(rtc::scoped_refptr<GpuMemoryBufferInterface> buffer);
-
-        // define friend class for test
-        friend class GpuMemoryBufferPoolTest;
-        void ReleaseStaleBuffers(Timestamp timestamp);
 
         static bool AreFrameResourcesCompatible(
             const FrameResources* resources, const Size& size, UnityRenderingExtTextureFormat format);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
@@ -20,18 +20,39 @@ namespace webrtc
 
     GpuMemoryBufferCudaHandle::~GpuMemoryBufferCudaHandle()
     {
+        CUresult result;
         if (externalMemory != nullptr)
         {
-            cuDestroyExternalMemory(externalMemory);
+            result = cuDestroyExternalMemory(externalMemory);
+            if (result != CUDA_SUCCESS)
+            {
+                RTC_LOG(LS_ERROR) << "faild cuDestroyExternalMemory CUresult: " << result;
+                throw;
+            }
         }
         if (resource != nullptr)
         {
-            cuGraphicsUnmapResources(1, &resource, 0);
-            cuGraphicsUnregisterResource(resource);
+            result = cuGraphicsUnmapResources(1, &resource, 0);
+            if (result != CUDA_SUCCESS)
+            {
+                RTC_LOG(LS_ERROR) << "faild cuGraphicsUnmapResources CUresult: " << result;
+                throw;
+            }
+            result = cuGraphicsUnregisterResource(resource);
+            if (result != CUDA_SUCCESS)
+            {
+                RTC_LOG(LS_ERROR) << "faild cuGraphicsUnregisterResource CUresult: " << result;
+                throw;
+            }
         }
         if (array != nullptr)
         {
             cuArrayDestroy(array);
+            if (result != CUDA_SUCCESS)
+            {
+                RTC_LOG(LS_ERROR) << "faild cuArrayDestroy CUresult: " << result;
+                throw;
+            }
         }
     }
 }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
@@ -30,7 +30,6 @@ namespace webrtc
             if (result != CUDA_SUCCESS)
             {
                 RTC_LOG(LS_ERROR) << "faild cuDestroyExternalMemory CUresult: " << result;
-                throw;
             }
         }
         if (resource != nullptr)
@@ -39,22 +38,19 @@ namespace webrtc
             if (result != CUDA_SUCCESS)
             {
                 RTC_LOG(LS_ERROR) << "faild cuGraphicsUnmapResources CUresult: " << result;
-                throw;
             }
             result = cuGraphicsUnregisterResource(resource);
             if (result != CUDA_SUCCESS)
             {
                 RTC_LOG(LS_ERROR) << "faild cuGraphicsUnregisterResource CUresult: " << result;
-                throw;
             }
         }
         if (array != nullptr)
         {
-            cuArrayDestroy(array);
+            result = cuArrayDestroy(array);
             if (result != CUDA_SUCCESS)
             {
                 RTC_LOG(LS_ERROR) << "faild cuArrayDestroy CUresult: " << result;
-                throw;
             }
         }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
@@ -7,7 +7,8 @@ namespace unity
 namespace webrtc
 {
     GpuMemoryBufferCudaHandle::GpuMemoryBufferCudaHandle()
-        : array(nullptr)
+        : context(nullptr)
+        , array(nullptr)
         , mappedArray(nullptr)
         , mappedPtr(0)
         , resource(nullptr)
@@ -20,6 +21,8 @@ namespace webrtc
 
     GpuMemoryBufferCudaHandle::~GpuMemoryBufferCudaHandle()
     {
+        cuCtxPushCurrent(context);
+
         CUresult result;
         if (externalMemory != nullptr)
         {
@@ -54,6 +57,8 @@ namespace webrtc
                 throw;
             }
         }
+
+        cuCtxPopCurrent(NULL);
     }
 }
 }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h
@@ -14,6 +14,7 @@ namespace webrtc
         GpuMemoryBufferCudaHandle& operator=(GpuMemoryBufferCudaHandle&& other);
         virtual ~GpuMemoryBufferCudaHandle();
 
+        CUcontext context;
         CUarray array;
         CUarray mappedArray;
         CUdeviceptr mappedPtr;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -189,6 +189,7 @@ rtc::scoped_refptr<I420Buffer> D3D11GraphicsDevice::ConvertRGBToI420(ITexture2D*
         cuCtxPopCurrent(NULL);
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
+        handle->context = GetCUcontext();
         handle->mappedArray = mappedArray;
         handle->resource = resource;
         return handle;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -364,6 +364,7 @@ rtc::scoped_refptr<webrtc::I420Buffer> D3D12GraphicsDevice::ConvertRGBToI420(
         cuCtxPopCurrent(NULL);
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
+        handle->context = GetCUcontext();
         handle->mappedArray = array;
         handle->externalMemory = externalMemory;
         return handle;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -298,6 +298,7 @@ rtc::scoped_refptr<webrtc::I420Buffer> OpenGLGraphicsDevice::ConvertRGBToI420(IT
         cuCtxPopCurrent(NULL);
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
+        handle->context = GetCUcontext();
         handle->mappedArray = mappedArray;
         handle->resource = resource;
         return handle;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -337,6 +337,7 @@ rtc::scoped_refptr<webrtc::I420Buffer> VulkanGraphicsDevice::ConvertRGBToI420(
         cuCtxPopCurrent(NULL);
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
+        handle->context = GetCUcontext();
         handle->mappedArray = array;
         handle->externalMemory = externalMemory;
         return handle;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -309,7 +309,9 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
                     s_bufferPool->CreateFrame(ptr, size, encodeData->format, timestamp);
                 source->OnFrameCaptured(std::move(frame));
             }
+
             s_bufferPool->ReleaseStaleBuffers(timestamp);
+
             return;
         }
         default: {

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -309,6 +309,7 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
                     s_bufferPool->CreateFrame(ptr, size, encodeData->format, timestamp);
                 source->OnFrameCaptured(std::move(frame));
             }
+            s_bufferPool->ReleaseStaleBuffers(timestamp);
             return;
         }
         default: {


### PR DESCRIPTION
- destructor process of `GpuMemoryBufferCudaHandle` need to called from RenderThread.
- `ReleaseStaleBuffers` called with `Encode` event on render thread