### PR TITLE
Use libyuv::ARGBToI420 instead of GraphicsUtility::ConvertRGBToI420Buffer

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 
+#include <third_party/libyuv/include/libyuv/convert.h>
+
 #include "D3D11GraphicsDevice.h"
 #include "D3D11Texture2D.h"
 #include "GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h"
@@ -176,12 +178,21 @@ namespace webrtc
         if (hr != S_OK)
             return nullptr;
 
-        const uint32_t width = tex->GetWidth();
-        const uint32_t height = tex->GetHeight();
+        const int32_t width = static_cast<int32_t>(tex->GetWidth());
+        const int32_t height = static_cast<int32_t>(tex->GetHeight());
 
-        // todo(kazuki) replace to using libyuv function
-        rtc::scoped_refptr<I420Buffer> i420_buffer = GraphicsUtility::ConvertRGBToI420Buffer(
-            width, height, pMappedResource.RowPitch, static_cast<uint8_t*>(pMappedResource.pData));
+        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = webrtc::I420Buffer::Create(width, height);
+        libyuv::ARGBToI420(
+            static_cast<uint8_t*>(pMappedResource.pData),
+            static_cast<int32_t>(pMappedResource.RowPitch),
+            i420_buffer->MutableDataY(),
+            i420_buffer->StrideY(),
+            i420_buffer->MutableDataU(),
+            i420_buffer->StrideU(),
+            i420_buffer->MutableDataV(),
+            i420_buffer->StrideV(),
+            width,
+            height);
 
         context->Unmap(pResource, 0);
         return i420_buffer;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
@@ -13,46 +13,6 @@ namespace webrtc
 
     namespace webrtc = ::webrtc;
 
-    rtc::scoped_refptr<webrtc::I420Buffer> GraphicsUtility::ConvertRGBToI420Buffer(
-        const uint32_t width, const uint32_t height, const uint32_t rowToRowInBytes, const uint8_t* srcData)
-    {
-
-        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer =
-            webrtc::I420Buffer::Create(static_cast<int>(width), static_cast<int>(height));
-
-        int yIndex = 0;
-        int uIndex = 0;
-        int vIndex = 0;
-
-        uint8_t* yuv_y = i420_buffer->MutableDataY();
-        uint8_t* yuv_u = i420_buffer->MutableDataU();
-        uint8_t* yuv_v = i420_buffer->MutableDataV();
-
-        for (uint32_t i = 0; i < height; i++)
-        {
-            for (uint32_t j = 0; j < width; j++)
-            {
-                const uint32_t startIndex = i * rowToRowInBytes + j * 4;
-                const int B = srcData[startIndex + 0];
-                const int G = srcData[startIndex + 1];
-                const int R = srcData[startIndex + 2];
-
-                const int Y = ((66 * R + 129 * G + 25 * B + 128) >> 8) + 16;
-                const int U = ((-38 * R - 74 * G + 112 * B + 128) >> 8) + 128;
-                const int V = ((112 * R - 94 * G - 18 * B + 128) >> 8) + 128;
-
-                yuv_y[yIndex++] = static_cast<uint8_t>((Y < 0) ? 0 : ((Y > 255) ? 255 : Y));
-                if (i % 2 == 0 && j % 2 == 0)
-                {
-                    yuv_u[uIndex++] = static_cast<uint8_t>((U < 0) ? 0 : ((U > 255) ? 255 : U));
-                    yuv_v[vIndex++] = static_cast<uint8_t>((V < 0) ? 0 : ((V > 255) ? 255 : V));
-                }
-            }
-        }
-
-        return i420_buffer;
-    }
-
     void* GraphicsUtility::TextureHandleToNativeGraphicsPtr(
         void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer)
     {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
@@ -10,8 +10,6 @@ namespace webrtc
     class GraphicsUtility
     {
     public:
-        static rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420Buffer(
-            const uint32_t width, const uint32_t height, const uint32_t rowToRowInBytes, const uint8_t* srcData);
         static void*
         TextureHandleToNativeGraphicsPtr(void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer);
     };

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -1,5 +1,7 @@
 #include "pch.h"
 
+#include <third_party/libyuv/include/libyuv/convert.h>
+
 #include "GraphicsDevice/GraphicsUtility.h"
 #include "MetalDevice.h"
 #include "MetalGraphicsDevice.h"
@@ -151,8 +153,19 @@ namespace webrtc
               fromRegion:MTLRegionMake2D(0, 0, width, height)
              mipmapLevel:0];
 
-        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer =
-            GraphicsUtility::ConvertRGBToI420Buffer(width, height, bytesPerRow, buffer.data());
+        rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = webrtc::I420Buffer::Create(
+            static_cast<int32_t>(width), static_cast<int32_t>(height));
+        libyuv::ARGBToI420(
+            buffer.data(),
+            static_cast<int32_t>(bytesPerRow),
+            i420_buffer->MutableDataY(),
+            i420_buffer->StrideY(),
+            i420_buffer->MutableDataU(),
+            i420_buffer->StrideU(),
+            i420_buffer->MutableDataV(),
+            i420_buffer->StrideV(),
+            static_cast<int32_t>(width),
+            static_cast<int32_t>(height));
         return i420_buffer;
     }
 


### PR DESCRIPTION
Hello

In order to increase overall performance, this PR replaces remaining `GraphicsUtility::ConvertRGBToI420Buffer` with `libyuv::ARGBToI420`.

Thank you in advance for your review.