### PR TITLE
fix: Remove references to obsolute warning

### DIFF
--- a/Editor/PeerStatsView.cs
+++ b/Editor/PeerStatsView.cs
@@ -178,9 +178,7 @@ namespace Unity.WebRTC.Editor
                 container.Add(new Label($"{nameof(inboundStats.Timestamp)}: {inboundStats.Timestamp}"));
                 container.Add(new Label($"{nameof(inboundStats.ssrc)}: {inboundStats.ssrc}"));
                 container.Add(new Label($"{nameof(inboundStats.estimatedPlayoutTimestamp)}: {inboundStats.estimatedPlayoutTimestamp}"));
-                container.Add(new Label($"{nameof(inboundStats.mediaType)}: {inboundStats.mediaType}"));
                 container.Add(new Label($"{nameof(inboundStats.kind)}: {inboundStats.kind}"));
-                container.Add(new Label($"{nameof(inboundStats.trackId)}: {inboundStats.trackId}"));
                 container.Add(new Label($"{nameof(inboundStats.transportId)}: {inboundStats.transportId}"));
                 container.Add(new Label($"{nameof(inboundStats.codecId)}: {inboundStats.codecId}"));
                 container.Add(new Label($"{nameof(inboundStats.firCount)}: {inboundStats.firCount}"));
@@ -248,9 +246,7 @@ namespace Unity.WebRTC.Editor
                 container.Add(new Label($"{nameof(outboundStats.Id)}: {outboundStats.Id}"));
                 container.Add(new Label($"{nameof(outboundStats.Timestamp)}: {outboundStats.Timestamp}"));
                 container.Add(new Label($"{nameof(outboundStats.ssrc)}: {outboundStats.ssrc}"));
-                container.Add(new Label($"{nameof(outboundStats.mediaType)}: {outboundStats.mediaType}"));
                 container.Add(new Label($"{nameof(outboundStats.kind)}: {outboundStats.kind}"));
-                container.Add(new Label($"{nameof(outboundStats.trackId)}: {outboundStats.trackId}"));
                 container.Add(new Label($"{nameof(outboundStats.transportId)}: {outboundStats.transportId}"));
                 container.Add(new Label($"{nameof(outboundStats.codecId)}: {outboundStats.codecId}"));
                 container.Add(new Label($"{nameof(outboundStats.firCount)}: {outboundStats.firCount}"));

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -136,7 +136,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         //todo(kazuki): workaround ObjectDisposedException for Linux playmode test
         [Test]
-        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxEditor })]
         public void AudioStreamTrackPlayAudio()
         {
             GameObject obj = new GameObject("audio");

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -134,7 +134,9 @@ namespace Unity.WebRTC.RuntimeTest
             UnityEngine.Object.DestroyImmediate(obj);
         }
 
+        //todo(kazuki): workaround ObjectDisposedException for Linux playmode test
         [Test]
+        [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public void AudioStreamTrackPlayAudio()
         {
             GameObject obj = new GameObject("audio");


### PR DESCRIPTION
Editor scripts have referenced the deprecated parameters below.
- `RTCRTPStreamStats.mediaType`
- `RTCRTPStreamStats.trackId`
