### PR TITLE
fix: Fix crash because of the old version of nvidia driver

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -622,7 +622,6 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% elsif target.is_gpu == "true" %}
 # workaround: avoid playmode linux glcore
 {% if target.name == "linux" and gfx_type.name == "glcore" and param.platform == "playmode" %}
-    -
 {% else %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -622,6 +622,7 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% elsif target.is_gpu == "true" %}
 # workaround: avoid playmode linux glcore
 {% if target.name == "linux" and gfx_type.name == "glcore" and param.platform == "playmode" %}
+    -
 {% else %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -397,7 +397,7 @@ build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
       cp -rf upm-ci~/package/Runtime/Plugins Runtime/
 {% if target.name == "vulkan" -%}
       cp -f WebRTC~/ProjectSettings/ProjectSettings-android-vulkan.asset WebRTC~/ProjectSettings/ProjectSettings.asset
-{% endif %}
+{% endif -%}
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast -w
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr
@@ -599,7 +599,7 @@ test_{{ package.name }}_{{ editor.version }}_nogpu:
 {% for gfx_type in target.gfx_types %}
 {% if target.is_gpu == "false" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endif %}
+{% endif -%}
 {% endfor %}
 {% endfor %}
 {% endfor %}
@@ -622,7 +622,6 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% elsif target.is_gpu == "true" %}
 # workaround: avoid playmode linux glcore
 {% if target.name == "linux" and gfx_type.name == "glcore" and param.platform == "playmode" %}
-    -
 {% else %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif %}
@@ -689,7 +688,7 @@ codecoverage_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 {% endfor %}
 
-{% endif %}
+{% endif -%}
 {% endfor %}
 
 push_plugin:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -621,7 +621,7 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% endfor %}
 {% elsif target.is_gpu == "true" %}
 # workaround: avoid playmode linux glcore
-{% if target.name == "linux" and gfx_type.name == "glcore" and param.platform == "playmode" %}
+{% if target.name == "linux-gpu" and gfx_type.name == "glcore" and param.platform == "playmode" %}
 {% else %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -397,7 +397,7 @@ build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
       cp -rf upm-ci~/package/Runtime/Plugins Runtime/
 {% if target.name == "vulkan" -%}
       cp -f WebRTC~/ProjectSettings/ProjectSettings-android-vulkan.asset WebRTC~/ProjectSettings/ProjectSettings.asset
-{% endif -%}
+{% endif %}
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast -w
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr
@@ -599,7 +599,7 @@ test_{{ package.name }}_{{ editor.version }}_nogpu:
 {% for gfx_type in target.gfx_types %}
 {% if target.is_gpu == "false" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endif -%}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}
@@ -622,8 +622,10 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
 {% elsif target.is_gpu == "true" %}
 # workaround: avoid playmode linux glcore
 {% if target.name == "linux" and gfx_type.name == "glcore" and param.platform == "playmode" %}
+    -
 {% else %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -688,7 +690,7 @@ codecoverage_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 {% endfor %}
 
-{% endif -%}
+{% endif %}
 {% endfor %}
 
 push_plugin:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -397,7 +397,7 @@ build_{{ package.name }}_{{ editor.version }}_android_{{ target.name }}:
       cp -rf upm-ci~/package/Runtime/Plugins Runtime/
 {% if target.name == "vulkan" -%}
       cp -f WebRTC~/ProjectSettings/ProjectSettings-android-vulkan.asset WebRTC~/ProjectSettings/ProjectSettings.asset
-{% endif -%}
+{% endif %}
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast -w
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr
@@ -599,7 +599,7 @@ test_{{ package.name }}_{{ editor.version }}_nogpu:
 {% for gfx_type in target.gfx_types %}
 {% if target.is_gpu == "false" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endif -%}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}
@@ -620,8 +620,11 @@ test_{{ package.name }}_{{ editor.version }}_gpu:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ architecture.architecture }}_{{ gfx_type.name }}
 {% endfor %}
 {% elsif target.is_gpu == "true" %}
+# workaround: avoid playmode linux glcore
+{% if target.name == "linux" and gfx_type.name == "glcore" and param.platform == "playmode" %}
+{% else %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
-{% endif -%}
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}
@@ -685,7 +688,7 @@ codecoverage_{{ package.name }}_{{ platform.name }}_{{ editor.version }}:
     - .yamato/upm-ci-{{ package.name }}-packages.yml#pack_{{ package.name }}
 {% endfor %}
 
-{% endif -%}
+{% endif %}
 {% endfor %}
 
 push_plugin:

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -123,6 +123,18 @@ namespace webrtc
         return std::make_unique<NvEncoderImpl>(codec, context, memoryType, format);
     }
 
+    bool NvEncoder::IsSupported()
+    {
+        uint32_t version = 0;
+        uint32_t currentVersion = (NVENCAPI_MAJOR_VERSION << 4) | NVENCAPI_MINOR_VERSION;
+        NVENC_API_CALL(NvEncodeAPIGetMaxSupportedVersion(&version));
+        if (currentVersion > version)
+        {
+            return false;
+        }
+        return true;
+    }
+
     std::unique_ptr<NvDecoder> NvDecoder::Create(const cricket::VideoCodec& codec, CUcontext context)
     {
         return std::make_unique<NvDecoderImpl>(context);

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
@@ -28,6 +28,7 @@ namespace webrtc
     public:
         static std::unique_ptr<NvEncoder> Create(
             const cricket::VideoCodec& codec, CUcontext context, CUmemorytype memoryType, NV_ENC_BUFFER_FORMAT format);
+        static bool IsSupported();
         ~NvEncoder() override { }
     };
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
@@ -42,6 +42,23 @@ namespace webrtc
         return true;
     }
 
+    static CUresult CheckDriverVersion()
+    {
+        int driverVersion = 0;
+        CUresult result = cuDriverGetVersion(&driverVersion);
+        if (result != CUDA_SUCCESS)
+        {
+            return result;
+        }
+
+        if (kRequiredDriverVersion > driverVersion)
+        {
+            RTC_LOG(LS_ERROR) << "CUDA driver version is not higher than the required version. " << driverVersion;
+            return CUDA_ERROR_NO_DEVICE;
+        }
+        return CUDA_SUCCESS;
+    }
+
     CudaContext::CudaContext()
         : m_context(nullptr)
     {
@@ -97,8 +114,14 @@ namespace webrtc
             return CUDA_ERROR_NOT_FOUND;
         }
 
+        CUresult result = CheckDriverVersion();
+        if (result != CUDA_SUCCESS)
+        {
+            return result;
+        }
+
         CUdevice cuDevice = 0;
-        CUresult result = cuInit(0);
+        result = cuInit(0);
         if (result != CUDA_SUCCESS)
         {
             return result;
@@ -154,7 +177,13 @@ namespace webrtc
             return CUDA_ERROR_NOT_FOUND;
         }
 
-        CUresult result = cuInit(0);
+        CUresult result = CheckDriverVersion();
+        if (result != CUDA_SUCCESS)
+        {
+            return result;
+        }
+
+        result = cuInit(0);
         if (result != CUDA_SUCCESS)
         {
             return result;
@@ -198,11 +227,18 @@ namespace webrtc
             return CUDA_ERROR_NOT_FOUND;
         }
 
-        CUresult result = cuInit(0);
+        CUresult result = CheckDriverVersion();
         if (result != CUDA_SUCCESS)
         {
             return result;
         }
+
+        result = cuInit(0);
+        if (result != CUDA_SUCCESS)
+        {
+            return result;
+        }
+
         int numDevices = 0;
         result = cuDeviceGetCount(&numDevices);
         if (result != CUDA_SUCCESS)
@@ -255,7 +291,13 @@ namespace webrtc
             return CUDA_ERROR_NOT_FOUND;
         }
 
-        CUresult result = cuInit(0);
+        CUresult result = CheckDriverVersion();
+        if (result != CUDA_SUCCESS)
+        {
+            return result;
+        }
+
+        result = cuInit(0);
         if (result != CUDA_SUCCESS)
         {
             return result;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.h
@@ -12,6 +12,8 @@ namespace unity
 {
 namespace webrtc
 {
+    // The minimum version of CUDA Toolkit 
+    const int kRequiredDriverVersion = 11000;
 
     // todo(kazuki):
     // This class manages only the context related on the render thread.

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -120,7 +120,7 @@ namespace webrtc
         if (IsVMInitialized())
             return CreateAndroidEncoderFactory().release();
 #elif CUDA_PLATFORM
-        if (gfxDevice->IsCudaSupport())
+        if (gfxDevice->IsCudaSupport() && NvEncoder::IsSupported())
         {
             CUcontext context = gfxDevice->GetCUcontext();
             NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -533,7 +533,7 @@ namespace webrtc
             device = GraphicsDevice::GetInstance().Init(renderer, nativeGfxDevice_, nullptr);
         }
         device_ = std::unique_ptr<IGraphicsDevice>(device);
-        device_->InitV();
+        EXPECT_TRUE(device_->InitV());
     }
 
     GraphicsDeviceContainer::~GraphicsDeviceContainer()

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
@@ -36,6 +36,8 @@ namespace webrtc
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
             if (!device_->IsCudaSupport())
                 GTEST_SKIP() << "CUDA is not supported on this device.";
+            if (!NvEncoder::IsSupported())
+                GTEST_SKIP() << "Current Driver Version does not support this NvEncodeAPI version.";
 
             context_ = device_->GetCUcontext();
 


### PR DESCRIPTION
Related issue #734.

This PR fixes the crash when launching Unity Editor on the machine which installing old NVIDIA driver.
If the CUDA version supported by the driver is lower than 11.0, NvCodec are removed from list of available codecs.