### PR TITLE
fix: Update UnityVulkanInitCallback.cpp

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/UnityVulkanInitCallback.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/UnityVulkanInitCallback.cpp
@@ -137,7 +137,7 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL Hook_vkGetInstanceProcAddr(VkIns
     {
         return reinterpret_cast<PFN_vkVoidFunction>(&Hook_vkCreateDevice);
     }
-    return nullptr;
+    return vkGetInstanceProcAddr(instance, funcName);
 }
 
 PFN_vkGetInstanceProcAddr InterceptVulkanInitialization(


### PR DESCRIPTION
Hook_vkGetInstanceProcAddr should apply vkGetInstanceProcAddr and return the result by default. As it is now, subsequent plugins that are loaded by Unity will get the Hook_vkGetInstanceProcAddr from this package, which returns nullptr for all but the specific functions checked for.

The change in this pull request is not tested in any way, and not even compiled.