### PR TITLE
fix: Fixed the error when stopping the playmode in Unity Editor

### DIFF
--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -681,7 +681,13 @@ namespace Unity.WebRTC
 
         static void Destroy(object state)
         {
-            (UnityEngine.Object obj, float delay)  = state as Tuple<UnityEngine.Object, float>;
+            (UnityEngine.Object obj, float delay) = state as Tuple<UnityEngine.Object, float>;
+
+            if (!Application.isPlaying)
+            {
+                UnityEngine.Object.DestroyImmediate(obj);
+                return;
+            }
             UnityEngine.Object.Destroy(obj, delay);
         }
 


### PR DESCRIPTION
This error was printed in the console log.
```
Destroy may not be called from edit mode! Use DestroyImmediate instead.
Destroying an object in edit mode destroys it permanently.
```

Checked `Application.isPlaying` and if it is false, use `Object.DestroyImmediate`.