### PR TITLE
feat: Display CPU loads of encoding/decoding thread more details

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
@@ -23,11 +23,17 @@ namespace webrtc
     std::vector<SdpVideoFormat> SupportedNvEncoderCodecs(CUcontext context);
     std::vector<SdpVideoFormat> SupportedNvDecoderCodecs(CUcontext context);
 
+    class ProfilerMarkerFactory;
+
     class NvEncoder : public VideoEncoder
     {
     public:
         static std::unique_ptr<NvEncoder> Create(
-            const cricket::VideoCodec& codec, CUcontext context, CUmemorytype memoryType, NV_ENC_BUFFER_FORMAT format);
+            const cricket::VideoCodec& codec,
+            CUcontext context,
+            CUmemorytype memoryType,
+            NV_ENC_BUFFER_FORMAT format,
+            ProfilerMarkerFactory* profiler);
         static bool IsSupported();
         ~NvEncoder() override { }
     };
@@ -35,7 +41,8 @@ namespace webrtc
     class NvDecoder : public VideoDecoder
     {
     public:
-        static std::unique_ptr<NvDecoder> Create(const cricket::VideoCodec& codec, CUcontext context);
+        static std::unique_ptr<NvDecoder>
+        Create(const cricket::VideoCodec& codec, CUcontext context, ProfilerMarkerFactory* profiler);
         static bool IsSupported();
 
         ~NvDecoder() override { }
@@ -44,7 +51,7 @@ namespace webrtc
     class NvEncoderFactory : public VideoEncoderFactory
     {
     public:
-        NvEncoderFactory(CUcontext context, NV_ENC_BUFFER_FORMAT format);
+        NvEncoderFactory(CUcontext context, NV_ENC_BUFFER_FORMAT format, ProfilerMarkerFactory* profiler);
         ~NvEncoderFactory() override;
 
         std::vector<SdpVideoFormat> GetSupportedFormats() const override;
@@ -54,6 +61,7 @@ namespace webrtc
     private:
         CUcontext context_;
         NV_ENC_BUFFER_FORMAT format_;
+        ProfilerMarkerFactory* profiler_;
 
         // Cache of capability to reduce calling SessionOpenAPI of NvEncoder
         std::vector<SdpVideoFormat> m_cachedSupportedFormats;
@@ -62,7 +70,7 @@ namespace webrtc
     class NvDecoderFactory : public VideoDecoderFactory
     {
     public:
-        NvDecoderFactory(CUcontext context);
+        NvDecoderFactory(CUcontext context, ProfilerMarkerFactory* profiler);
         ~NvDecoderFactory() override;
 
         std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
@@ -70,6 +78,7 @@ namespace webrtc
 
     private:
         CUcontext context_;
+        ProfilerMarkerFactory* profiler_;
     };
 
 #ifndef _WIN32

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvDecoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvDecoderImpl.h
@@ -24,10 +24,11 @@ namespace webrtc
         absl::optional<PpsParser::PpsState> pps() { return pps_; }
     };
 
+    class ProfilerMarkerFactory;
     class NvDecoderImpl : public unity::webrtc::NvDecoder
     {
     public:
-        NvDecoderImpl(CUcontext context);
+        NvDecoderImpl(CUcontext context, ProfilerMarkerFactory* profiler);
         NvDecoderImpl(const NvDecoderImpl&) = delete;
         NvDecoderImpl& operator=(const NvDecoderImpl&) = delete;
         ~NvDecoderImpl() override;
@@ -48,6 +49,9 @@ namespace webrtc
         DecodedImageCallback* m_decodedCompleteCallback = nullptr;
         webrtc::VideoFrameBufferPool m_buffer_pool;
         H264BitstreamParser m_h264_bitstream_parser;
+
+        ProfilerMarkerFactory* m_profiler;
+        const UnityProfilerMarkerDesc* m_marker;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
@@ -22,6 +22,7 @@ namespace webrtc
 
     class ITexture2D;
     class IGraphicsDevice;
+    class ProfilerMarkerFactory;
     struct GpuMemoryBufferHandle;
     class GpuMemoryBufferInterface;
     class NvEncoderImpl : public unity::webrtc::NvEncoder
@@ -44,7 +45,11 @@ namespace webrtc
             void SetStreamState(bool send_stream);
         };
         NvEncoderImpl(
-            const cricket::VideoCodec& codec, CUcontext context, CUmemorytype memoryType, NV_ENC_BUFFER_FORMAT format);
+            const cricket::VideoCodec& codec,
+            CUcontext context,
+            CUmemorytype memoryType,
+            NV_ENC_BUFFER_FORMAT format,
+            ProfilerMarkerFactory* profiler);
         NvEncoderImpl(const NvEncoderImpl&) = delete;
         NvEncoderImpl& operator=(const NvEncoderImpl&) = delete;
         ~NvEncoderImpl() override;
@@ -97,6 +102,8 @@ namespace webrtc
         Clock* const m_clock;
         GUID m_profileGuid;
         NV_ENC_LEVEL m_level;
+        ProfilerMarkerFactory* m_profiler;
+        const UnityProfilerMarkerDesc* m_marker;
 
         std::vector<LayerConfig> m_configurations;
 

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -27,6 +27,10 @@ namespace webrtc
         texture_.reset(device_->CreateDefaultTextureV(width, height, format));
         textureCpuRead_.reset(device_->CreateCPUReadTextureV(width, height, format));
 
+        if (device_->GetProfilerFactory())
+            marker_ = device_->GetProfilerFactory()->CreateMarker(
+                "GpuMemoryBufferFromUnity.CopyBuffer", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
+
 // todo(kazuki): need to refactor
 #if CUDA_PLATFORM
         if (device_->IsCudaSupport())
@@ -43,6 +47,10 @@ namespace webrtc
 
     void GpuMemoryBufferFromUnity::CopyBuffer(NativeTexPtr ptr)
     {
+        std::unique_ptr<const ScopedProfiler> profiler;
+        if (device_->GetProfilerFactory())
+            profiler = device_->GetProfilerFactory()->CreateScopedProfiler(*marker_);
+
         // One texture cannot map CUDA memory and CPU memory simultaneously.
         // Believe there is still room for improvement.
         device_->CopyResourceFromNativeV(texture_.get(), ptr);

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -27,10 +27,6 @@ namespace webrtc
         texture_.reset(device_->CreateDefaultTextureV(width, height, format));
         textureCpuRead_.reset(device_->CreateCPUReadTextureV(width, height, format));
 
-        if (device_->GetProfilerFactory())
-            marker_ = device_->GetProfilerFactory()->CreateMarker(
-                "GpuMemoryBufferFromUnity.CopyBuffer", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
-
 // todo(kazuki): need to refactor
 #if CUDA_PLATFORM
         if (device_->IsCudaSupport())
@@ -47,10 +43,6 @@ namespace webrtc
 
     void GpuMemoryBufferFromUnity::CopyBuffer(NativeTexPtr ptr)
     {
-        std::unique_ptr<const ScopedProfiler> profiler;
-        if (device_->GetProfilerFactory())
-            profiler = device_->GetProfilerFactory()->CreateScopedProfiler(*marker_);
-
         // One texture cannot map CUDA memory and CPU memory simultaneously.
         // Believe there is still room for improvement.
         device_->CopyResourceFromNativeV(texture_.get(), ptr);

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.h
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.h
@@ -66,8 +66,6 @@ namespace webrtc
         std::unique_ptr<ITexture2D> texture_;
         std::unique_ptr<ITexture2D> textureCpuRead_;
         std::unique_ptr<GpuMemoryBufferHandle> handle_;
-
-        const UnityProfilerMarkerDesc* marker_;
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.h
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.h
@@ -66,6 +66,8 @@ namespace webrtc
         std::unique_ptr<ITexture2D> texture_;
         std::unique_ptr<ITexture2D> textureCpuRead_;
         std::unique_ptr<GpuMemoryBufferHandle> handle_;
+
+        const UnityProfilerMarkerDesc* marker_;
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -14,8 +14,9 @@ namespace unity
 namespace webrtc
 {
 
-    D3D11GraphicsDevice::D3D11GraphicsDevice(ID3D11Device* nativeDevice, UnityGfxRenderer renderer)
-        : IGraphicsDevice(renderer)
+    D3D11GraphicsDevice::D3D11GraphicsDevice(
+        ID3D11Device* nativeDevice, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
+        : IGraphicsDevice(renderer, profiler)
         , m_d3d11Device(nativeDevice)
         , m_isCudaSupport(false)
     {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
@@ -18,7 +18,7 @@ namespace webrtc
     class D3D11GraphicsDevice : public IGraphicsDevice
     {
     public:
-        D3D11GraphicsDevice(ID3D11Device* nativeDevice, UnityGfxRenderer renderer);
+        D3D11GraphicsDevice(ID3D11Device* nativeDevice, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
         virtual ~D3D11GraphicsDevice() override;
         virtual bool InitV() override;
         virtual void ShutdownV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -23,8 +23,11 @@ namespace webrtc
     //---------------------------------------------------------------------------------------------------------------------
 
     D3D12GraphicsDevice::D3D12GraphicsDevice(
-        ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer)
-        : IGraphicsDevice(renderer)
+        ID3D12Device* nativeDevice,
+        IUnityGraphicsD3D12v5* unityInterface,
+        UnityGfxRenderer renderer,
+        ProfilerMarkerFactory* profiler)
+        : IGraphicsDevice(renderer, profiler)
         , m_d3d12Device(nativeDevice)
         , m_d3d12CommandQueue(unityInterface->GetCommandQueue())
         , m_d3d11Device(nullptr)
@@ -35,8 +38,11 @@ namespace webrtc
     }
     //---------------------------------------------------------------------------------------------------------------------
     D3D12GraphicsDevice::D3D12GraphicsDevice(
-        ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer)
-        : IGraphicsDevice(renderer)
+        ID3D12Device* nativeDevice,
+        ID3D12CommandQueue* commandQueue,
+        UnityGfxRenderer renderer,
+        ProfilerMarkerFactory* profiler)
+        : IGraphicsDevice(renderer, profiler)
         , m_d3d12Device(nativeDevice)
         , m_d3d12CommandQueue(commandQueue)
         , m_d3d11Device(nullptr)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -57,9 +57,9 @@ namespace webrtc
     {
     public:
         explicit D3D12GraphicsDevice(
-            ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer);
+            ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
         explicit D3D12GraphicsDevice(
-            ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer);
+            ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
         virtual ~D3D12GraphicsDevice();
         virtual bool InitV() override;
         virtual void ShutdownV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -57,9 +57,15 @@ namespace webrtc
     {
     public:
         explicit D3D12GraphicsDevice(
-            ID3D12Device* nativeDevice, IUnityGraphicsD3D12v5* unityInterface, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
+            ID3D12Device* nativeDevice,
+            IUnityGraphicsD3D12v5* unityInterface,
+            UnityGfxRenderer renderer,
+            ProfilerMarkerFactory* profiler);
         explicit D3D12GraphicsDevice(
-            ID3D12Device* nativeDevice, ID3D12CommandQueue* commandQueue, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
+            ID3D12Device* nativeDevice,
+            ID3D12CommandQueue* commandQueue,
+            UnityGfxRenderer renderer,
+            ProfilerMarkerFactory* profiler);
         virtual ~D3D12GraphicsDevice();
         virtual bool InitV() override;
         virtual void ShutdownV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
@@ -83,8 +83,8 @@ namespace webrtc
 
     //---------------------------------------------------------------------------------------------------------------------
 
-    IGraphicsDevice*
-    GraphicsDevice::Init(const UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface, ProfilerMarkerFactory* profiler)
+    IGraphicsDevice* GraphicsDevice::Init(
+        const UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface, ProfilerMarkerFactory* profiler)
     {
         IGraphicsDevice* pDevice = nullptr;
         switch (renderer)
@@ -102,7 +102,10 @@ namespace webrtc
         {
             RTC_DCHECK(device);
             pDevice = new D3D12GraphicsDevice(
-                static_cast<ID3D12Device*>(device), reinterpret_cast<IUnityGraphicsD3D12v5*>(unityInterface), renderer, profiler);
+                static_cast<ID3D12Device*>(device),
+                reinterpret_cast<IUnityGraphicsD3D12v5*>(unityInterface),
+                renderer,
+                profiler);
             break;
         }
 #endif

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
@@ -31,7 +31,7 @@ namespace webrtc
         return device;
     }
 
-    IGraphicsDevice* GraphicsDevice::Init(IUnityInterfaces* unityInterface)
+    IGraphicsDevice* GraphicsDevice::Init(IUnityInterfaces* unityInterface, ProfilerMarkerFactory* profiler)
     {
         const UnityGfxRenderer rendererType = unityInterface->Get<IUnityGraphics>()->GetRenderer();
         switch (rendererType)
@@ -40,14 +40,14 @@ namespace webrtc
         case kUnityGfxRendererD3D11:
         {
             IUnityGraphicsD3D11* deviceInterface = unityInterface->Get<IUnityGraphicsD3D11>();
-            return Init(rendererType, deviceInterface->GetDevice(), deviceInterface);
+            return Init(rendererType, deviceInterface->GetDevice(), deviceInterface, profiler);
         }
 #endif
 #if SUPPORT_D3D12
         case kUnityGfxRendererD3D12:
         {
             IUnityGraphicsD3D12v5* deviceInterface = unityInterface->Get<IUnityGraphicsD3D12v5>();
-            return Init(rendererType, deviceInterface->GetDevice(), deviceInterface);
+            return Init(rendererType, deviceInterface->GetDevice(), deviceInterface, profiler);
         }
 #endif
 #if SUPPORT_OPENGL_CORE || SUPPORT_OPENGL_ES
@@ -55,7 +55,7 @@ namespace webrtc
         case kUnityGfxRendererOpenGLES30:
         case kUnityGfxRendererOpenGLCore:
         {
-            return Init(rendererType, nullptr, nullptr);
+            return Init(rendererType, nullptr, nullptr, profiler);
         }
 #endif
 #if SUPPORT_VULKAN
@@ -63,14 +63,14 @@ namespace webrtc
         {
             IUnityGraphicsVulkan* deviceInterface = unityInterface->Get<IUnityGraphicsVulkan>();
             UnityVulkanInstance vulkan = deviceInterface->Instance();
-            return Init(rendererType, reinterpret_cast<void*>(&vulkan), deviceInterface);
+            return Init(rendererType, reinterpret_cast<void*>(&vulkan), deviceInterface, profiler);
         }
 #endif
 #if SUPPORT_METAL
         case kUnityGfxRendererMetal:
         {
             std::unique_ptr<MetalDevice> device = MetalDevice::Create(unityInterface->Get<IUnityGraphicsMetal>());
-            return Init(rendererType, device.release(), nullptr);
+            return Init(rendererType, device.release(), nullptr, profiler);
             break;
         }
 #endif
@@ -84,7 +84,7 @@ namespace webrtc
     //---------------------------------------------------------------------------------------------------------------------
 
     IGraphicsDevice*
-    GraphicsDevice::Init(const UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface)
+    GraphicsDevice::Init(const UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface, ProfilerMarkerFactory* profiler)
     {
         IGraphicsDevice* pDevice = nullptr;
         switch (renderer)
@@ -93,7 +93,7 @@ namespace webrtc
         case kUnityGfxRendererD3D11:
         {
             RTC_DCHECK(device);
-            pDevice = new D3D11GraphicsDevice(static_cast<ID3D11Device*>(device), renderer);
+            pDevice = new D3D11GraphicsDevice(static_cast<ID3D11Device*>(device), renderer, profiler);
             break;
         }
 #endif
@@ -102,7 +102,7 @@ namespace webrtc
         {
             RTC_DCHECK(device);
             pDevice = new D3D12GraphicsDevice(
-                static_cast<ID3D12Device*>(device), reinterpret_cast<IUnityGraphicsD3D12v5*>(unityInterface), renderer);
+                static_cast<ID3D12Device*>(device), reinterpret_cast<IUnityGraphicsD3D12v5*>(unityInterface), renderer, profiler);
             break;
         }
 #endif
@@ -111,7 +111,7 @@ namespace webrtc
         case kUnityGfxRendererOpenGLES30:
         case kUnityGfxRendererOpenGLCore:
         {
-            pDevice = new OpenGLGraphicsDevice(renderer);
+            pDevice = new OpenGLGraphicsDevice(renderer, profiler);
             break;
         }
 #endif
@@ -127,7 +127,8 @@ namespace webrtc
                 vulkan->device,
                 vulkan->graphicsQueue,
                 vulkan->queueFamilyIndex,
-                renderer);
+                renderer,
+                profiler);
             break;
         }
 #endif
@@ -136,7 +137,7 @@ namespace webrtc
         {
             RTC_DCHECK(device);
             MetalDevice* metalDevice = static_cast<MetalDevice*>(device);
-            pDevice = new MetalGraphicsDevice(metalDevice, renderer);
+            pDevice = new MetalGraphicsDevice(metalDevice, renderer, profiler);
             break;
         }
 #endif

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.h
@@ -13,7 +13,8 @@ namespace webrtc
     public:
         static GraphicsDevice& GetInstance();
         IGraphicsDevice* Init(IUnityInterfaces* unityInterface, ProfilerMarkerFactory* profiler);
-        IGraphicsDevice* Init(UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface, ProfilerMarkerFactory* profiler);
+        IGraphicsDevice*
+        Init(UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface, ProfilerMarkerFactory* profiler);
 
     private:
         GraphicsDevice();

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.h
@@ -12,8 +12,8 @@ namespace webrtc
     {
     public:
         static GraphicsDevice& GetInstance();
-        IGraphicsDevice* Init(IUnityInterfaces* unityInterface);
-        IGraphicsDevice* Init(UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface);
+        IGraphicsDevice* Init(IUnityInterfaces* unityInterface, ProfilerMarkerFactory* profiler);
+        IGraphicsDevice* Init(UnityGfxRenderer renderer, void* device, IUnityInterface* unityInterface, ProfilerMarkerFactory* profiler);
 
     private:
         GraphicsDevice();

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -6,6 +6,8 @@
 #include <api/video/i420_buffer.h>
 
 #include "PlatformBase.h"
+#include "ProfilerMarkerFactory.h"
+#include "ScopedProfiler.h"
 
 #if CUDA_PLATFORM
 #include "Cuda/ICudaDevice.h"
@@ -18,14 +20,16 @@ namespace webrtc
     using NativeTexPtr = void*;
     class ITexture2D;
     struct GpuMemoryBufferHandle;
+    class ProfilerMarkerFactory;
     class IGraphicsDevice
 #if CUDA_PLATFORM
         : public ICudaDevice
 #endif
     {
     public:
-        IGraphicsDevice(UnityGfxRenderer renderer)
+        IGraphicsDevice(UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
             : m_gfxRenderer(renderer)
+            , m_profiler(profiler)
         {
         }
 #if CUDA_PLATFORM
@@ -51,6 +55,7 @@ namespace webrtc
 
     protected:
         UnityGfxRenderer m_gfxRenderer;
+        ProfilerMarkerFactory* m_profiler;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -46,7 +46,6 @@ namespace webrtc
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, NativeTexPtr nativeTexturePtr) = 0;
         virtual NativeTexPtr ConvertNativeFromUnityPtr(void* tex) { return tex; }
         virtual UnityGfxRenderer GetGfxRenderer() const { return m_gfxRenderer; }
-        virtual ProfilerMarkerFactory* GetProfilerFactory() const { return m_profiler; }
         virtual std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) = 0;
 
         // Required for software encoding

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -46,6 +46,7 @@ namespace webrtc
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, NativeTexPtr nativeTexturePtr) = 0;
         virtual NativeTexPtr ConvertNativeFromUnityPtr(void* tex) { return tex; }
         virtual UnityGfxRenderer GetGfxRenderer() const { return m_gfxRenderer; }
+        virtual ProfilerMarkerFactory* GetProfilerFactory() const { return m_profiler; }
         virtual std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) = 0;
 
         // Required for software encoding

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
@@ -14,7 +14,7 @@ namespace webrtc
     class MetalGraphicsDevice : public IGraphicsDevice
     {
     public:
-        MetalGraphicsDevice(MetalDevice* device, UnityGfxRenderer renderer);
+        MetalGraphicsDevice(MetalDevice* device, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
         virtual ~MetalGraphicsDevice() = default;
 
         bool InitV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -10,8 +10,8 @@ namespace unity
 namespace webrtc
 {
 
-    MetalGraphicsDevice::MetalGraphicsDevice(MetalDevice* device, UnityGfxRenderer renderer)
-        : IGraphicsDevice(renderer)
+    MetalGraphicsDevice::MetalGraphicsDevice(MetalDevice* device, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
+        : IGraphicsDevice(renderer, profiler)
         , m_device(device)
     {
     }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -10,7 +10,8 @@ namespace unity
 namespace webrtc
 {
 
-    MetalGraphicsDevice::MetalGraphicsDevice(MetalDevice* device, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
+    MetalGraphicsDevice::MetalGraphicsDevice(
+        MetalDevice* device, UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
         : IGraphicsDevice(renderer, profiler)
         , m_device(device)
     {
@@ -68,7 +69,7 @@ namespace webrtc
         RTC_DCHECK_EQ(src.height, dest.height);
 
         m_device->EndCurrentCommandEncoder();
-        
+
         id<MTLCommandBuffer> commandBuffer = [m_queue commandBuffer];
         id<MTLBlitCommandEncoder> blit = [commandBuffer blitCommandEncoder];
         NSUInteger width = src.width;
@@ -92,13 +93,13 @@ namespace webrtc
         // must be explicitly synchronized if the storageMode is Managed.
         if (dest.storageMode == MTLStorageModeManaged)
             [blit synchronizeResource:dest];
-#endif            
+#endif
         [blit endEncoding];
-        
+
         // Commit the current command buffer and wait until the GPU process is completed.
         [commandBuffer commit];
         [commandBuffer waitUntilCompleted];
-        
+
         return true;
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -37,8 +37,8 @@ Size glTexSize(GLenum target, GLuint texture, GLint mipLevel)
 
 
 OpenGLGraphicsDevice::OpenGLGraphicsDevice(
-    UnityGfxRenderer renderer)
-    : IGraphicsDevice(renderer)
+    UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
+    : IGraphicsDevice(renderer, profiler)
     , mainContext_(nullptr)
 {
     OpenGLContext::Init();

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
@@ -22,7 +22,7 @@ struct OpenGLTexture2D;
 class OpenGLGraphicsDevice : public IGraphicsDevice
 {
 public:
-    OpenGLGraphicsDevice(UnityGfxRenderer renderer);
+    OpenGLGraphicsDevice(UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler);
     virtual ~OpenGLGraphicsDevice();
 
     virtual bool InitV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -24,8 +24,9 @@ namespace webrtc
         const VkDevice device,
         const VkQueue graphicsQueue,
         const uint32_t queueFamilyIndex,
-        UnityGfxRenderer renderer)
-        : IGraphicsDevice(renderer)
+        UnityGfxRenderer renderer,
+        ProfilerMarkerFactory* profiler)
+        : IGraphicsDevice(renderer, profiler)
         , m_unityVulkan(unityVulkan)
         , m_physicalDevice(physicalDevice)
         , m_device(device)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -30,7 +30,8 @@ namespace webrtc
             const VkDevice device,
             const VkQueue graphicsQueue,
             const uint32_t queueFamilyIndex,
-            UnityGfxRenderer renderer);
+            UnityGfxRenderer renderer,
+            ProfilerMarkerFactory* profiler);
 
         virtual ~VulkanGraphicsDevice() override = default;
         virtual bool InitV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -74,6 +74,8 @@ namespace webrtc
         VkCommandPool m_commandPool;
         uint32_t m_queueFamilyIndex;
         VkAllocationCallbacks* m_allocator;
+        const UnityProfilerMarkerDesc* m_maker;
+
 #if CUDA_PLATFORM
         bool InitCudaContext();
         VkInstance m_instance;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -135,7 +135,7 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             }
         }
 #endif
-        s_gfxDevice.reset(GraphicsDevice::GetInstance().Init(s_UnityInterfaces));
+        s_gfxDevice.reset(GraphicsDevice::GetInstance().Init(s_UnityInterfaces, s_ProfilerMarkerFactory.get()));
         if (s_gfxDevice != nullptr)
         {
             s_gfxDevice->InitV();

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -81,7 +81,7 @@ namespace webrtc
         std::unique_ptr<const ScopedProfilerThread> profilerThread_;
     };
 
-    static webrtc::VideoDecoderFactory* CreateNativeDecoderFactory(IGraphicsDevice* gfxDevice)
+    static webrtc::VideoDecoderFactory* CreateNativeDecoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler)
     {
 #if UNITY_OSX || UNITY_IOS
         return webrtc::ObjCToNativeVideoDecoderFactory([[RTCDefaultVideoDecoderFactory alloc] init]).release();
@@ -92,7 +92,7 @@ namespace webrtc
         if (gfxDevice->IsCudaSupport())
         {
             CUcontext context = gfxDevice->GetCUcontext();
-            return new NvDecoderFactory(context);
+            return new NvDecoderFactory(context, profiler);
         }
 #endif
         return nullptr;
@@ -101,7 +101,7 @@ namespace webrtc
     UnityVideoDecoderFactory::UnityVideoDecoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler)
         : profiler_(profiler)
         , internal_decoder_factory_(new webrtc::InternalDecoderFactory())
-        , native_decoder_factory_(CreateNativeDecoderFactory(gfxDevice))
+        , native_decoder_factory_(CreateNativeDecoderFactory(gfxDevice, profiler))
     {
     }
 

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -112,7 +112,7 @@ namespace webrtc
         std::unique_ptr<const ScopedProfilerThread> profilerThread_;
     };
 
-    static webrtc::VideoEncoderFactory* CreateNativeEncoderFactory(IGraphicsDevice* gfxDevice)
+    static webrtc::VideoEncoderFactory* CreateNativeEncoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler)
     {
 #if UNITY_OSX || UNITY_IOS
         return webrtc::ObjCToNativeVideoEncoderFactory([[RTCDefaultVideoEncoderFactory alloc] init]).release();
@@ -124,7 +124,7 @@ namespace webrtc
         {
             CUcontext context = gfxDevice->GetCUcontext();
             NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();
-            return new NvEncoderFactory(context, format);
+            return new NvEncoderFactory(context, format, profiler);
         }
 #endif
         return nullptr;
@@ -133,7 +133,7 @@ namespace webrtc
     UnityVideoEncoderFactory::UnityVideoEncoderFactory(IGraphicsDevice* gfxDevice, ProfilerMarkerFactory* profiler)
         : profiler_(profiler)
         , internal_encoder_factory_(new webrtc::InternalEncoderFactory())
-        , native_encoder_factory_(CreateNativeEncoderFactory(gfxDevice))
+        , native_encoder_factory_(CreateNativeEncoderFactory(gfxDevice, profiler))
     {
     }
 

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -525,12 +525,12 @@ namespace webrtc
         {
 #if defined(SUPPORT_D3D12)
             device =
-                new D3D12GraphicsDevice(static_cast<ID3D12Device*>(nativeGfxDevice_), pCommandQueue.Get(), renderer);
+                new D3D12GraphicsDevice(static_cast<ID3D12Device*>(nativeGfxDevice_), pCommandQueue.Get(), renderer, nullptr);
 #endif
         }
         else
         {
-            device = GraphicsDevice::GetInstance().Init(renderer, nativeGfxDevice_, nullptr);
+            device = GraphicsDevice::GetInstance().Init(renderer, nativeGfxDevice_, nullptr, nullptr);
         }
         device_ = std::unique_ptr<IGraphicsDevice>(device);
         EXPECT_TRUE(device_->InitV());

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
@@ -49,14 +49,14 @@ namespace webrtc
         {
             cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
             codec.SetParam(cricket::kH264FmtpProfileLevelId, kProfileLevelIdString());
-            return NvEncoder::Create(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB);
+            return NvEncoder::Create(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
         }
 
         std::unique_ptr<VideoDecoder> CreateDecoder() override
         {
             cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
             codec.SetParam(cricket::kH264FmtpProfileLevelId, kProfileLevelIdString());
-            return NvDecoder::Create(codec, context_);
+            return NvDecoder::Create(codec, context_, nullptr);
         }
 
         std::unique_ptr<FrameGeneratorInterface> CreateFrameGenerator(

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvDecoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvDecoderImplTest.cpp
@@ -41,7 +41,7 @@ namespace webrtc
 
     TEST_P(NvDecoderImplTest, CanInitializeWithDefaultParameters)
     {
-        NvDecoderImpl decoder(context_);
+        NvDecoderImpl decoder(context_, nullptr);
 
         VideoCodec codec_settings;
         SetDefaultSettings(&codec_settings);

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
@@ -42,7 +42,7 @@ namespace webrtc
     {
         cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
         codec.SetParam(cricket::kH264FmtpProfileLevelId, kProfileLevelIdString());
-        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB);
+        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
 
         VideoCodec codec_settings;
         SetDefaultSettings(&codec_settings);
@@ -55,7 +55,7 @@ namespace webrtc
 
         cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
         codec.SetParam(cricket::kH264FmtpProfileLevelId, *H264ProfileLevelIdToString(profileLevelId));
-        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB);
+        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
 
         VideoCodec codec_settings;
         SetDefaultSettings(&codec_settings);
@@ -71,7 +71,7 @@ namespace webrtc
 
         cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
         codec.SetParam(cricket::kH264FmtpProfileLevelId, *H264ProfileLevelIdToString(profileLevelId));
-        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB);
+        NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
 
         VideoCodec codec_settings;
         SetDefaultSettings(&codec_settings);


### PR DESCRIPTION
Changed to be able to profile process in the detailed implementation of each graphics device class and Encoder / Decoder class.

example

1. NvEncoder.CopyResource
![image](https://user-images.githubusercontent.com/26959415/172548169-41fda75a-2deb-4e0a-af7d-578f1833a78a.png)

2. VulkanGraphicsDevice.CopyImage
![image](https://user-images.githubusercontent.com/26959415/172548319-44f89908-2532-46bf-ae6c-f1992afcb259.png)
