### PR TITLE
Fix crash could be occurred when using scaleResolutionDownBy parameter

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -79,6 +79,10 @@ void* UnityVideoRenderer::ConvertVideoFrameToTextureAndWriteToBuffer(
 {
     auto frame = GetFrameBuffer();
 
+    size_t size = static_cast<size_t>(width * height * 4);
+    if (tempBuffer.size() != size)
+        tempBuffer.resize(size);
+
     // return a previous texture buffer when framebuffer is returned null.
     if (frame == nullptr)
         return tempBuffer.data();
@@ -94,10 +98,6 @@ void* UnityVideoRenderer::ConvertVideoFrameToTextureAndWriteToBuffer(
         temp->ScaleFrom(*frame->ToI420());
         i420_buffer = temp;
     }
-
-    size_t size = width * height * 4;
-    if (tempBuffer.size() != size)
-        tempBuffer.resize(size);
 
     if (m_needFlipVertical)
         height = -height;


### PR DESCRIPTION
Hello.

This PR fixes the crash could be occurred when using scaleResolutionDownBy parameter to resize the video resolution.
If `GetFrameBuffer()` return nullptr due to failed to lock, `ConvertVideoFrameToTextureAndWriteToBuffer()` return `tempBuffer.data()` immediately, but if texture size has already been changed, access violation would be occurred.

To prevent this, make to call `tempBuffer.resize()` before `return tempBuffer.data()`. It resolves #626

Thank you in advance for your review.
