### PR TITLE
fix: Fix PeerConnection/MediaStreamObserver leaks and crash

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -284,7 +284,6 @@ namespace webrtc
         const rtc::scoped_refptr<UnityVideoTrackSource> source =
             new rtc::RefCountedObject<UnityVideoTrackSource>(
                 false, absl::nullopt);
-
         AddRefPtr(source);
         return source;
     }
@@ -294,7 +293,6 @@ namespace webrtc
     {
         const rtc::scoped_refptr<VideoTrackInterface> track =
             m_peerConnectionFactory->CreateVideoTrack(label, source);
-
         AddRefPtr(track);
         return track;
     }

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -46,7 +46,7 @@ namespace webrtc
             IGraphicsDevice* gfxDevice = nullptr);
         ~Context();
 
-        bool ExistsRefPtr(const rtc::RefCountInterface* ptr) {
+        bool ExistsRefPtr(const rtc::RefCountInterface* ptr) const {
             return m_mapRefPtr.find(ptr) != m_mapRefPtr.end(); }
         template <typename T>
         void AddRefPtr(rtc::scoped_refptr<T> refptr) {
@@ -85,9 +85,7 @@ namespace webrtc
         webrtc::VideoTrackInterface* CreateVideoTrack(const std::string& label, webrtc::VideoTrackSourceInterface* source);
         webrtc::AudioTrackInterface* CreateAudioTrack(const std::string& label, webrtc::AudioSourceInterface* source);
         void StopMediaStreamTrack(webrtc::MediaStreamTrackInterface* track);
-        UnityVideoTrackSource* GetVideoSource(
-            const MediaStreamTrackInterface* track);
-        bool ExistsVideoSource(UnityVideoTrackSource* source);
+        UnityVideoTrackSource* GetVideoSource(const MediaStreamTrackInterface* track);
 
         // PeerConnection
         PeerConnectionObject* CreatePeerConnection(const webrtc::PeerConnectionInterface::RTCConfiguration& config);

--- a/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
+++ b/Plugin~/WebRTCPlugin/MediaStreamObserver.cpp
@@ -18,7 +18,6 @@ namespace webrtc
 
     void MediaStreamObserver::OnVideoTrackAdded(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
-        DebugLog("OnVideoTrackAdded trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
         m_context->AddRefPtr(track);
         for (auto callback : m_listOnAddTrack)
         {
@@ -28,7 +27,6 @@ namespace webrtc
 
     void MediaStreamObserver::OnAudioTrackAdded(webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
-        DebugLog("OnAudioTrackAdded trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
         m_context->AddRefPtr(track);
         for (auto callback : m_listOnAddTrack)
         {
@@ -38,7 +36,6 @@ namespace webrtc
 
     void MediaStreamObserver::OnVideoTrackRemoved(webrtc::VideoTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
-        DebugLog("OnVideoTrackRemoved trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
         for (auto callback : m_listOnRemoveTrack)
         {
             callback(stream, track);
@@ -47,7 +44,6 @@ namespace webrtc
 
     void MediaStreamObserver::OnAudioTrackRemoved(webrtc::AudioTrackInterface* track, webrtc::MediaStreamInterface* stream)
     {
-        DebugLog("OnAudioTrackRemoved trackId:%s, streamId:%s", track->id().c_str(), stream->id().c_str());
         for (auto callback : m_listOnRemoveTrack)
         {
             callback(stream, track);

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -296,6 +296,8 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
         case VideoStreamRenderEventID::Encode:
         {
             UnityVideoTrackSource* source = encodeData->source;
+            if (!s_context->ExistsRefPtr(source))
+                return;
             Timestamp timestamp = s_clock->CurrentTime();
             IGraphicsDevice* device = GraphicsUtility::GetGraphicsDevice();
             UnityGfxRenderer gfxRenderer = GraphicsUtility::GetGfxRenderer();

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -187,7 +187,7 @@ namespace Unity.WebRTC
 
         public void UnRegisterMediaStreamObserver(MediaStream stream)
         {
-            NativeMethods.ContextRegisterMediaStreamObserver(self, stream.GetSelfOrThrow());
+            NativeMethods.ContextUnRegisterMediaStreamObserver(self, stream.GetSelfOrThrow());
         }
 
         public void MediaStreamRegisterOnAddTrack(MediaStream stream, DelegateNativeMediaStreamOnAddTrack callback)

--- a/Runtime/Scripts/MediaStream.cs
+++ b/Runtime/Scripts/MediaStream.cs
@@ -103,13 +103,14 @@ namespace Unity.WebRTC
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeMediaStreamOnAddTrack))]
-        static void MediaStreamOnAddTrack(IntPtr ptr, IntPtr trackPtr)
+        static void MediaStreamOnAddTrack(IntPtr ptr, IntPtr ptrTrack)
         {
             WebRTC.Sync(ptr, () =>
             {
                 if (WebRTC.Table[ptr] is MediaStream stream)
                 {
-                    var e = new MediaStreamTrackEvent(trackPtr);
+                    var track = WebRTC.FindOrCreate(ptrTrack, MediaStreamTrack.Create);
+                    var e = new MediaStreamTrackEvent(track);
                     stream.onAddTrack?.Invoke(e);
                     stream.cacheTracks.Add(e.Track);
                 }
@@ -117,15 +118,19 @@ namespace Unity.WebRTC
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeMediaStreamOnRemoveTrack))]
-        static void MediaStreamOnRemoveTrack(IntPtr ptr, IntPtr trackPtr)
+        static void MediaStreamOnRemoveTrack(IntPtr ptr, IntPtr ptrTrack)
         {
             WebRTC.Sync(ptr, () =>
             {
                 if (WebRTC.Table[ptr] is MediaStream stream)
                 {
-                    var e = new MediaStreamTrackEvent(trackPtr);
-                    stream.onRemoveTrack?.Invoke(e);
-                    stream.cacheTracks.Remove(e.Track);
+                    if(WebRTC.Table.ContainsKey(ptrTrack))
+                    {
+                        var track = WebRTC.Table[ptrTrack] as MediaStreamTrack;
+                        var e = new MediaStreamTrackEvent(track);
+                        stream.onRemoveTrack?.Invoke(e);
+                        stream.cacheTracks.Remove(e.Track);
+                    }
                 }
             });
         }

--- a/Runtime/Scripts/MediaStreamTrack.cs
+++ b/Runtime/Scripts/MediaStreamTrack.cs
@@ -130,9 +130,9 @@ namespace Unity.WebRTC
     {
         public MediaStreamTrack Track { get; }
 
-        internal MediaStreamTrackEvent(IntPtr ptrTrack)
+        internal MediaStreamTrackEvent(MediaStreamTrack track)
         {
-            Track = WebRTC.FindOrCreate(ptrTrack, MediaStreamTrack.Create);
+            Track = track;
         }
     }
 }

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -83,6 +83,7 @@ namespace Unity.WebRTC
             {
                 Close();
                 DisposeAllTransceivers();
+                WebRTC.Context.DeletePeerConnection(self);
                 WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
             }

--- a/Samples~/PeerConnection/PeerConnectionSample.cs
+++ b/Samples~/PeerConnection/PeerConnectionSample.cs
@@ -234,11 +234,10 @@ class PeerConnectionSample : MonoBehaviour
 
         pc1Senders.Clear();
 
-        MediaStreamTrack[] tracks = receiveStream.GetTracks().ToArray();
+        var tracks = receiveStream.GetTracks().ToArray();
         foreach (var track in tracks)
         {
             receiveStream.RemoveTrack(track);
-            track.Dispose();
         }
     }
 

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -21,7 +21,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             foreach (var track in stream.GetTracks())
             {
-                peers[0].AddTrack(track, stream);
+                peers[indexPeer].AddTrack(track, stream);
             }
         }
 
@@ -141,11 +141,6 @@ namespace Unity.WebRTC.RuntimeTest
                 IsTestFinished = false;
                 StartCoroutine(Negotiate(peers[1], peers[0]));
             };
-        }
-
-        IEnumerator Start()
-        {
-            yield return new WaitUntil(() => NegotiationCompleted());
         }
 
         IEnumerator Negotiate(RTCPeerConnection peer1, RTCPeerConnection peer2)


### PR DESCRIPTION
This pull request is for merging #644,
#644 is made by @aet, the fixes are right, but this leads the crash at another parts.

The crash is occurred when `MediaStream.OnRemoveTrack` is called from the native code. This method accesses `MediaStreamTrack` instance but this instance is already destroyed, so it leads the crash.