### PR TITLE
fix: Fix freeze bug when streaming video on macos Apple Silicon

### DIFF
--- a/Plugin~/CMakePresets.json
+++ b/Plugin~/CMakePresets.json
@@ -221,11 +221,27 @@
     {
       "name": "release-android",
       "displayName": "Build Release",
-      "description": "Release build for Linux",
+      "description": "Release build for Android",
       "configurePreset": "arm64-android",
       "configuration": "Release",
       "cleanFirst": true
-    }
+    },
+    {
+      "name": "debug-ios",
+      "displayName": "Build Debug",
+      "description": "Debug build for iOS",
+      "configurePreset": "ios",
+      "configuration": "Debug",
+      "verbose": true
+    },
+    {
+      "name": "release-ios",
+      "displayName": "Build Release",
+      "description": "Release build for iOS",
+      "configurePreset": "ios",
+      "configuration": "Release",
+      "cleanFirst": true
+    }    
   ],
   "testPresets": [
     {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -1,9 +1,9 @@
 #include "pch.h"
 
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "MetalDevice.h"
 #include "MetalGraphicsDevice.h"
 #include "MetalTexture2D.h"
-#include "GraphicsDevice/GraphicsUtility.h"
 
 #import <Metal/Metal.h>
 
@@ -23,15 +23,13 @@ namespace webrtc
         return true;
     }
 
-    void MetalGraphicsDevice::ShutdownV()
-    {
-    }
+    void MetalGraphicsDevice::ShutdownV() { }
 
-//---------------------------------------------------------------------------------------------------------------------
-    ITexture2D* MetalGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat)
+    ITexture2D*
+    MetalGraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat)
     {
         id<MTLDevice> device = m_device->Device();
-        MTLTextureDescriptor *textureDescriptor = [[MTLTextureDescriptor alloc] init];
+        MTLTextureDescriptor* textureDescriptor = [[MTLTextureDescriptor alloc] init];
         textureDescriptor.pixelFormat = ConvertFormat(textureFormat);
         textureDescriptor.width = w;
         textureDescriptor.height = h;
@@ -39,23 +37,23 @@ namespace webrtc
         return new MetalTexture2D(w, h, texture);
     }
 
-//---------------------------------------------------------------------------------------------------------------------
-    ITexture2D* MetalGraphicsDevice::CreateDefaultTextureFromNativeV(uint32_t w, uint32_t h, void* nativeTexturePtr) {
+    ITexture2D* MetalGraphicsDevice::CreateDefaultTextureFromNativeV(uint32_t w, uint32_t h, void* nativeTexturePtr)
+    {
         id<MTLTexture> texture = (__bridge id<MTLTexture>)nativeTexturePtr;
         return new MetalTexture2D(w, h, texture);
     }
 
-
-//---------------------------------------------------------------------------------------------------------------------
-    bool MetalGraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src) {
+    bool MetalGraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src)
+    {
         id<MTLTexture> dstTexture = (__bridge id<MTLTexture>)dest->GetNativeTexturePtrV();
         id<MTLTexture> srcTexture = (__bridge id<MTLTexture>)src->GetNativeTexturePtrV();
         return CopyTexture(dstTexture, srcTexture);
     }
 
-//---------------------------------------------------------------------------------------------------------------------
-    bool MetalGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) {
-        if(nativeTexturePtr == nullptr) {
+    bool MetalGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr)
+    {
+        if (nativeTexturePtr == nullptr)
+        {
             return false;
         }
         id<MTLTexture> dstTexture = (__bridge id<MTLTexture>)dest->GetNativeTexturePtrV();
@@ -63,15 +61,12 @@ namespace webrtc
         return CopyTexture(dstTexture, srcTexture);
     }
 
-//---------------------------------------------------------------------------------------------------------------------
-
     bool MetalGraphicsDevice::CopyTexture(id<MTLTexture> dest, id<MTLTexture> src)
     {
-        if(dest == src)
-            return false;
-
-        if(src.pixelFormat != dest.pixelFormat)
-            return false;
+        RTC_DCHECK_NE(dest, src);
+        RTC_DCHECK_EQ(src.pixelFormat, dest.pixelFormat);
+        RTC_DCHECK_EQ(src.width, dest.width);
+        RTC_DCHECK_EQ(src.height, dest.height);
 
         m_device->EndCurrentCommandEncoder();
 
@@ -106,17 +101,22 @@ namespace webrtc
         return true;
     }
 
-//---------------------------------------------------------------------------------------------------------------------
-    ITexture2D* MetalGraphicsDevice::CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat)
+    //---------------------------------------------------------------------------------------------------------------------
+    ITexture2D* MetalGraphicsDevice::CreateCPUReadTextureV(
+        uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat)
     {
         id<MTLDevice> device = m_device->Device();
-        MTLTextureDescriptor *textureDescriptor = [[MTLTextureDescriptor alloc] init];
+        MTLTextureDescriptor* textureDescriptor = [[MTLTextureDescriptor alloc] init];
         textureDescriptor.pixelFormat = ConvertFormat(textureFormat);
         textureDescriptor.width = width;
         textureDescriptor.height = height;
-        if (@available(macOS 10.14, iOS 12.0, *)) {
+        if (@available(macOS 10.14, iOS 12.0, *))
+        {
+            // This texture is a managed or shared resource.
             textureDescriptor.allowGPUOptimizedContents = false;
-        } else {
+        }
+        else
+        {
             // Fallback on earlier versions
         }
 #if TARGET_OS_OSX
@@ -126,48 +126,47 @@ namespace webrtc
 #endif
         id<MTLTexture> texture = [device newTextureWithDescriptor:textureDescriptor];
         return new MetalTexture2D(width, height, texture);
-
     }
 
-//---------------------------------------------------------------------------------------------------------------------
-    rtc::scoped_refptr<webrtc::I420Buffer> MetalGraphicsDevice::ConvertRGBToI420(ITexture2D* tex){
-        id<MTLTexture> nativeTex = (__bridge id<MTLTexture>)tex->GetNativeTexturePtrV();
-        if (nil == nativeTex)
-            return nullptr;
-
-        const uint32_t BYTES_PER_PIXEL = 4;        
-        const uint32_t width  = tex->GetWidth();
+    rtc::scoped_refptr<webrtc::I420Buffer> MetalGraphicsDevice::ConvertRGBToI420(ITexture2D* tex)
+    {
+        id<MTLTexture> source = (__bridge id<MTLTexture>)tex->GetNativeTexturePtrV();
+        const uint32_t width = tex->GetWidth();
         const uint32_t height = tex->GetHeight();
+
+        RTC_DCHECK(source);
+        RTC_DCHECK_GT(width, 0);
+        RTC_DCHECK_GT(height, 0);
+
+        const uint32_t BYTES_PER_PIXEL = 4;
         const uint32_t bytesPerRow = width * BYTES_PER_PIXEL;
         const uint32_t bufferSize = bytesPerRow * height;
 
         std::vector<uint8_t> buffer;
         buffer.resize(bufferSize);
-        
-        [nativeTex getBytes:buffer.data()
-            bytesPerRow:bytesPerRow
-            fromRegion:MTLRegionMake2D(0,0,width,height)
-            mipmapLevel:0];
 
-        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = GraphicsUtility::ConvertRGBToI420Buffer(
-            width, height,
-            bytesPerRow, buffer.data()
-        );
+        [source getBytes:buffer.data()
+             bytesPerRow:bytesPerRow
+              fromRegion:MTLRegionMake2D(0, 0, width, height)
+             mipmapLevel:0];
+
+        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer =
+            GraphicsUtility::ConvertRGBToI420Buffer(width, height, bytesPerRow, buffer.data());
         return i420_buffer;
     }
 
-//---------------------------------------------------------------------------------------------------------------------
     MTLPixelFormat MetalGraphicsDevice::ConvertFormat(UnityRenderingExtTextureFormat format)
     {
-        switch(format) {
-            case kUnityRenderingExtFormatB8G8R8A8_SRGB:
-                return MTLPixelFormatBGRA8Unorm_sRGB;
-            case kUnityRenderingExtFormatB8G8R8A8_UNorm:
-                return MTLPixelFormatBGRA8Unorm;
-            case kUnityRenderingExtFormatR8G8B8A8_SRGB:
-                return MTLPixelFormatRGBA8Unorm_sRGB;
-            default:
-                return MTLPixelFormatInvalid;
+        switch (format)
+        {
+        case kUnityRenderingExtFormatB8G8R8A8_SRGB:
+            return MTLPixelFormatBGRA8Unorm_sRGB;
+        case kUnityRenderingExtFormatB8G8R8A8_UNorm:
+            return MTLPixelFormatBGRA8Unorm;
+        case kUnityRenderingExtFormatR8G8B8A8_SRGB:
+            return MTLPixelFormatRGBA8Unorm_sRGB;
+        default:
+            return MTLPixelFormatInvalid;
         }
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
@@ -11,8 +11,6 @@ namespace webrtc
     struct MetalTexture2D : ITexture2D
     {
     public:
-        id<MTLTexture> m_texture;
-
         MetalTexture2D(uint32_t w, uint32_t h, id<MTLTexture> tex);
         virtual ~MetalTexture2D();
 
@@ -20,6 +18,8 @@ namespace webrtc
         inline const void* GetNativeTexturePtrV() const override;
         inline void* GetEncodeTexturePtrV() override;
         inline const void* GetEncodeTexturePtrV() const override;
+    private:
+        id<MTLTexture> m_texture;
     };
 
     void* MetalTexture2D::GetNativeTexturePtrV() { return m_texture; }

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -282,6 +282,8 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
     EncodeData* encodeData =
         static_cast<EncodeData*>(data);
 
+    RTC_DCHECK(encodeData->texture);
+    RTC_DCHECK(encodeData->source);
     RTC_DCHECK_GT(encodeData->width, 0);
     RTC_DCHECK_GT(encodeData->height, 0);
 
@@ -294,8 +296,6 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         case VideoStreamRenderEventID::Encode:
         {
             UnityVideoTrackSource* source = encodeData->source;
-            if (source == nullptr)
-                return;
             Timestamp timestamp = s_clock->CurrentTime();
             IGraphicsDevice* device = GraphicsUtility::GetGraphicsDevice();
             UnityGfxRenderer gfxRenderer = GraphicsUtility::GetGfxRenderer();

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -200,7 +200,8 @@ namespace Unity.WebRTC
 
     internal class VideoTrackSource : RefCountedObject
     {
-        public struct EncodeData
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct EncodeData
         {
             public IntPtr ptrTexture;
             public IntPtr ptrTrackSource;

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -220,6 +220,7 @@ namespace Unity.WebRTC
 
         IntPtr ptr_ = IntPtr.Zero;
         EncodeData data_;
+        Texture prevTexture_;
 
         public VideoTrackSource()
             : base(WebRTC.Context.CreateVideoTrackSource())
@@ -237,10 +238,14 @@ namespace Unity.WebRTC
         {
             if (texture == null)
                 Debug.LogError("texture is null");
-            if (data_.ptrTexture != texture.GetNativeTexturePtr())
+
+            // todo:: This comparison is not sufficiency but it is for workaround of freeze bug.
+            // Texture.GetNativeTexturePtr method freezes Unity Editor on apple silicon.
+            if (prevTexture_ != texture)
             {
                 data_ = new EncodeData(texture, self);
                 Marshal.StructureToPtr(data_, ptr_, true);
+                prevTexture_ = texture;
             }
             WebRTC.Context.Encode(ptr_);
         }

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -142,8 +142,11 @@ namespace Unity.WebRTC
                 }
 
                 m_sourceTexture = null;
+
                 // Unity API must be called from main thread.
-                WebRTC.DestroyOnMainThread(m_destTexture);
+                // This texture is referred from the rendering thread,
+                // so set the delay 100ms to wait the task of another thread.
+                WebRTC.DestroyOnMainThread(m_destTexture, 0.1f);
 
                 m_renderer?.Dispose();
                 m_source?.Dispose();
@@ -258,8 +261,15 @@ namespace Unity.WebRTC
                 return;
             }
 
-            if(ptr_ != IntPtr.Zero)
-                Marshal.FreeHGlobal(ptr_);
+            if (ptr_ != IntPtr.Zero)
+            {
+                // This buffer is referred from the rendering thread,
+                // so set the delay 100ms to wait the task of another thread.
+                WebRTC.DelayActionOnMainThread(() =>
+                {
+                    Marshal.FreeHGlobal(ptr_);
+                }, 0.1f);
+            }
 
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {


### PR DESCRIPTION
This pull request makes workaround for the issue that freezing the Unity editor on macOS Apple Silicon.
I already reported the bug to Unity team.
https://fogbugz.unity3d.com/default.asp?1419782_hputlaje02r19pbr