### PR TITLE
fix: Fix error when using the video resolution which not supported by the H264 profile level

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/Codec/CMakeLists.txt
@@ -1,3 +1,9 @@
+target_sources(WebRTCLib
+  PRIVATE
+    H264ProfileLevelId.cpp
+    H264ProfileLevelId.h
+)
+
 if(Windows OR Linux)
   add_subdirectory(NvCodec)
 endif()

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
@@ -1,0 +1,57 @@
+#include "pch.h"
+#include "H264ProfileLevelId.h"
+
+using namespace ::webrtc;
+
+namespace unity
+{
+namespace webrtc
+{
+    struct LevelConstraint
+    {
+        const int max_macroblocks_per_second;
+        const int max_macroblock_frame_size;
+        const H264Level level;
+    };
+
+    static constexpr LevelConstraint kLevelConstraints[] =
+    {
+        { 1485, 99, H264Level::kLevel1 },
+        { 1485, 99, H264Level::kLevel1_b },
+        { 3000, 396, H264Level::kLevel1_1 },
+        { 6000, 396, H264Level::kLevel1_2 },
+        { 11880, 396, H264Level::kLevel1_3 },
+        { 11880, 396, H264Level::kLevel2 },
+        { 19800, 792, H264Level::kLevel2_1 },
+        { 20250, 1620, H264Level::kLevel2_2 },
+        { 40500, 1620, H264Level::kLevel3 },
+        { 108000, 3600, H264Level::kLevel3_1 },
+        { 216000, 5120, H264Level::kLevel3_2 },
+        { 245760, 8192, H264Level::kLevel4 },
+        { 245760, 8192, H264Level::kLevel4_1 },
+        { 522240, 8704, H264Level::kLevel4_2 },
+        { 589824, 22080, H264Level::kLevel5 },
+        { 983040, 36864, H264Level::kLevel5_1 },
+        { 2073600, 36864, H264Level::kLevel5_2 },
+    };
+
+    absl::optional<webrtc::H264Level> H264SupportedLevel(int maxFramePixelCount, float maxFramerate)
+    {
+        static const int kPixelsPerMacroblock = 16 * 16;
+
+        for (int i = 0; i < arraysize(kLevelConstraints); i++)
+        {
+            const LevelConstraint& level_constraint = kLevelConstraints[i];
+            if (level_constraint.max_macroblock_frame_size * kPixelsPerMacroblock >= maxFramePixelCount &&
+                level_constraint.max_macroblocks_per_second >=
+                    maxFramerate * level_constraint.max_macroblock_frame_size)
+            {
+                return level_constraint.level;
+            }
+        }
+
+        // No level supported.
+        return absl::nullopt;
+    }
+}
+}

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+
 #include "H264ProfileLevelId.h"
 
 using namespace ::webrtc;
@@ -15,8 +16,7 @@ namespace webrtc
         const H264Level level;
     };
 
-    static constexpr LevelConstraint kLevelConstraints[] =
-    {
+    static constexpr LevelConstraint kLevelConstraints[] = {
         { 1485, 99, 64, H264Level::kLevel1 },
         { 1485, 99, 128, H264Level::kLevel1_b },
         { 3000, 396, 192, H264Level::kLevel1_1 },
@@ -33,7 +33,7 @@ namespace webrtc
         { 522240, 8704, 50000, H264Level::kLevel4_2 },
         { 589824, 22080, 135000, H264Level::kLevel5 },
         { 983040, 36864, 240000, H264Level::kLevel5_1 },
-        { 2073600, 36864, 240000, H264Level ::kLevel5_2 },
+        { 2073600, 36864, 240000, H264Level::kLevel5_2 },
     };
 
     absl::optional<webrtc::H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate, int maxBitrate)

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
@@ -11,40 +11,46 @@ namespace webrtc
     {
         const int max_macroblocks_per_second;
         const int max_macroblock_frame_size;
+        const int max_video_bitrate;
         const H264Level level;
     };
 
     static constexpr LevelConstraint kLevelConstraints[] =
     {
-        { 1485, 99, H264Level::kLevel1 },
-        { 1485, 99, H264Level::kLevel1_b },
-        { 3000, 396, H264Level::kLevel1_1 },
-        { 6000, 396, H264Level::kLevel1_2 },
-        { 11880, 396, H264Level::kLevel1_3 },
-        { 11880, 396, H264Level::kLevel2 },
-        { 19800, 792, H264Level::kLevel2_1 },
-        { 20250, 1620, H264Level::kLevel2_2 },
-        { 40500, 1620, H264Level::kLevel3 },
-        { 108000, 3600, H264Level::kLevel3_1 },
-        { 216000, 5120, H264Level::kLevel3_2 },
-        { 245760, 8192, H264Level::kLevel4 },
-        { 245760, 8192, H264Level::kLevel4_1 },
-        { 522240, 8704, H264Level::kLevel4_2 },
-        { 589824, 22080, H264Level::kLevel5 },
-        { 983040, 36864, H264Level::kLevel5_1 },
-        { 2073600, 36864, H264Level::kLevel5_2 },
+        { 1485, 99, 64, H264Level::kLevel1 },
+        { 1485, 99, 128, H264Level::kLevel1_b },
+        { 3000, 396, 192, H264Level::kLevel1_1 },
+        { 6000, 396, 384, H264Level::kLevel1_2 },
+        { 11880, 396, 768, H264Level::kLevel1_3 },
+        { 11880, 396, 2000, H264Level::kLevel2 },
+        { 19800, 792, 4000, H264Level::kLevel2_1 },
+        { 20250, 1620, 4000, H264Level::kLevel2_2 },
+        { 40500, 1620, 10000, H264Level::kLevel3 },
+        { 108000, 3600, 14000, H264Level::kLevel3_1 },
+        { 216000, 5120, 20000, H264Level::kLevel3_2 },
+        { 245760, 8192, 20000, H264Level::kLevel4 },
+        { 245760, 8192, 50000, H264Level::kLevel4_1 },
+        { 522240, 8704, 50000, H264Level::kLevel4_2 },
+        { 589824, 22080, 135000, H264Level::kLevel5 },
+        { 983040, 36864, 240000, H264Level::kLevel5_1 },
+        { 2073600, 36864, 240000, H264Level ::kLevel5_2 },
     };
 
-    absl::optional<webrtc::H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate)
+    absl::optional<webrtc::H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate, int maxBitrate)
     {
         static const int kPixelsPerMacroblock = 16 * 16;
+        static const int kUnitMaxBRWithNAL = 1200;
+
+        if (maxFramePixelCount <= 0 || maxFramerate <= 0 || maxBitrate <= 0)
+            return absl::nullopt;
 
         for (size_t i = 0; i < arraysize(kLevelConstraints); i++)
         {
             const LevelConstraint& level_constraint = kLevelConstraints[i];
             if (level_constraint.max_macroblock_frame_size * kPixelsPerMacroblock >= maxFramePixelCount &&
                 level_constraint.max_macroblocks_per_second >=
-                    maxFramerate * level_constraint.max_macroblock_frame_size)
+                    maxFramerate * level_constraint.max_macroblock_frame_size &&
+                level_constraint.max_video_bitrate * kUnitMaxBRWithNAL >= maxBitrate)
             {
                 return level_constraint.level;
             }

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.cpp
@@ -35,11 +35,11 @@ namespace webrtc
         { 2073600, 36864, H264Level::kLevel5_2 },
     };
 
-    absl::optional<webrtc::H264Level> H264SupportedLevel(int maxFramePixelCount, float maxFramerate)
+    absl::optional<webrtc::H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate)
     {
         static const int kPixelsPerMacroblock = 16 * 16;
 
-        for (int i = 0; i < arraysize(kLevelConstraints); i++)
+        for (size_t i = 0; i < arraysize(kLevelConstraints); i++)
         {
             const LevelConstraint& level_constraint = kLevelConstraints[i];
             if (level_constraint.max_macroblock_frame_size * kPixelsPerMacroblock >= maxFramePixelCount &&

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "absl/types/optional.h"
+#include "api/video_codecs/h264_profile_level_id.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    using namespace ::webrtc;
+
+    // Returns the minumum level which can supports given parameters.
+    // webrtc::H264SupportedLevel function is defined in libwebrtc, but that is for decoder.
+    absl::optional<H264Level> H264SupportedLevel(int maxFramePixelCount, float maxFramerate);
+
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
@@ -11,7 +11,7 @@ namespace webrtc
 
     // Returns the minumum level which can supports given parameters.
     // webrtc::H264SupportedLevel function is defined in libwebrtc, but that is for decoder.
-    absl::optional<H264Level> H264SupportedLevel(int maxFramePixelCount, float maxFramerate);
+    absl::optional<H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate);
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
@@ -11,7 +11,7 @@ namespace webrtc
 
     // Returns the minumum level which can supports given parameters.
     // webrtc::H264SupportedLevel function is defined in libwebrtc, but that is for decoder.
-    absl::optional<H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate);
+    absl::optional<H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate, int maxBitrate);
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -48,7 +48,7 @@ namespace webrtc
     NvEncRequiredLevel(const VideoCodec& codec, CUcontext context, const GUID& guid)
     {
         int pixelCount = codec.width * codec.height;
-        auto requiredLevel = unity::webrtc::H264SupportedLevel(pixelCount, static_cast<float>(codec.maxFramerate));
+        auto requiredLevel = unity::webrtc::H264SupportedLevel(pixelCount, static_cast<int>(codec.maxFramerate));
 
         if (!requiredLevel)
         {

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -48,7 +48,7 @@ namespace webrtc
     NvEncRequiredLevel(const VideoCodec& codec, CUcontext context, const GUID& guid)
     {
         int pixelCount = codec.width * codec.height;
-        auto requiredLevel = unity::webrtc::H264SupportedLevel(pixelCount, static_cast<int>(codec.maxFramerate));
+        auto requiredLevel = unity::webrtc::H264SupportedLevel(pixelCount, static_cast<int>(codec.maxFramerate), codec.maxBitrate);
 
         if (!requiredLevel)
         {

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -75,7 +75,6 @@ namespace webrtc
         // The H264SupportedLevel function can be used to obtain the supported profile levels.
         // However, NvEnc may return an error even when using the value returned by H264SupportedLevel,
         // so `NV_ENC_LEVEL_AUTOSELECT` is used here.
-        // 
         // m_level = static_cast<NV_ENC_LEVEL>(profileLevelId.value().level);
         m_level = NV_ENC_LEVEL_AUTOSELECT;
 
@@ -471,10 +470,10 @@ namespace webrtc
         auto requiredLevel = H264RequiredLevel(m_codec);
         if (!requiredLevel)
         {
-            RTC_LOG(LS_WARNING) << "Not supported codec parameter " <<
-                "width:" << m_codec.width << " " <<
-                "height:" << m_codec.height << " " <<
-                "maxFramerate:" << m_codec.maxFramerate;
+            RTC_LOG(LS_WARNING) << "Not supported codec parameter "
+                                << "width:" << m_codec.width << " "
+                                << "height:" << m_codec.height << " "
+                                << "maxFramerate:" << m_codec.maxFramerate;
 
             m_configurations[0].SetStreamState(false);
             return;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
@@ -93,7 +93,8 @@ namespace webrtc
         NV_ENC_LEVEL m_level;
 
         std::vector<LayerConfig> m_configurations;
-    };
 
+        static std::vector<SdpVideoFormat> s_formats;
+    };
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(WebRTCLibTest
     GraphicsDeviceTest.cpp
     GraphicsDeviceTestBase.cpp
     GraphicsDeviceTestBase.h
+    H264ProfileLevelIdTest.cpp
     InternalCodecsTest.cpp
     UnityVideoEncoderFactoryTest.cpp
     UnityVideoDecoderFactoryTest.cpp

--- a/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
+++ b/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
@@ -1,5 +1,6 @@
-#include "Codec/H264ProfileLevelId.h"
 #include "pch.h"
+
+#include "Codec/H264ProfileLevelId.h"
 
 namespace unity
 {

--- a/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
+++ b/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
@@ -1,0 +1,19 @@
+#include "Codec/H264ProfileLevelId.h"
+#include "pch.h"
+
+namespace unity
+{
+namespace webrtc
+{
+
+    TEST(H264ProfileLevelId, TestSupportedLevel)
+    {
+        EXPECT_EQ(H264Level::kLevel2_1, *H264SupportedLevel(320 * 240, 25, 4000 * 1200));
+        EXPECT_EQ(H264Level::kLevel3_1, *H264SupportedLevel(1280 * 720, 30, 14000 * 1200));
+        EXPECT_EQ(H264Level::kLevel4_2, *H264SupportedLevel(1920 * 1080, 60, 50000 * 1200));
+    }
+
+    TEST(H264ProfileLevelId, TestSupportedLevelInvalid) { EXPECT_FALSE(H264SupportedLevel(0, 0, 0)); }
+
+}
+}

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
@@ -77,7 +77,7 @@ namespace webrtc
         codec_settings.width = 4000;
         codec_settings.height = 4000;
       
-        EXPECT_THROW(encoder.InitEncode(&codec_settings, kSettings()), NVENCException);
+        EXPECT_EQ(encoder.InitEncode(&codec_settings, kSettings()), WEBRTC_VIDEO_CODEC_ERR_PARAMETER);
     }
 
     INSTANTIATE_TEST_SUITE_P(GfxDevice, NvEncoderImplTest, testing::ValuesIn(supportedGfxDevices));


### PR DESCRIPTION
H.264 defines the maximum number of pixels and framerate depending on the profile level. The profile level used by most browsers is **3.1**, which does not support high-resolution frames such as Full HD. 

NvEnc will fail to initialize if an invalid profile level and resolution combination is specified. So as a workaround, it calculates a valid profile level for a given resolution and frame rate and uses it in NvEnc. Note that encoder initialization will fail if there is no valid profile level.

## TODO
Currently, the framerate used by NvEnc is a fixed value of **30** because the encoder framerate depends on the Unity frame rate. This will be supported in the future.