### PR TITLE
fix: Fix the crash bug when applying the scaleResolutionDownBy parameter in Bandwidth sample on macOS

### DIFF
--- a/Plugin~/WebRTCPlugin/VideoFrameAdapter.h
+++ b/Plugin~/WebRTCPlugin/VideoFrameAdapter.h
@@ -33,7 +33,8 @@ namespace webrtc
             bool scaled() const final { return true; }
 
             rtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() override;
-
+            const webrtc::I420BufferInterface* GetI420() const override;
+            
             rtc::scoped_refptr<webrtc::VideoFrameBuffer>
             GetMappedFrameBuffer(rtc::ArrayView<webrtc::VideoFrameBuffer::Type> types) override;
 
@@ -75,9 +76,11 @@ namespace webrtc
         // todo(kazuki):
         // Need this buffer because the type() method returns kI420.
         mutable rtc::scoped_refptr<I420BufferInterface> i420Buffer_;
+        std::vector<rtc::scoped_refptr<VideoFrameBuffer>> scaledI40Buffers_;
         const rtc::scoped_refptr<VideoFrame> frame_;
         const Size size_;
-        mutable std::mutex frameLock_;
+        mutable std::mutex scaleLock_;
+        mutable std::mutex convertLock_;
     };
 }
 }

--- a/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GpuMemoryBufferTest.cpp
@@ -71,12 +71,25 @@ namespace webrtc
         EXPECT_EQ(buffer2->width(), kSize2.width());
         EXPECT_EQ(buffer2->height(), kSize2.height());
 
-        auto i420Buffer = buffer2->ToI420();
+        // check ScaledBuffer::ToI420()
+        {
+            auto i420Buffer = buffer2->ToI420();
 
-        EXPECT_NE(i420Buffer, nullptr);
-        EXPECT_EQ(i420Buffer->type(), VideoFrameBuffer::Type::kI420);
-        EXPECT_EQ(i420Buffer->width(), kSize2.width());
-        EXPECT_EQ(i420Buffer->height(), kSize2.height());
+            EXPECT_NE(i420Buffer, nullptr);
+            EXPECT_EQ(i420Buffer->type(), VideoFrameBuffer::Type::kI420);
+            EXPECT_EQ(i420Buffer->width(), kSize2.width());
+            EXPECT_EQ(i420Buffer->height(), kSize2.height());
+        }
+        
+        // check ScaledBuffer::GetI420()
+        {
+            auto i420Buffer = buffer2->GetI420();
+
+            EXPECT_NE(i420Buffer, nullptr);
+            EXPECT_EQ(i420Buffer->type(), VideoFrameBuffer::Type::kI420);
+            EXPECT_EQ(i420Buffer->width(), kSize2.width());
+            EXPECT_EQ(i420Buffer->height(), kSize2.height());
+        }
     }
 
     INSTANTIATE_TEST_SUITE_P(GfxDevice, GpuMemoryBufferTest, testing::ValuesIn(supportedGfxDevices));


### PR DESCRIPTION
When using `scaleResolutionDownBy` parameter, the encoder calls the 'VideoFrameBuffer::GetI420()' to get I420 buffer, but `ScaledBuffer` is not provided the method, so it leads the crash.

Also the I420 buffer should be kept the instance in the `ScaledBuffer` instance, so the `scaledI40Buffers_` is added.