### PR TITLE
fix: Fix invalid sendtexture on dx12 with Software encoder

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -21,294 +21,307 @@ namespace unity
 namespace webrtc
 {
 
-//---------------------------------------------------------------------------------------------------------------------
+    //---------------------------------------------------------------------------------------------------------------------
 
-D3D12GraphicsDevice::D3D12GraphicsDevice(
-    ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer)
-    : IGraphicsDevice(renderer)
-    , m_d3d12Device(nativeDevice)
-    , m_d3d11Device(nullptr), m_d3d11Context(nullptr)
-    , m_d3d12CommandQueue(unityInterface->GetCommandQueue())
-    , m_copyResourceFence(nullptr)
-    , m_copyResourceEventHandle(nullptr)
-{
-}
-//---------------------------------------------------------------------------------------------------------------------
-D3D12GraphicsDevice::D3D12GraphicsDevice(
-    ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer)
-    : IGraphicsDevice(renderer)
-    , m_d3d12Device(nativeDevice)
-    , m_d3d11Device(nullptr), m_d3d11Context(nullptr)
-    , m_d3d12CommandQueue(commandQueue)
-    , m_copyResourceFence(nullptr)
-    , m_copyResourceEventHandle(nullptr)
-{
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-D3D12GraphicsDevice::~D3D12GraphicsDevice()
-{
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-
-bool D3D12GraphicsDevice::InitV() {
-
-    ID3D11Device* legacyDevice;
-    ID3D11DeviceContext* legacyContext;
-
-    ThrowIfFailed(D3D11CreateDevice(
-        nullptr,
-        D3D_DRIVER_TYPE_HARDWARE,
-        nullptr,
-        0,
-        nullptr,
-        0,
-        D3D11_SDK_VERSION,
-        &legacyDevice,
-        nullptr,
-        &legacyContext));
-
-    ThrowIfFailed(legacyDevice->QueryInterface(IID_PPV_ARGS(&m_d3d11Device)));
-
-    legacyDevice->GetImmediateContext(&legacyContext);
-    ThrowIfFailed(legacyContext->QueryInterface(IID_PPV_ARGS(&m_d3d11Context)));
-
-    ThrowIfFailed(m_d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
-    ThrowIfFailed(m_d3d12Device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator, nullptr, IID_PPV_ARGS(&m_commandList)));
-
-    // Command lists are created in the recording state, but there is nothing
-    // to record yet. The main loop expects it to be closed, so close it now.
-    ThrowIfFailed(m_commandList->Close());
-
-    ThrowIfFailed(m_d3d12Device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_copyResourceFence)));
-    m_copyResourceEventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-    if (m_copyResourceEventHandle == nullptr)
+    D3D12GraphicsDevice::D3D12GraphicsDevice(
+        ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer)
+        : IGraphicsDevice(renderer)
+        , m_d3d12Device(nativeDevice)
+        , m_d3d11Device(nullptr)
+        , m_d3d11Context(nullptr)
+        , m_d3d12CommandQueue(unityInterface->GetCommandQueue())
+        , m_copyResourceFence(nullptr)
+        , m_copyResourceEventHandle(nullptr)
     {
-        ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
     }
-    m_isCudaSupport = CUDA_SUCCESS == m_cudaContext.Init(m_d3d12Device);
-    return true;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void D3D12GraphicsDevice::ShutdownV() {
-    m_cudaContext.Shutdown();
-    SAFE_RELEASE(m_d3d11Device);
-    SAFE_RELEASE(m_d3d11Context);
-    SAFE_RELEASE(m_copyResourceFence);
-    SAFE_CLOSE_HANDLE(m_copyResourceEventHandle);
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-ITexture2D* D3D12GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
-
-    return CreateSharedD3D12Texture(w, h);
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-
-    bool D3D12GraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src) {
-    //[Note-sin: 2020-2-19] This function is currently not required by RenderStreaming. Delete?
-    return true;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-bool D3D12GraphicsDevice::CopyResourceFromNativeV(ITexture2D* baseDest, void* nativeTexturePtr) {
-
-    D3D12Texture2D* dest = reinterpret_cast<D3D12Texture2D*>(baseDest);
-    assert(nullptr != dest);
-    if (nullptr == dest)
-        return false;
-
-    ID3D12Resource* nativeDest = reinterpret_cast<ID3D12Resource*>(dest->GetNativeTexturePtrV());
-    ID3D12Resource* nativeSrc = reinterpret_cast<ID3D12Resource*>(nativeTexturePtr);
-    if (nativeSrc == nativeDest)
-        return false;
-    if (nativeSrc == nullptr || nativeDest == nullptr)
-        return false;
-
-    ThrowIfFailed(m_commandAllocator->Reset());
-    ThrowIfFailed(m_commandList->Reset(m_commandAllocator, nullptr));
-
-    m_commandList->CopyResource(nativeDest, nativeSrc);
-
-    //for CPU accessible texture
-    ID3D12Resource* readbackResource = dest->GetReadbackResource();
-    const D3D12ResourceFootprint* resFP = dest->GetNativeTextureFootprint();
-    if (nullptr != readbackResource)
+    //---------------------------------------------------------------------------------------------------------------------
+    D3D12GraphicsDevice::D3D12GraphicsDevice(
+        ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer)
+        : IGraphicsDevice(renderer)
+        , m_d3d12Device(nativeDevice)
+        , m_d3d11Device(nullptr)
+        , m_d3d11Context(nullptr)
+        , m_d3d12CommandQueue(commandQueue)
+        , m_copyResourceFence(nullptr)
+        , m_copyResourceEventHandle(nullptr)
     {
-        //Change dest state, copy, change dest state back
-        Barrier(nativeDest,D3D12_RESOURCE_STATE_COPY_DEST,D3D12_RESOURCE_STATE_COPY_SOURCE);
-        D3D12_TEXTURE_COPY_LOCATION td, ts;
-        td.pResource = readbackResource;
-        td.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
-        td.PlacedFootprint = resFP->Footprint;
-        ts.pResource = nativeDest;
-        ts.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-        ts.SubresourceIndex = 0;
-        m_commandList->CopyTextureRegion(&td, 0, 0, 0, &ts, nullptr);
-        Barrier(nativeDest,D3D12_RESOURCE_STATE_COPY_SOURCE,D3D12_RESOURCE_STATE_COPY_DEST);        
     }
 
-    ThrowIfFailed(m_commandList->Close());
+    //---------------------------------------------------------------------------------------------------------------------
+    D3D12GraphicsDevice::~D3D12GraphicsDevice() { }
 
-    ID3D12CommandList* cmdList[] = { m_commandList };
-    m_d3d12CommandQueue->ExecuteCommandLists(_countof(cmdList), cmdList);
+    //---------------------------------------------------------------------------------------------------------------------
 
-    WaitForFence(m_copyResourceFence, m_copyResourceEventHandle, &m_copyResourceFenceValue);
-
-    return true;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-
-D3D12Texture2D* D3D12GraphicsDevice::CreateSharedD3D12Texture(uint32_t w, uint32_t h) {
-    //[Note-sin: 2019-10-30] Taken from RaytracedHardShadow
-    // note: sharing textures with d3d11 requires some flags and restrictions:
-    // - MipLevels must be 1
-    // - D3D12_HEAP_FLAG_SHARED for heap flags
-    // - D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET and D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS for resource flags
-
-    D3D12_RESOURCE_DESC desc{};
-    desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-    desc.Alignment = 0;
-    desc.Width = w;
-    desc.Height = h;
-    desc.DepthOrArraySize = 1;
-    desc.MipLevels = 1;
-    desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM; //We only support this format which has 4 bytes -> DX12_BYTES_PER_PIXEL
-    desc.SampleDesc.Count = 1;
-    desc.SampleDesc.Quality = 0;
-    desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-    desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-    desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
-
-    const D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_SHARED;
-    const D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_COPY_DEST;
-
-    ID3D12Resource* resource = nullptr;
-    HRESULT result = m_d3d12Device->CreateCommittedResource(
-        &D3D12_DEFAULT_HEAP_PROPS, flags, &desc, initialState,
-        nullptr, IID_PPV_ARGS(&resource));
-
-    if (result != S_OK)
+    bool D3D12GraphicsDevice::InitV()
     {
-        RTC_LOG(LS_INFO) << "CreateCommittedResource failed. error:" << result;
-        return nullptr;
+
+        ID3D11Device* legacyDevice;
+        ID3D11DeviceContext* legacyContext;
+
+        ThrowIfFailed(D3D11CreateDevice(
+            nullptr,
+            D3D_DRIVER_TYPE_HARDWARE,
+            nullptr,
+            0,
+            nullptr,
+            0,
+            D3D11_SDK_VERSION,
+            &legacyDevice,
+            nullptr,
+            &legacyContext));
+
+        ThrowIfFailed(legacyDevice->QueryInterface(IID_PPV_ARGS(&m_d3d11Device)));
+
+        legacyDevice->GetImmediateContext(&legacyContext);
+        ThrowIfFailed(legacyContext->QueryInterface(IID_PPV_ARGS(&m_d3d11Context)));
+
+        ThrowIfFailed(
+            m_d3d12Device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, IID_PPV_ARGS(&m_commandAllocator)));
+        ThrowIfFailed(m_d3d12Device->CreateCommandList(
+            0, D3D12_COMMAND_LIST_TYPE_DIRECT, m_commandAllocator, nullptr, IID_PPV_ARGS(&m_commandList)));
+
+        // Command lists are created in the recording state, but there is nothing
+        // to record yet. The main loop expects it to be closed, so close it now.
+        ThrowIfFailed(m_commandList->Close());
+
+        ThrowIfFailed(m_d3d12Device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_copyResourceFence)));
+        m_copyResourceEventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+        if (m_copyResourceEventHandle == nullptr)
+        {
+            ThrowIfFailed(HRESULT_FROM_WIN32(GetLastError()));
+        }
+        m_isCudaSupport = CUDA_SUCCESS == m_cudaContext.Init(m_d3d12Device);
+        return true;
     }
 
-    HANDLE handle = nullptr;
-    result = m_d3d12Device->CreateSharedHandle(
-        resource, nullptr, GENERIC_ALL, nullptr, &handle);
-    if (result != S_OK)
+    //---------------------------------------------------------------------------------------------------------------------
+    void D3D12GraphicsDevice::ShutdownV()
     {
-        RTC_LOG(LS_INFO) << "CreateSharedHandle failed. error:" << result;
-        return nullptr;
+        m_cudaContext.Shutdown();
+        SAFE_RELEASE(m_d3d11Device);
+        SAFE_RELEASE(m_d3d11Context);
+        SAFE_RELEASE(m_copyResourceFence);
+        SAFE_CLOSE_HANDLE(m_copyResourceEventHandle);
     }
 
-    // ID3D11Device::OpenSharedHandle() doesn't accept handles created by d3d12.
-    // OpenSharedResource1() is needed.
-    ID3D11Texture2D* sharedTex = nullptr;
-    result = m_d3d11Device->OpenSharedResource1(handle, IID_PPV_ARGS(&sharedTex));
-    if (result != S_OK)
+    //---------------------------------------------------------------------------------------------------------------------
+    ITexture2D*
+    D3D12GraphicsDevice::CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat)
     {
-        RTC_LOG(LS_INFO) << "OpenSharedResource1 failed. error:" << result;
-        return nullptr;
+
+        return CreateSharedD3D12Texture(w, h);
     }
 
-    return new D3D12Texture2D(w, h, resource, handle, sharedTex);
-}
+    //---------------------------------------------------------------------------------------------------------------------
 
-//----------------------------------------------------------------------------------------------------------------------
-void D3D12GraphicsDevice::WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue) {
-    ThrowIfFailed(m_d3d12CommandQueue->Signal(fence, *fenceValue));
-    ThrowIfFailed(fence->SetEventOnCompletion(*fenceValue, handle));
-    WaitForSingleObject(handle, INFINITE);
-    ++(*fenceValue);       
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-
-void D3D12GraphicsDevice::Barrier(ID3D12Resource* res,
-                                  const D3D12_RESOURCE_STATES stateBefore, const D3D12_RESOURCE_STATES stateAfter,
-                                  const UINT subresource)
-{
-    D3D12_RESOURCE_BARRIER barrier;
-    barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-    barrier.Flags =  D3D12_RESOURCE_BARRIER_FLAG_NONE;
-    barrier.Transition.pResource = res;
-    barrier.Transition.StateBefore = stateBefore;
-    barrier.Transition.StateAfter = stateAfter;
-    barrier.Transition.Subresource = subresource;
-    m_commandList->ResourceBarrier(1, &barrier);
-    
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-
-ITexture2D* D3D12GraphicsDevice::CreateCPUReadTextureV(
-    uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) {
-    D3D12Texture2D* tex = CreateSharedD3D12Texture(w,h);
-    const HRESULT hr = tex->CreateReadbackResource(m_d3d12Device);
-    if (FAILED(hr)){
-        delete tex;
-        return nullptr;
-    }
-
-    return tex;
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-rtc::scoped_refptr<webrtc::I420Buffer> D3D12GraphicsDevice::ConvertRGBToI420(ITexture2D* baseTex)
-{
-    D3D12Texture2D* tex = reinterpret_cast<D3D12Texture2D*>(baseTex);
-    assert(nullptr != tex);
-    if (nullptr == tex)
-        return nullptr;
-
-    ID3D12Resource* readbackResource = tex->GetReadbackResource();
-    assert(nullptr != readbackResource);
-    if (nullptr == readbackResource) // the texture has to be prepared for CPU access
-        return nullptr;
-
-    const uint32_t width = tex->GetWidth();
-    const uint32_t height = tex->GetHeight();
-    const D3D12ResourceFootprint* footprint = tex->GetNativeTextureFootprint();
-    const uint32_t rowPitch = static_cast<uint32_t>(footprint->Footprint.Footprint.RowPitch);
-
-    // Map to read from CPU
-    uint8* data {};
-    const HRESULT hr = readbackResource->Map(0, nullptr, reinterpret_cast<void**>(&data));
-    assert(hr == S_OK);
-    if (hr != S_OK)
+    bool D3D12GraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src)
     {
-        return nullptr;
+        //[Note-sin: 2020-2-19] This function is currently not required by RenderStreaming. Delete?
+        return true;
     }
 
-    // RGBA -> I420
-    rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = webrtc::I420Buffer::Create(width, height);
-    libyuv::ARGBToI420(
-        static_cast<uint8_t*>(data),
-        rowPitch,
-        i420_buffer->MutableDataY(),
-        i420_buffer->StrideY(),
-        i420_buffer->MutableDataU(),
-        i420_buffer->StrideU(),
-        i420_buffer->MutableDataV(),
-        i420_buffer->StrideV(),
-        width,
-        height);
+    //---------------------------------------------------------------------------------------------------------------------
+    bool D3D12GraphicsDevice::CopyResourceFromNativeV(ITexture2D* baseDest, void* nativeTexturePtr)
+    {
 
-    D3D12_RANGE emptyRange { 0, 0 };
-    readbackResource->Unmap(0, &emptyRange);
+        D3D12Texture2D* dest = reinterpret_cast<D3D12Texture2D*>(baseDest);
+        assert(nullptr != dest);
+        if (nullptr == dest)
+            return false;
 
-    return i420_buffer;
-}
+        ID3D12Resource* nativeDest = reinterpret_cast<ID3D12Resource*>(dest->GetNativeTexturePtrV());
+        ID3D12Resource* nativeSrc = reinterpret_cast<ID3D12Resource*>(nativeTexturePtr);
+        if (nativeSrc == nativeDest)
+            return false;
+        if (nativeSrc == nullptr || nativeDest == nullptr)
+            return false;
+
+        ThrowIfFailed(m_commandAllocator->Reset());
+        ThrowIfFailed(m_commandList->Reset(m_commandAllocator, nullptr));
+
+        m_commandList->CopyResource(nativeDest, nativeSrc);
+
+        // for CPU accessible texture
+        ID3D12Resource* readbackResource = dest->GetReadbackResource();
+        const D3D12ResourceFootprint* resFP = dest->GetNativeTextureFootprint();
+        if (nullptr != readbackResource)
+        {
+            // Change dest state, copy, change dest state back
+            Barrier(nativeDest, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COPY_SOURCE);
+            D3D12_TEXTURE_COPY_LOCATION td, ts;
+            td.pResource = readbackResource;
+            td.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+            td.PlacedFootprint = resFP->Footprint;
+            ts.pResource = nativeDest;
+            ts.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+            ts.SubresourceIndex = 0;
+            m_commandList->CopyTextureRegion(&td, 0, 0, 0, &ts, nullptr);
+            Barrier(nativeDest, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_DEST);
+        }
+
+        ThrowIfFailed(m_commandList->Close());
+
+        ID3D12CommandList* cmdList[] = { m_commandList };
+        m_d3d12CommandQueue->ExecuteCommandLists(_countof(cmdList), cmdList);
+
+        WaitForFence(m_copyResourceFence, m_copyResourceEventHandle, &m_copyResourceFenceValue);
+
+        return true;
+    }
+
+    //---------------------------------------------------------------------------------------------------------------------
+
+    D3D12Texture2D* D3D12GraphicsDevice::CreateSharedD3D12Texture(uint32_t w, uint32_t h)
+    {
+        //[Note-sin: 2019-10-30] Taken from RaytracedHardShadow
+        // note: sharing textures with d3d11 requires some flags and restrictions:
+        // - MipLevels must be 1
+        // - D3D12_HEAP_FLAG_SHARED for heap flags
+        // - D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET and D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS for resource
+        // flags
+
+        D3D12_RESOURCE_DESC desc {};
+        desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        desc.Alignment = 0;
+        desc.Width = w;
+        desc.Height = h;
+        desc.DepthOrArraySize = 1;
+        desc.MipLevels = 1;
+        desc.Format =
+            DXGI_FORMAT_B8G8R8A8_UNORM; // We only support this format which has 4 bytes -> DX12_BYTES_PER_PIXEL
+        desc.SampleDesc.Count = 1;
+        desc.SampleDesc.Quality = 0;
+        desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
+
+        const D3D12_HEAP_FLAGS flags = D3D12_HEAP_FLAG_SHARED;
+        const D3D12_RESOURCE_STATES initialState = D3D12_RESOURCE_STATE_COPY_DEST;
+
+        ID3D12Resource* resource = nullptr;
+        HRESULT result = m_d3d12Device->CreateCommittedResource(
+            &D3D12_DEFAULT_HEAP_PROPS, flags, &desc, initialState, nullptr, IID_PPV_ARGS(&resource));
+
+        if (result != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "CreateCommittedResource failed. error:" << result;
+            return nullptr;
+        }
+
+        HANDLE handle = nullptr;
+        result = m_d3d12Device->CreateSharedHandle(resource, nullptr, GENERIC_ALL, nullptr, &handle);
+        if (result != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "CreateSharedHandle failed. error:" << result;
+            return nullptr;
+        }
+
+        // ID3D11Device::OpenSharedHandle() doesn't accept handles created by d3d12.
+        // OpenSharedResource1() is needed.
+        ID3D11Texture2D* sharedTex = nullptr;
+        result = m_d3d11Device->OpenSharedResource1(handle, IID_PPV_ARGS(&sharedTex));
+        if (result != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "OpenSharedResource1 failed. error:" << result;
+            return nullptr;
+        }
+
+        return new D3D12Texture2D(w, h, resource, handle, sharedTex);
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+    void D3D12GraphicsDevice::WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue)
+    {
+        ThrowIfFailed(m_d3d12CommandQueue->Signal(fence, *fenceValue));
+        ThrowIfFailed(fence->SetEventOnCompletion(*fenceValue, handle));
+        WaitForSingleObject(handle, INFINITE);
+        ++(*fenceValue);
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    void D3D12GraphicsDevice::Barrier(
+        ID3D12Resource* res,
+        const D3D12_RESOURCE_STATES stateBefore,
+        const D3D12_RESOURCE_STATES stateAfter,
+        const UINT subresource)
+    {
+        D3D12_RESOURCE_BARRIER barrier;
+        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        barrier.Transition.pResource = res;
+        barrier.Transition.StateBefore = stateBefore;
+        barrier.Transition.StateAfter = stateAfter;
+        barrier.Transition.Subresource = subresource;
+        m_commandList->ResourceBarrier(1, &barrier);
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    ITexture2D*
+    D3D12GraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat)
+    {
+        D3D12Texture2D* tex = CreateSharedD3D12Texture(w, h);
+        const HRESULT hr = tex->CreateReadbackResource(m_d3d12Device);
+        if (FAILED(hr))
+        {
+            delete tex;
+            return nullptr;
+        }
+
+        return tex;
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------
+    rtc::scoped_refptr<webrtc::I420Buffer> D3D12GraphicsDevice::ConvertRGBToI420(ITexture2D* baseTex)
+    {
+        D3D12Texture2D* tex = reinterpret_cast<D3D12Texture2D*>(baseTex);
+        assert(nullptr != tex);
+        if (nullptr == tex)
+            return nullptr;
+
+        ID3D12Resource* readbackResource = tex->GetReadbackResource();
+        assert(nullptr != readbackResource);
+        if (nullptr == readbackResource) // the texture has to be prepared for CPU access
+            return nullptr;
+
+        const uint32_t width = tex->GetWidth();
+        const uint32_t height = tex->GetHeight();
+        const D3D12ResourceFootprint* footprint = tex->GetNativeTextureFootprint();
+        const uint32_t rowPitch = static_cast<uint32_t>(footprint->Footprint.Footprint.RowPitch);
+
+        // Map to read from CPU
+        uint8* data {};
+        const HRESULT hr = readbackResource->Map(0, nullptr, reinterpret_cast<void**>(&data));
+        assert(hr == S_OK);
+        if (hr != S_OK)
+        {
+            return nullptr;
+        }
+
+        // RGBA -> I420
+        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = webrtc::I420Buffer::Create(width, height);
+        libyuv::ARGBToI420(
+            static_cast<uint8_t*>(data),
+            rowPitch,
+            i420_buffer->MutableDataY(),
+            i420_buffer->StrideY(),
+            i420_buffer->MutableDataU(),
+            i420_buffer->StrideU(),
+            i420_buffer->MutableDataV(),
+            i420_buffer->StrideV(),
+            width,
+            height);
+
+        D3D12_RANGE emptyRange { 0, 0 };
+        readbackResource->Unmap(0, &emptyRange);
+
+        return i420_buffer;
+    }
 
     std::unique_ptr<GpuMemoryBufferHandle> D3D12GraphicsDevice::Map(ITexture2D* texture)
     {
-        if(!IsCudaSupport())
+        if (!IsCudaSupport())
             return nullptr;
 
         D3D12Texture2D* d3d12Texure = static_cast<D3D12Texture2D*>(texture);
@@ -326,7 +339,7 @@ rtc::scoped_refptr<webrtc::I420Buffer> D3D12GraphicsDevice::ConvertRGBToI420(ITe
         size_t width = d3d12Texure->GetWidth();
         size_t height = d3d12Texure->GetHeight();
         D3D12_RESOURCE_DESC desc = d3d12Texure->GetDesc();
-		D3D12_RESOURCE_ALLOCATION_INFO d3d12ResourceAllocationInfo;
+        D3D12_RESOURCE_ALLOCATION_INFO d3d12ResourceAllocationInfo;
         d3d12ResourceAllocationInfo = m_d3d12Device->GetResourceAllocationInfo(0, 1, &desc);
         size_t actualSize = d3d12ResourceAllocationInfo.SizeInBytes;
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -72,7 +72,6 @@ namespace webrtc
         NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
 
     private:
-    private:
         D3D12Texture2D* CreateSharedD3D12Texture(uint32_t w, uint32_t h);
         void WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue);
         void Barrier(

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -1,108 +1,119 @@
 #pragma once
 
-#include "WebRTCConstants.h"
 #include "D3D12Texture2D.h"
 #include "GraphicsDevice/Cuda/CudaContext.h"
 #include "GraphicsDevice/IGraphicsDevice.h"
+#include "WebRTCConstants.h"
 
 namespace unity
 {
 namespace webrtc
 {
 
-namespace webrtc = ::webrtc;
+    namespace webrtc = ::webrtc;
 
 #define DefPtr(_a) _COM_SMARTPTR_TYPEDEF(_a, __uuidof(_a))
-DefPtr(ID3D12CommandAllocator);
-DefPtr(ID3D12GraphicsCommandList4);
+    DefPtr(ID3D12CommandAllocator);
+    DefPtr(ID3D12GraphicsCommandList4);
 
-inline std::string HrToString(HRESULT hr)
-{
-    char s_str[64] = {};
-    sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
-    return std::string(s_str);
-}
-
-class HrException : public std::runtime_error
-{
-public:
-    HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), m_hr(hr) {}
-    HRESULT Error() const { return m_hr; }
-private:
-    const HRESULT m_hr;
-};
-
-inline void ThrowIfFailed(HRESULT hr)
-{
-    if (FAILED(hr))
+    inline std::string HrToString(HRESULT hr)
     {
-        throw HrException(hr);
+        char s_str[64] = {};
+        sprintf_s(s_str, "HRESULT of 0x%08X", static_cast<UINT>(hr));
+        return std::string(s_str);
     }
-}
 
-class D3D12GraphicsDevice : public IGraphicsDevice
-{
-public:
-    explicit D3D12GraphicsDevice(ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer);
-    explicit D3D12GraphicsDevice(ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer);
-    virtual ~D3D12GraphicsDevice();
-    virtual bool InitV() override;
-    virtual void ShutdownV() override;
-    inline virtual void* GetEncodeDevicePtrV() override;
+    class HrException : public std::runtime_error
+    {
+    public:
+        HrException(HRESULT hr)
+            : std::runtime_error(HrToString(hr))
+            , m_hr(hr)
+        {
+        }
+        HRESULT Error() const { return m_hr; }
 
-    virtual ITexture2D* CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
-    virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
-    virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
-    std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
+    private:
+        const HRESULT m_hr;
+    };
 
-    virtual ITexture2D* CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
-    virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
+    inline void ThrowIfFailed(HRESULT hr)
+    {
+        if (FAILED(hr))
+        {
+            throw HrException(hr);
+        }
+    }
 
-    bool IsCudaSupport() override { return m_isCudaSupport; }
-    CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
-    NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
-private:
+    class D3D12GraphicsDevice : public IGraphicsDevice
+    {
+    public:
+        explicit D3D12GraphicsDevice(
+            ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer);
+        explicit D3D12GraphicsDevice(
+            ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer);
+        virtual ~D3D12GraphicsDevice();
+        virtual bool InitV() override;
+        virtual void ShutdownV() override;
+        inline virtual void* GetEncodeDevicePtrV() override;
 
-private:
-    D3D12Texture2D* CreateSharedD3D12Texture(uint32_t w, uint32_t h);
-    void WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue);
-    void Barrier(ID3D12Resource* res,
-        const D3D12_RESOURCE_STATES stateBefore, const D3D12_RESOURCE_STATES stateAfter,
-        const UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES);
+        virtual ITexture2D*
+        CreateDefaultTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
+        virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
+        virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
+        std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
 
-    ID3D12Device* m_d3d12Device;
-    ID3D12CommandQueue* m_d3d12CommandQueue;
+        virtual ITexture2D*
+        CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
+        virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
 
-    //[Note-sin: 2019-10-30] sharing res from d3d12 to d3d11 require d3d11.1. Fence is supported in d3d11.4 or newer.
-    ID3D11Device5* m_d3d11Device;
-    ID3D11DeviceContext4* m_d3d11Context;
+        bool IsCudaSupport() override { return m_isCudaSupport; }
+        CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
+        NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
 
-    bool m_isCudaSupport;
-    CudaContext m_cudaContext;
+    private:
+    private:
+        D3D12Texture2D* CreateSharedD3D12Texture(uint32_t w, uint32_t h);
+        void WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue);
+        void Barrier(
+            ID3D12Resource* res,
+            const D3D12_RESOURCE_STATES stateBefore,
+            const D3D12_RESOURCE_STATES stateAfter,
+            const UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES);
 
-    //[TODO-sin: 2019-12-2] //This should be allocated for each frame.
-    ID3D12CommandAllocatorPtr m_commandAllocator;
-    ID3D12GraphicsCommandList4Ptr m_commandList;
+        ID3D12Device* m_d3d12Device;
+        ID3D12CommandQueue* m_d3d12CommandQueue;
 
-    //Fence to copy resource on GPU (and CPU if the texture was created with CPU-access)
-    ID3D12Fence* m_copyResourceFence;
-	HANDLE m_copyResourceEventHandle;
-    uint64_t m_copyResourceFenceValue = 1;
+        //[Note-sin: 2019-10-30] sharing res from d3d12 to d3d11 require d3d11.1. Fence is supported in d3d11.4 or
+        //newer.
+        ID3D11Device5* m_d3d11Device;
+        ID3D11DeviceContext4* m_d3d11Context;
 
-    CUcontext m_context;
-    CUdevice m_device;
-};
+        bool m_isCudaSupport;
+        CudaContext m_cudaContext;
 
-//---------------------------------------------------------------------------------------------------------------------
+        //[TODO-sin: 2019-12-2] //This should be allocated for each frame.
+        ID3D12CommandAllocatorPtr m_commandAllocator;
+        ID3D12GraphicsCommandList4Ptr m_commandList;
 
-//use D3D11. See notes below
-void* D3D12GraphicsDevice::GetEncodeDevicePtrV() { return reinterpret_cast<void*>(m_d3d11Device); }
+        // Fence to copy resource on GPU (and CPU if the texture was created with CPU-access)
+        ID3D12Fence* m_copyResourceFence;
+        HANDLE m_copyResourceEventHandle;
+        uint64_t m_copyResourceFenceValue = 1;
+
+        CUcontext m_context;
+        CUdevice m_device;
+    };
+
+    //---------------------------------------------------------------------------------------------------------------------
+
+    // use D3D11. See notes below
+    void* D3D12GraphicsDevice::GetEncodeDevicePtrV() { return reinterpret_cast<void*>(m_d3d11Device); }
 
 } // end namespace webrtc
 } // end namespace unity
 
 //---------------------------------------------------------------------------------------------------------------------
 //[Note-sin: 2019-10-30]
-//Since NVEncoder does not support DX12, we use a DX12 resource that can be shared with DX11, and then pass it
-//the DX11 resource to NVidia Encoder
-
+// Since NVEncoder does not support DX12, we use a DX12 resource that can be shared with DX11, and then pass it
+// the DX11 resource to NVidia Encoder


### PR DESCRIPTION
fix commit 9d19591604b9c859878d78f89c479dae1d0353bf

- Changed to use the correct RowPitch.
- Changed to use libyuv convert.

resolve for https://github.com/Unity-Technologies/com.unity.webrtc/issues/520