### PR TITLE
fix: Returns Constrained Baseline profile as an item of supported profile list from NvCodec

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
 
 #include "NvCodec.h"
-#include "NvEncoder/NvEncoderCuda.h"
-#include "NvEncoderImpl.h"
 #include "NvDecoder/NvDecoder.h"
 #include "NvDecoderImpl.h"
+#include "NvEncoder/NvEncoderCuda.h"
+#include "NvEncoderImpl.h"
 
 #include "absl/strings/match.h"
 #include "api/video_codecs/video_encoder_factory.h"
@@ -104,6 +104,9 @@ namespace webrtc
         else
         {
             supportedFormats = {
+                // Constrained Baseline Profile does not support NvDecoder, but WebRTC uses this profile by default,
+                // so it must be returned in this method.
+                CreateH264Format(webrtc::H264Profile::kProfileConstrainedBaseline, webrtc::H264Level::kLevel5_1, "1"),
                 CreateH264Format(webrtc::H264Profile::kProfileBaseline, webrtc::H264Level::kLevel5_1, "1"),
                 CreateH264Format(webrtc::H264Profile::kProfileHigh, webrtc::H264Level::kLevel5_1, "1"),
                 CreateH264Format(webrtc::H264Profile::kProfileMain, webrtc::H264Level::kLevel5_1, "1"),

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
@@ -22,10 +22,7 @@ namespace webrtc
     {
     public:
         static std::unique_ptr<NvEncoder> Create(
-            const cricket::VideoCodec& codec,
-            CUcontext context,
-            CUmemorytype memoryType,
-            NV_ENC_BUFFER_FORMAT format);
+            const cricket::VideoCodec& codec, CUcontext context, CUmemorytype memoryType, NV_ENC_BUFFER_FORMAT format);
         // If H.264 is supported (any implementation).
         static bool IsSupported();
         static bool SupportsScalabilityMode(absl::string_view scalability_mode);
@@ -74,10 +71,7 @@ namespace webrtc
     };
 
 #ifndef _WIN32
-    static bool operator==(const GUID& a, const GUID& b)
-    {
-        return !std::memcmp(&a, &b, sizeof(GUID));
-    }
+    static bool operator==(const GUID& a, const GUID& b) { return !std::memcmp(&a, &b, sizeof(GUID)); }
 #endif
 
 // todo(kazuki):: fix workaround
@@ -100,6 +94,10 @@ namespace webrtc
     static absl::optional<GUID> ProfileToGuid(H264Profile profile)
     {
         if (profile == H264Profile::kProfileBaseline)
+            return NV_ENC_H264_PROFILE_BASELINE_GUID;
+        // Returns Baseline Profile instead because NVCodec is not supported Constrained Baseline Profile
+        // officially, but WebRTC use the profile in default.
+        if (profile == H264Profile::kProfileConstrainedBaseline)
             return NV_ENC_H264_PROFILE_BASELINE_GUID;
         if (profile == H264Profile::kProfileMain)
             return NV_ENC_H264_PROFILE_MAIN_GUID;


### PR DESCRIPTION
#702, #695, #705

NvCodec supports Baseline, Main, High for H264 profile, but some browsers only supports **Constrained Baseline Profile** for H264 codec (ex: Firefox, Safari).
Constrained Baseline Profile is compatible with Baseline Profile, so NvCodec returns the profile to work fine with these browsers.