### PR TITLE
fix: Add resolution option for vertical layout in menu scene

### DIFF
--- a/Samples~/Scripts/SceneSelectUI.cs
+++ b/Samples~/Scripts/SceneSelectUI.cs
@@ -64,6 +64,11 @@ namespace Unity.WebRTC.Samples
             new Vector2Int(1920, 1080),
             new Vector2Int(2560, 1440),
             new Vector2Int(3840, 2160),
+            new Vector2Int(360, 640),
+            new Vector2Int(720, 1280),
+            new Vector2Int(1080, 1920),
+            new Vector2Int(1440, 2560),
+            new Vector2Int(2160, 3840),
         };
 
         private static readonly string[] excludeCodecMimeType = { "video/red", "video/ulpfec", "video/rtx" };


### PR DESCRIPTION
WebRTC supports video streaming for vertical layout so this pull request adds options to make convenience for testing. 
![image](https://user-images.githubusercontent.com/1132081/163951136-635f1071-ae8c-4d59-8a32-09322afc832a.png)