### PR TITLE
fix: Fix freeze bug when streaming video on macos Apple Silicon

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -19,8 +19,8 @@ public:
     struct EncodeData
     {
         void* texture;
-        size_t width;
-        size_t height;
+        int width;
+        int height;
         UnityRenderingExtTextureFormat format;
     };
 

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -15,7 +15,15 @@ using namespace ::webrtc;
 class UnityVideoTrackSource :
     public rtc::AdaptedVideoTrackSource
 {
-    public:
+public:
+    struct EncodeData
+    {
+        void* texture;
+        size_t width;
+        size_t height;
+        UnityRenderingExtTextureFormat format;
+    };
+
         //struct FrameAdaptationParams
         //{
         //    bool should_drop_frame;
@@ -32,6 +40,15 @@ class UnityVideoTrackSource :
         absl::optional<bool> needs_denoising);
     ~UnityVideoTrackSource() override;
 
+    const EncodeData* encodeData() const { return &encodeData_; }
+    void SetEncodeData(void* texture, int width, int height, UnityRenderingExtTextureFormat format)
+    {
+        encodeData_.texture = texture;
+        encodeData_.width = width;
+        encodeData_.height = height;
+        encodeData_.format = format;
+    }
+    
     SourceState state() const override;
 
     bool remote() const override;
@@ -65,6 +82,7 @@ private:
 
     // State for the timestamp translation.
     rtc::TimestampAligner timestamp_aligner_;
+    EncodeData encodeData_;
 
     const bool is_screencast_;
     const absl::optional<bool> needs_denoising_;

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -336,6 +336,11 @@ extern "C"
         return track->GetSource();
     }
 
+    UNITY_INTERFACE_EXPORT void VideoTrackSourceSetData(UnityVideoTrackSource* source, void* texture, int width, int height, UnityRenderingExtTextureFormat format)
+    {
+        source->SetEncodeData(texture, width, height, format);
+    }
+
     UNITY_INTERFACE_EXPORT TrackKind MediaStreamTrackGetKind(MediaStreamTrackInterface* track)
     {
         const auto kindStr = track->kind();

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -397,10 +397,11 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public static IEnumerator Update()
         {
+            var wait = new WaitForEndOfFrame();
             while (true)
             {
                 // Wait until all frame rendering is done
-                yield return new WaitForEndOfFrame();
+                yield return wait;
                 {
                     foreach (var reference in VideoStreamTrack.s_tracks.Values)
                     {
@@ -1120,6 +1121,8 @@ namespace Unity.WebRTC
         public static extern IntPtr StatsMemberGetDoubleArray(IntPtr member, out ulong length);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsMemberGetStringArray(IntPtr member, out ulong length);
+        [DllImport(WebRTC.Lib)]
+        public static extern void VideoTrackSourceSetData(IntPtr source, IntPtr texture, int width, int height, GraphicsFormat format);
     }
 
     internal static class VideoEncoderMethods

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -394,13 +394,11 @@ namespace Unity.WebRTC.RuntimeTest
             var callback = NativeMethods.GetRenderEventFunc(context);
             yield return new WaitForSeconds(1.0f);
 
-            VideoTrackSource.EncodeData data = new VideoTrackSource.EncodeData(renderTexture, source);
-            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VideoTrackSource.EncodeData)));
-            Marshal.StructureToPtr(data, ptr, true);
-            VideoEncoderMethods.Encode(callback, ptr);
+            NativeMethods.VideoTrackSourceSetData(source, renderTexture.GetNativeTexturePtr(), renderTexture.width,
+                renderTexture.height, renderTexture.graphicsFormat);
+            VideoEncoderMethods.Encode(callback, source);
             yield return new WaitForSeconds(1.0f);
 
-            Marshal.FreeHGlobal(ptr);
             Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
@@ -442,10 +440,9 @@ namespace Unity.WebRTC.RuntimeTest
 
             yield return new WaitForSeconds(1.0f);
 
-            VideoTrackSource.EncodeData data = new VideoTrackSource.EncodeData(renderTexture, source);
-            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VideoTrackSource.EncodeData)));
-            Marshal.StructureToPtr(data, ptr, true);
-            VideoEncoderMethods.Encode(renderEvent, ptr);
+            NativeMethods.VideoTrackSourceSetData(source, renderTexture.GetNativeTexturePtr(), renderTexture.width,
+                renderTexture.height, renderTexture.graphicsFormat);
+            VideoEncoderMethods.Encode(renderEvent, source);
             yield return new WaitForSeconds(1.0f);
 
             // this method is not supported on Direct3D12
@@ -454,7 +451,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             yield return new WaitForSeconds(1.0f);
 
-            Marshal.FreeHGlobal(ptr);
+//            Marshal.FreeHGlobal(ptr);
             NativeMethods.VideoTrackRemoveSink(track, renderer);
             NativeMethods.DeleteVideoRenderer(context, renderer);
             NativeMethods.ContextDeleteRefPtr(context, track);


### PR DESCRIPTION
This pull request makes workaround for the issue that freezing the Unity editor on macOS Apple Silicon.
I already reported the bug to Unity team.
https://fogbugz.unity3d.com/default.asp?1419782_hputlaje02r19pbr

We need to avoid to call `Texture.GetNativeTexturePtr` method for every frame, the native function is added to pass the texture pointer to the `UnityVideoTrackSource` instance in native code.