### PR TITLE
fix: Received video images are weird when multiple peers stream video on macOS

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -96,7 +96,10 @@ namespace webrtc
             [blit synchronizeResource:dest];
 #endif            
         [blit endEncoding];
+        
+        // Commit the current command buffer and wait until the GPU process is completed.
         [commandBuffer commit];
+        [commandBuffer waitUntilCompleted];
         
         return true;
     }


### PR DESCRIPTION
This pull request fixes the disruption of video frame when using multiple peers like Perfect Negotiation sample. This fix affects on iOS/macOS.
This video shows the issue.

https://user-images.githubusercontent.com/1132081/165681059-de0f0200-12f6-4584-b54f-c01abff5066e.mp4

