### PR TITLE
feat: Add the argument to RTCPeerConnection.AddTransceiver method to configure streaming

### DIFF
--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1225,7 +1225,16 @@ extern "C"
 
         for (size_t i = 0; i < dst.encodings.size(); i++)
         {
-            dst.encodings[i] = src->encodings[i];
+            dst.encodings[i].active = src->encodings[i].active;
+            dst.encodings[i].max_bitrate_bps =
+                static_cast<absl::optional<int>>(ConvertOptional(src->encodings[i].maxBitrate));
+            dst.encodings[i].min_bitrate_bps =
+                static_cast<absl::optional<int>>(ConvertOptional(src->encodings[i].minBitrate));
+            dst.encodings[i].max_framerate =
+                static_cast<absl::optional<double>>(ConvertOptional(src->encodings[i].maxFramerate));
+            dst.encodings[i].scale_resolution_down_by = ConvertOptional(src->encodings[i].scaleResolutionDownBy);
+            if (src->encodings[i].rid != nullptr)
+                dst.encodings[i].rid = std::string(src->encodings[i].rid);
         }
         const ::webrtc::RTCError error = sender->SetParameters(dst);
         return error.type();

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -542,7 +542,7 @@ extern "C"
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface* PeerConnectionAddTransceiverWithInit(
-        Context* context, PeerConnectionObject* obj, MediaStreamTrackInterface* track, RtpTransceiverInit* init)
+        Context* context, PeerConnectionObject* obj, MediaStreamTrackInterface* track, RTCRtpTransceiverInit* init)
     {
         auto result = obj->connection->AddTransceiver(track, *init);
         if (!result.ok())

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -532,7 +532,7 @@ extern "C"
     };
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface*
-    PeerConnectionAddTransceiver(Context* context, PeerConnectionObject* obj, MediaStreamTrackInterface* track)
+    PeerConnectionAddTransceiver(PeerConnectionObject* obj, MediaStreamTrackInterface* track)
     {
         auto result = obj->connection->AddTransceiver(track);
         if (!result.ok())
@@ -542,7 +542,7 @@ extern "C"
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface* PeerConnectionAddTransceiverWithInit(
-        Context* context, PeerConnectionObject* obj, MediaStreamTrackInterface* track, RTCRtpTransceiverInit* init)
+        PeerConnectionObject* obj, MediaStreamTrackInterface* track, const RTCRtpTransceiverInit* init)
     {
         auto result = obj->connection->AddTransceiver(track, *init);
         if (!result.ok())
@@ -552,7 +552,7 @@ extern "C"
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface*
-    PeerConnectionAddTransceiverWithType(Context* context, PeerConnectionObject* obj, cricket::MediaType type)
+    PeerConnectionAddTransceiverWithType(PeerConnectionObject* obj, cricket::MediaType type)
     {
         auto result = obj->connection->AddTransceiver(type);
         if (!result.ok())
@@ -562,7 +562,7 @@ extern "C"
     }
 
     UNITY_INTERFACE_EXPORT RtpTransceiverInterface* PeerConnectionAddTransceiverWithTypeAndInit(
-        Context* context, PeerConnectionObject* obj, cricket::MediaType type, const RTCRtpTransceiverInit* init)
+        PeerConnectionObject* obj, cricket::MediaType type, const RTCRtpTransceiverInit* init)
     {
         auto result = obj->connection->AddTransceiver(type, *init);
         if (!result.ok())

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -127,14 +127,20 @@ namespace Unity.WebRTC
             NativeMethods.PeerConnectionRegisterOnSetSessionDescFailure(self, ptr, callback);
         }
 
-        public IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track)
+        public IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init = null)
         {
-            return NativeMethods.PeerConnectionAddTransceiver(self, pc, track);
+            if (init == null)
+                return NativeMethods.PeerConnectionAddTransceiver(self, pc, track);
+            RTCRtpTransceiverInitInternal _init = init.Cast();
+            return NativeMethods.PeerConnectionAddTransceiverWithInit(self, pc, track, ref _init);
         }
 
-        public IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind)
+        public IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind, RTCRtpTransceiverInit init = null)
         {
-            return NativeMethods.PeerConnectionAddTransceiverWithType(self, pc, kind);
+            if (init == null)
+                return NativeMethods.PeerConnectionAddTransceiverWithType(self, pc, kind);
+            RTCRtpTransceiverInitInternal _init = init.Cast();
+            return NativeMethods.PeerConnectionAddTransceiverWithTypeAndInit(self, pc, kind, ref _init);
         }
 
         public IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length)

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -127,7 +127,7 @@ namespace Unity.WebRTC
             NativeMethods.PeerConnectionRegisterOnSetSessionDescFailure(self, ptr, callback);
         }
 
-        public IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init = null)
+        public IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init)
         {
             if (init == null)
                 return NativeMethods.PeerConnectionAddTransceiver(self, pc, track);
@@ -135,7 +135,7 @@ namespace Unity.WebRTC
             return NativeMethods.PeerConnectionAddTransceiverWithInit(self, pc, track, ref _init);
         }
 
-        public IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind, RTCRtpTransceiverInit init = null)
+        public IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind, RTCRtpTransceiverInit init)
         {
             if (init == null)
                 return NativeMethods.PeerConnectionAddTransceiverWithType(self, pc, kind);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -127,22 +127,6 @@ namespace Unity.WebRTC
             NativeMethods.PeerConnectionRegisterOnSetSessionDescFailure(self, ptr, callback);
         }
 
-        public IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init)
-        {
-            if (init == null)
-                return NativeMethods.PeerConnectionAddTransceiver(self, pc, track);
-            RTCRtpTransceiverInitInternal _init = init.Cast();
-            return NativeMethods.PeerConnectionAddTransceiverWithInit(self, pc, track, ref _init);
-        }
-
-        public IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind, RTCRtpTransceiverInit init)
-        {
-            if (init == null)
-                return NativeMethods.PeerConnectionAddTransceiverWithType(self, pc, kind);
-            RTCRtpTransceiverInitInternal _init = init.Cast();
-            return NativeMethods.PeerConnectionAddTransceiverWithTypeAndInit(self, pc, kind, ref _init);
-        }
-
         public IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length)
         {
             return NativeMethods.PeerConnectionGetReceivers(self, ptr, out length);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -565,7 +565,7 @@ namespace Unity.WebRTC
         public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track, RTCRtpTransceiverInit init = null)
         {
             IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiver(
-                GetSelfOrThrow(), track.GetSelfOrThrow());
+                GetSelfOrThrow(), track.GetSelfOrThrow(), init);
             return CreateTransceiver(ptr);
         }
 
@@ -577,7 +577,7 @@ namespace Unity.WebRTC
         public RTCRtpTransceiver AddTransceiver(TrackKind kind, RTCRtpTransceiverInit init = null)
         {
             IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiverWithType(
-                GetSelfOrThrow(), kind);
+                GetSelfOrThrow(), kind, init);
             return CreateTransceiver(ptr);
         }
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -562,7 +562,7 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="track"></param>
         /// <returns></returns>
-        public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track)
+        public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track, RTCRtpTransceiverInit init = null)
         {
             IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiver(
                 GetSelfOrThrow(), track.GetSelfOrThrow());
@@ -574,7 +574,7 @@ namespace Unity.WebRTC
         /// </summary>
         /// <param name="kind"></param>
         /// <returns></returns>
-        public RTCRtpTransceiver AddTransceiver(TrackKind kind)
+        public RTCRtpTransceiver AddTransceiver(TrackKind kind, RTCRtpTransceiverInit init = null)
         {
             IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiverWithType(
                 GetSelfOrThrow(), kind);

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -564,7 +564,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(MediaStreamTrack track, RTCRtpTransceiverInit init = null)
         {
-            IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiver(
+            IntPtr ptr = PeerConnectionAddTransceiver(
                 GetSelfOrThrow(), track.GetSelfOrThrow(), init);
             return CreateTransceiver(ptr);
         }
@@ -576,7 +576,7 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public RTCRtpTransceiver AddTransceiver(TrackKind kind, RTCRtpTransceiverInit init = null)
         {
-            IntPtr ptr = WebRTC.Context.PeerConnectionAddTransceiverWithType(
+            IntPtr ptr = PeerConnectionAddTransceiverWithType(
                 GetSelfOrThrow(), kind, init);
             return CreateTransceiver(ptr);
         }
@@ -922,6 +922,22 @@ namespace Unity.WebRTC
                     connection.OnStatsDelivered(report);
                 }
             });
+        }
+
+        static IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init)
+        {
+            if (init == null)
+                return NativeMethods.PeerConnectionAddTransceiver(pc, track);
+            RTCRtpTransceiverInitInternal _init = init.Cast();
+            return NativeMethods.PeerConnectionAddTransceiverWithInit(pc, track, ref _init);
+        }
+
+        static IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind, RTCRtpTransceiverInit init)
+        {
+            if (init == null)
+                return NativeMethods.PeerConnectionAddTransceiverWithType(pc, kind);
+            RTCRtpTransceiverInitInternal _init = init.Cast();
+            return NativeMethods.PeerConnectionAddTransceiverWithTypeAndInit(pc, kind, ref _init);
         }
     }
 }

--- a/Runtime/Scripts/RTCRtpTransceiver.cs
+++ b/Runtime/Scripts/RTCRtpTransceiver.cs
@@ -71,8 +71,7 @@ namespace Unity.WebRTC
         {
             get
             {
-                var direction = RTCRtpTransceiverDirection.RecvOnly;
-                if (NativeMethods.TransceiverGetCurrentDirection(GetSelfOrThrow(), ref direction))
+                if (NativeMethods.TransceiverGetCurrentDirection(GetSelfOrThrow(), out var direction))
                 {
                     return direction;
                 }

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Unity.WebRTC
@@ -11,6 +12,8 @@ namespace Unity.WebRTC
         public uint? maxFramerate;
         public double? scaleResolutionDownBy;
         public string rid;
+
+        public RTCRtpEncodingParameters() { }
 
         internal RTCRtpEncodingParameters(ref RTCRtpEncodingParametersInternal parameter)
         {
@@ -31,6 +34,19 @@ namespace Unity.WebRTC
             instance.maxFramerate = maxFramerate;
             instance.scaleResolutionDownBy = scaleResolutionDownBy;
             instance.rid = string.IsNullOrEmpty(rid) ? IntPtr.Zero : Marshal.StringToCoTaskMemAnsi(rid);
+        }
+
+        internal RTCRtpEncodingParametersInternal Cast()
+        {
+            return new RTCRtpEncodingParametersInternal
+            {
+                active = this.active,
+                maxBitrate = this.maxBitrate,
+                minBitrate = this.minBitrate,
+                maxFramerate = this.maxFramerate,
+                scaleResolutionDownBy = this.scaleResolutionDownBy,
+                rid = string.IsNullOrEmpty(this.rid) ? IntPtr.Zero : Marshal.StringToCoTaskMemAnsi(this.rid)
+            };
         }
     }
 
@@ -202,6 +218,26 @@ namespace Unity.WebRTC
         }
     }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    public class RTCRtpTransceiverInit
+    {
+        public RTCRtpTransceiverDirection direction;
+        public RTCRtpEncodingParameters[] sendEncodings;
+        public MediaStream[] streams;
+
+        internal RTCRtpTransceiverInitInternal Cast()
+        {
+            return new RTCRtpTransceiverInitInternal
+            {
+                direction = this.direction,
+                sendEncodings = this.sendEncodings.Select(_ => _.Cast()).ToArray(),
+                streams = streams.Select(_ => _.self).ToArray(),
+            };
+        }
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     internal struct RTCRtpCodecCapabilityInternal
     {
@@ -288,4 +324,19 @@ namespace Unity.WebRTC
         public OptionalDouble scaleResolutionDownBy;
         public IntPtr rid;
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RTCRtpTransceiverInitInternal
+    {
+        public RTCRtpTransceiverDirection direction;
+        public MarshallingArray<RTCRtpEncodingParametersInternal> sendEncodings;
+        public MarshallingArray<IntPtr> streams;
+
+        public void Dispose()
+        {
+            sendEncodings.Dispose();
+            streams.Dispose();
+        }
+    }
+
 }

--- a/Runtime/Scripts/RTPParameters.cs
+++ b/Runtime/Scripts/RTPParameters.cs
@@ -22,7 +22,7 @@ namespace Unity.WebRTC
             minBitrate = parameter.minBitrate;
             maxFramerate = parameter.maxFramerate;
             scaleResolutionDownBy = parameter.scaleResolutionDownBy;
-            if(parameter.rid != IntPtr.Zero)
+            if (parameter.rid != IntPtr.Zero)
                 rid = parameter.rid.AsAnsiStringWithFreeMem();
         }
 
@@ -135,7 +135,7 @@ namespace Unity.WebRTC
             instance = default;
             RTCRtpEncodingParametersInternal[] encodings =
                 new RTCRtpEncodingParametersInternal[this.encodings.Length];
-            for(int i = 0; i < this.encodings.Length; i++)
+            for (int i = 0; i < this.encodings.Length; i++)
             {
                 this.encodings[i].CopyInternal(ref encodings[i]);
             }
@@ -223,7 +223,7 @@ namespace Unity.WebRTC
     /// </summary>
     public class RTCRtpTransceiverInit
     {
-        public RTCRtpTransceiverDirection direction;
+        public RTCRtpTransceiverDirection? direction;
         public RTCRtpEncodingParameters[] sendEncodings;
         public MediaStream[] streams;
 
@@ -231,9 +231,9 @@ namespace Unity.WebRTC
         {
             return new RTCRtpTransceiverInitInternal
             {
-                direction = this.direction,
-                sendEncodings = this.sendEncodings.Select(_ => _.Cast()).ToArray(),
-                streams = streams.Select(_ => _.self).ToArray(),
+                direction = direction.GetValueOrDefault(RTCRtpTransceiverDirection.SendRecv),
+                sendEncodings = sendEncodings == null ? default(MarshallingArray<RTCRtpEncodingParametersInternal>) : sendEncodings.Select(_ => _.Cast()).ToArray(),
+                streams = streams == null ? default(MarshallingArray<IntPtr>) : streams.Select(_ => _.self).ToArray(),
             };
         }
     }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -947,6 +947,10 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr PeerConnectionAddTransceiverWithType(IntPtr context, IntPtr pc, TrackKind kind);
         [DllImport(WebRTC.Lib)]
+        public static extern IntPtr PeerConnectionAddTransceiverWithInit(IntPtr context, IntPtr pc, IntPtr track, ref RTCRtpTransceiverInitInternal init);
+        [DllImport(WebRTC.Lib)]
+        public static extern IntPtr PeerConnectionAddTransceiverWithTypeAndInit(IntPtr context, IntPtr pc, TrackKind kind, ref RTCRtpTransceiverInitInternal init);
+        [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType PeerConnectionRemoveTrack(IntPtr pc, IntPtr sender);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -943,13 +943,13 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType PeerConnectionAddTrack(IntPtr pc, IntPtr track, [MarshalAs(UnmanagedType.LPStr, SizeConst = 256)] string streamId, out IntPtr sender);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionAddTransceiver(IntPtr context, IntPtr pc, IntPtr track);
+        public static extern IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionAddTransceiverWithType(IntPtr context, IntPtr pc, TrackKind kind);
+        public static extern IntPtr PeerConnectionAddTransceiverWithType(IntPtr pc, TrackKind kind);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionAddTransceiverWithInit(IntPtr context, IntPtr pc, IntPtr track, ref RTCRtpTransceiverInitInternal init);
+        public static extern IntPtr PeerConnectionAddTransceiverWithInit(IntPtr pc, IntPtr track, ref RTCRtpTransceiverInitInternal init);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr PeerConnectionAddTransceiverWithTypeAndInit(IntPtr context, IntPtr pc, TrackKind kind, ref RTCRtpTransceiverInitInternal init);
+        public static extern IntPtr PeerConnectionAddTransceiverWithTypeAndInit(IntPtr pc, TrackKind kind, ref RTCRtpTransceiverInitInternal init);
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType PeerConnectionRemoveTrack(IntPtr pc, IntPtr sender);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -993,7 +993,7 @@ namespace Unity.WebRTC
         public static extern void PeerConnectionRegisterOnRemoveTrack(IntPtr ptr, DelegateNativeOnRemoveTrack callback);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static extern bool TransceiverGetCurrentDirection(IntPtr transceiver, ref RTCRtpTransceiverDirection direction);
+        public static extern bool TransceiverGetCurrentDirection(IntPtr transceiver, out RTCRtpTransceiverDirection direction);
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType TransceiverStop(IntPtr transceiver);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -242,9 +242,10 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var peer = new RTCPeerConnection();
             var stream = new MediaStream();
+            var direction = RTCRtpTransceiverDirection.SendOnly;
             var init = new RTCRtpTransceiverInit()
             {
-                direction = RTCRtpTransceiverDirection.SendOnly,
+                direction = direction,
                 sendEncodings = new RTCRtpEncodingParameters[] {
                     new RTCRtpEncodingParameters { maxFramerate = 30 }
                 },
@@ -253,6 +254,12 @@ namespace Unity.WebRTC.RuntimeTest
             var transceiver = peer.AddTransceiver(TrackKind.Video, init);
             Assert.That(transceiver, Is.Not.Null);
             Assert.That(transceiver.CurrentDirection, Is.Null);
+            Assert.That(transceiver.Direction, Is.EqualTo(RTCRtpTransceiverDirection.SendOnly));
+            Assert.That(transceiver.Sender, Is.Not.Null);
+
+            var parameters = transceiver.Sender.GetParameters();
+            Assert.That(parameters, Is.Not.Null);
+            Assert.That(parameters.codecs, Is.Not.Null.And.Empty);
             peer.Dispose();
         }
 
@@ -334,16 +341,8 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(transceiver1.CurrentDirection, RTCRtpTransceiverDirection.RecvOnly);
             Assert.AreEqual(transceiver2.CurrentDirection, RTCRtpTransceiverDirection.SendOnly);
 
-            //Assert.That(transceiver2.Stop(), Is.EqualTo(RTCErrorType.None));
-            //Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
-
-            // todo(kazuki):: Transceiver.CurrentDirection of Sender is not changed to "Stopped" even if waiting
-            // yield return new WaitUntil(() => transceiver2.CurrentDirection == RTCRtpTransceiverDirection.Stopped);
-            // Assert.That(transceiver2.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
-
-            // todo(kazuki):: Transceiver.CurrentDirection of Receiver is not changed to "Stopped" even if waiting
-            // yield return new WaitUntil(() => transceiver1.Direction == RTCRtpTransceiverDirection.Stopped);
-            // Assert.That(transceiver1.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+            Assert.That(transceiver2.Stop(), Is.EqualTo(RTCErrorType.None));
+            Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
 
             audioTrack.Dispose();
             peer1.Close();

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -293,6 +293,18 @@ namespace Unity.WebRTC.RuntimeTest
             var parameters = transceiver.Sender.GetParameters();
             Assert.That(parameters, Is.Not.Null);
             Assert.That(parameters.codecs, Is.Not.Null.And.Empty);
+
+            var init2 = new RTCRtpTransceiverInit()
+            {
+                direction = null,
+                sendEncodings = null,
+                streams = null
+            };
+            var transceiver2 = peer.AddTransceiver(TrackKind.Video, init2);
+            Assert.That(transceiver2, Is.Not.Null);
+            Assert.That(transceiver2.CurrentDirection, Is.Null);
+            Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.SendRecv));
+            Assert.That(transceiver2.Sender, Is.Not.Null);
             peer.Dispose();
         }
 

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -243,6 +243,39 @@ namespace Unity.WebRTC.RuntimeTest
             var peer = new RTCPeerConnection();
             var stream = new MediaStream();
             var direction = RTCRtpTransceiverDirection.SendOnly;
+            var width = 256;
+            var height = 256;
+            var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
+            var rt = new RenderTexture(width, height, 0, format);
+            rt.Create();
+            var track = new VideoStreamTrack(rt);
+            var init = new RTCRtpTransceiverInit()
+            {
+                direction = direction,
+                sendEncodings = new RTCRtpEncodingParameters[] {
+                    new RTCRtpEncodingParameters { maxFramerate = 30 }
+                },
+                streams = new MediaStream[] { stream }
+            };
+            var transceiver = peer.AddTransceiver(track, init);
+            Assert.That(transceiver, Is.Not.Null);
+            Assert.That(transceiver.CurrentDirection, Is.Null);
+            Assert.That(transceiver.Direction, Is.EqualTo(RTCRtpTransceiverDirection.SendOnly));
+            Assert.That(transceiver.Sender, Is.Not.Null);
+
+            var parameters = transceiver.Sender.GetParameters();
+            Assert.That(parameters, Is.Not.Null);
+            Assert.That(parameters.codecs, Is.Not.Null.And.Empty);
+            peer.Dispose();
+        }
+
+        [Test]
+        [Category("PeerConnection")]
+        public void AddTransceiverWithKindAndInit()
+        {
+            var peer = new RTCPeerConnection();
+            var stream = new MediaStream();
+            var direction = RTCRtpTransceiverDirection.SendOnly;
             var init = new RTCRtpTransceiverInit()
             {
                 direction = direction,

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -69,7 +69,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var peer = new RTCPeerConnection();
             peer.Dispose();
-            Assert.That(() => {  var state = peer.ConnectionState; }, Throws.TypeOf<ObjectDisposedException>());
+            Assert.That(() => { var state = peer.ConnectionState; }, Throws.TypeOf<ObjectDisposedException>());
         }
 
         [Test]
@@ -235,6 +235,27 @@ namespace Unity.WebRTC.RuntimeTest
 
             peer.Dispose();
         }
+
+        [Test]
+        [Category("PeerConnection")]
+        public void AddTransceiverWithInit()
+        {
+            var peer = new RTCPeerConnection();
+            var stream = new MediaStream();
+            var init = new RTCRtpTransceiverInit()
+            {
+                direction = RTCRtpTransceiverDirection.SendOnly,
+                sendEncodings = new RTCRtpEncodingParameters[] {
+                    new RTCRtpEncodingParameters { maxFramerate = 30 }
+                },
+                streams = new MediaStream[] { stream }
+            };
+            var transceiver = peer.AddTransceiver(TrackKind.Video, init);
+            Assert.That(transceiver, Is.Not.Null);
+            Assert.That(transceiver.CurrentDirection, Is.Null);
+            peer.Dispose();
+        }
+
 
         [Test]
         [Category("PeerConnection")]
@@ -666,7 +687,7 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator AddIceCandidate()
         {
             RTCConfiguration config = default;
-            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
 
@@ -821,9 +842,9 @@ namespace Unity.WebRTC.RuntimeTest
             var op6 = peer1.SetRemoteDescription(ref desc);
             yield return op6;
 
-            var op7 = new WaitUntilWithTimeout( () =>
-                    state1 == RTCPeerConnectionState.Connected &&
-                    state2 == RTCPeerConnectionState.Connected, 5000);
+            var op7 = new WaitUntilWithTimeout(() =>
+                   state1 == RTCPeerConnectionState.Connected &&
+                   state2 == RTCPeerConnectionState.Connected, 5000);
             yield return op7;
             Assert.That(op7.IsCompleted, Is.True);
 
@@ -908,7 +929,7 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator RestartIceInvokeOnNegotiationNeeded()
         {
             RTCConfiguration config = default;
-            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
 
@@ -951,7 +972,7 @@ namespace Unity.WebRTC.RuntimeTest
         public IEnumerator RemoteOnRemoveTrack()
         {
             RTCConfiguration config = default;
-            config.iceServers = new[] {new RTCIceServer {urls = new[] {"stun:stun.l.google.com:19302"}}};
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
             var peer1 = new RTCPeerConnection(ref config);
             var peer2 = new RTCPeerConnection(ref config);
 

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -386,8 +386,16 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.AreEqual(transceiver1.CurrentDirection, RTCRtpTransceiverDirection.RecvOnly);
             Assert.AreEqual(transceiver2.CurrentDirection, RTCRtpTransceiverDirection.SendOnly);
 
-            Assert.That(transceiver2.Stop(), Is.EqualTo(RTCErrorType.None));
-            Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+            //Assert.That(transceiver2.Stop(), Is.EqualTo(RTCErrorType.None));
+            //Assert.That(transceiver2.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+
+            // todo(kazuki):: Transceiver.CurrentDirection of Sender is not changed to "Stopped" even if waiting
+            // yield return new WaitUntil(() => transceiver2.CurrentDirection == RTCRtpTransceiverDirection.Stopped);
+            // Assert.That(transceiver2.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
+
+            // todo(kazuki):: Transceiver.CurrentDirection of Receiver is not changed to "Stopped" even if waiting
+            // yield return new WaitUntil(() => transceiver1.Direction == RTCRtpTransceiverDirection.Stopped);
+            // Assert.That(transceiver1.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
 
             audioTrack.Dispose();
             peer1.Close();


### PR DESCRIPTION
This pull request adds the argument `RTCRtpTransceiverInit` to `RTCPeerConnection.AddTransceiver` method.
Developers can easily set bitrate or framerate for stream senders.
```csharp
RTCPeerConnection.AddTransceiver(MediaStreamTrack track, RTCRtpTransceiverInit init = null)
RTCPeerConnection.AddTransceiver(TrackKind kind, RTCRtpTransceiverInit init = null)
```