### PR TITLE
fix: Fix issues of video streaming in multipeer sample on macOS

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalDevice.h
@@ -17,7 +17,8 @@ namespace webrtc
 
         virtual ~MetalDevice() { }
         virtual id<MTLDevice> Device() = 0;
-        virtual id<MTLCommandBuffer> CurrentCommandEncoder() = 0;
+        virtual id<MTLCommandBuffer> CurrentCommandBuffer() = 0;
+        virtual id<MTLCommandEncoder> CurrentCommandEncoder() = 0;
         virtual void EndCurrentCommandEncoder() = 0;
     };
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalDevice.mm
@@ -22,7 +22,11 @@ namespace webrtc
         {
             return device_;
         }
-        id<MTLCommandBuffer> CurrentCommandEncoder() override
+        id<MTLCommandBuffer> CurrentCommandBuffer() override
+        {
+            return nullptr;
+        }
+        id<MTLCommandEncoder> CurrentCommandEncoder() override
         {
             return nullptr;
         }
@@ -46,9 +50,13 @@ namespace webrtc
         {
             return graphics_->MetalDevice();
         }
-        id<MTLCommandBuffer> CurrentCommandEncoder() override
+        id<MTLCommandBuffer> CurrentCommandBuffer() override
         {
             return graphics_->CurrentCommandBuffer();
+        }
+        id<MTLCommandEncoder> CurrentCommandEncoder() override
+        {
+            return graphics_->CurrentCommandEncoder();
         }
         void EndCurrentCommandEncoder() override
         {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
@@ -34,7 +34,7 @@ namespace webrtc
 
     private:
         MetalDevice* m_device;
-
+        id<MTLCommandQueue> m_queue;
         bool CopyTexture(id<MTLTexture> dest, id<MTLTexture> src);
         static MTLPixelFormat ConvertFormat(UnityRenderingExtTextureFormat format);
     };

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -90,9 +90,11 @@ namespace webrtc
              destinationLevel:0
             destinationOrigin:outTxtOrigin];
 
+#if TARGET_OS_OSX
         // must be explicitly synchronized if the storageMode is Managed.
         if (dest.storageMode == MTLStorageModeManaged)
             [blit synchronizeResource:dest];
+#endif            
         [blit endEncoding];
         [commandBuffer commit];
         


### PR DESCRIPTION
Fixed the issue below.
To copy the texture completely, `commit` method of `MTLCommandBuffer` should be called at the last.

https://user-images.githubusercontent.com/1132081/163503370-6873cde3-9354-4128-8543-382513dc729c.mov