### PR TITLE
fix: Fix display probmen on CPU profiler for macOS/iOS platform

### DIFF
--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -27,6 +27,14 @@ target_sources(WebRTCLib
     ScopedProfiler.h
     ScopedProfiler.cpp
     targetver.h
+    UnityAudioDecoderFactory.cpp
+    UnityAudioDecoderFactory.h
+    UnityAudioEncoderFactory.cpp
+    UnityAudioEncoderFactory.h
+    UnityAudioTrackSource.cpp
+    UnityAudioTrackSource.h
+    UnityProfilerInterfaceFunctions.cpp
+    UnityProfilerInterfaceFunctions.h
     UnityVideoDecoderFactory.cpp
     UnityVideoDecoderFactory.h
     UnityVideoEncoderFactory.cpp
@@ -35,12 +43,8 @@ target_sources(WebRTCLib
     UnityVideoRenderer.h
     UnityVideoTrackSource.cpp
     UnityVideoTrackSource.h
-    UnityAudioDecoderFactory.cpp
-    UnityAudioDecoderFactory.h
-    UnityAudioEncoderFactory.cpp
-    UnityAudioEncoderFactory.h
-    UnityAudioTrackSource.cpp
-    UnityAudioTrackSource.h
+    UnityVulkanInterfaceFunctions.cpp
+    UnityVulkanInterfaceFunctions.h
     WebRTCMacros.h
     WebRTCPlugin.h
     UnityLogStream.h
@@ -356,8 +360,6 @@ target_sources(WebRTCPlugin
     WebRTCPlugin.cpp
     WebRTCPlugin.h
     UnityRenderEvent.cpp
-    UnityVulkanInterfaceFunctions.h
-    UnityProfilerInterfaceFunctions.h
 )
 
 # rename dll/framework filename

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -43,8 +43,6 @@ target_sources(WebRTCLib
     UnityVideoRenderer.h
     UnityVideoTrackSource.cpp
     UnityVideoTrackSource.h
-    UnityVulkanInterfaceFunctions.cpp
-    UnityVulkanInterfaceFunctions.h
     WebRTCMacros.h
     WebRTCPlugin.h
     UnityLogStream.h
@@ -93,6 +91,12 @@ if(iOS OR macOS)
   target_sources(WebRTCLib
     PRIVATE
       ../libcxx/debug.cpp
+  )
+else()
+  target_sources(WebRTCLib
+    PRIVATE
+    UnityVulkanInterfaceFunctions.cpp
+    UnityVulkanInterfaceFunctions.h
   )
 endif()
 

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -357,6 +357,7 @@ target_sources(WebRTCPlugin
     WebRTCPlugin.h
     UnityRenderEvent.cpp
     UnityVulkanInterfaceFunctions.h
+    UnityProfilerInterfaceFunctions.h
 )
 
 # rename dll/framework filename

--- a/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.cpp
+++ b/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.cpp
@@ -3,23 +3,22 @@
 #include "IUnityInterface.h"
 #include "ProfilerMarkerFactory.h"
 #include "ScopedProfiler.h"
+#include "UnityProfilerInterfaceFunctions.h"
 
 namespace unity
 {
 namespace webrtc
 {
-    std::unique_ptr<ProfilerMarkerFactory> ProfilerMarkerFactory::Create(IUnityInterfaces* unityInterfaces)
+    std::unique_ptr<ProfilerMarkerFactory> ProfilerMarkerFactory::Create(UnityProfiler* profiler)
     {
-        IUnityProfiler* profiler = unityInterfaces->Get<IUnityProfiler>();
-        if (!profiler)
-            return nullptr;
         return std::unique_ptr<ProfilerMarkerFactory>(new ProfilerMarkerFactory(profiler));
     }
 
-    ProfilerMarkerFactory::ProfilerMarkerFactory(IUnityProfiler* profiler)
+    ProfilerMarkerFactory::ProfilerMarkerFactory(UnityProfiler* profiler)
         : profiler_(profiler)
     {
     }
+
     ProfilerMarkerFactory::~ProfilerMarkerFactory() { }
 
     const UnityProfilerMarkerDesc* ProfilerMarkerFactory::CreateMarker(

--- a/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.h
+++ b/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.h
@@ -8,10 +8,11 @@ namespace webrtc
 {
     class ScopedProfiler;
     class ScopedProfilerThread;
+    class UnityProfiler;
     class ProfilerMarkerFactory
     {
     public:
-        static std::unique_ptr<ProfilerMarkerFactory> Create(IUnityInterfaces* unityInterfaces);
+        static std::unique_ptr<ProfilerMarkerFactory> Create(UnityProfiler* profiler);
 
         const UnityProfilerMarkerDesc* CreateMarker(
             const char* name, UnityProfilerCategoryId category, UnityProfilerMarkerFlags flags, int eventDataCount);
@@ -25,10 +26,10 @@ namespace webrtc
         virtual ~ProfilerMarkerFactory();
 
     protected:
-        ProfilerMarkerFactory(IUnityProfiler* profiler_);
+        ProfilerMarkerFactory(UnityProfiler* profiler);
 
     private:
-        IUnityProfiler* profiler_;
+        UnityProfiler* profiler_;
     };
 }
 }

--- a/Plugin~/WebRTCPlugin/ScopedProfiler.cpp
+++ b/Plugin~/WebRTCPlugin/ScopedProfiler.cpp
@@ -1,12 +1,13 @@
 #include "pch.h"
 
 #include "ScopedProfiler.h"
+#include "UnityProfilerInterfaceFunctions.h"
 
 namespace unity
 {
 namespace webrtc
 {
-    ScopedProfiler::ScopedProfiler(IUnityProfiler* profiler, const UnityProfilerMarkerDesc& desc)
+    ScopedProfiler::ScopedProfiler(UnityProfiler* profiler, const UnityProfilerMarkerDesc& desc)
         : profiler_(profiler)
         , m_desc(&desc)
     {
@@ -22,7 +23,7 @@ namespace webrtc
             profiler_->EndSample(m_desc);
     }
 
-    ScopedProfilerThread::ScopedProfilerThread(IUnityProfiler* profiler, const char* groupName, const char* name)
+    ScopedProfilerThread::ScopedProfilerThread(UnityProfiler* profiler, const char* groupName, const char* name)
         : profiler_(profiler)
     {
         RTC_DCHECK(profiler);
@@ -37,7 +38,6 @@ namespace webrtc
                 RTC_LOG(LS_INFO) << "IUnityProfiler::RegisterThread error:" << result;
                 throw;
             }
-            RTC_LOG(LS_INFO) << "IUnityProfiler::RegisterThread id:" << threadId_ << " thread groupe name:" << groupName << " name:" << name;
         }
     }
     ScopedProfilerThread ::~ScopedProfilerThread()

--- a/Plugin~/WebRTCPlugin/ScopedProfiler.cpp
+++ b/Plugin~/WebRTCPlugin/ScopedProfiler.cpp
@@ -37,6 +37,7 @@ namespace webrtc
                 RTC_LOG(LS_INFO) << "IUnityProfiler::RegisterThread error:" << result;
                 throw;
             }
+            RTC_LOG(LS_INFO) << "IUnityProfiler::RegisterThread id:" << threadId_ << " thread groupe name:" << groupName << " name:" << name;
         }
     }
     ScopedProfilerThread ::~ScopedProfilerThread()

--- a/Plugin~/WebRTCPlugin/ScopedProfiler.h
+++ b/Plugin~/WebRTCPlugin/ScopedProfiler.h
@@ -6,32 +6,33 @@ namespace unity
 {
 namespace webrtc
 {
+    class UnityProfiler;
 
     class ScopedProfiler
     {
     public:
-        ScopedProfiler(IUnityProfiler* profiler, const UnityProfilerMarkerDesc& desc);
+        ScopedProfiler(UnityProfiler* profiler, const UnityProfilerMarkerDesc& desc);
         ~ScopedProfiler();
 
     private:
         void operator=(const ScopedProfiler& src) const { }
         ScopedProfiler(const ScopedProfiler& src) { }
 
-        IUnityProfiler* profiler_;
+        UnityProfiler* profiler_;
         const UnityProfilerMarkerDesc* m_desc;
     };
 
     class ScopedProfilerThread
     {
     public:
-        ScopedProfilerThread(IUnityProfiler* profiler, const char* groupName, const char* name);
+        ScopedProfilerThread(UnityProfiler* profiler, const char* groupName, const char* name);
         ~ScopedProfilerThread();
 
     private:
         void operator=(const ScopedProfilerThread& src) const { }
         ScopedProfilerThread(const ScopedProfilerThread& src) { }
 
-        IUnityProfiler* profiler_;
+        UnityProfiler* profiler_;
         UnityProfilerThreadId threadId_;
     };
 

--- a/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.cpp
+++ b/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+
+#include "UnityProfilerInterfaceFunctions.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    std::unique_ptr<UnityProfiler> UnityProfiler::Get(IUnityInterfaces* unityInterfaces)
+    {
+        IUnityProfilerV2* profilerV2 = unityInterfaces->Get<IUnityProfilerV2>();
+        if (profilerV2)
+            return std::make_unique<UnityProfilerImpl<IUnityProfilerV2>>(profilerV2);
+        IUnityProfiler* profiler = unityInterfaces->Get<IUnityProfiler>();
+        if (profiler)
+            return std::make_unique<UnityProfilerImpl<IUnityProfiler>>(profiler);
+        return nullptr;
+    }
+}
+}

--- a/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.h
@@ -1,9 +1,25 @@
 #include <IUnityProfiler.h>
+#include <memory>
 
 namespace unity
 {
 namespace webrtc
 {
+    template<typename T>
+    inline int CreateCategory(T* instance, UnityProfilerCategoryId* category, const char* name, uint32_t unused)
+    {
+        return instance->CreateCategory(category, name, unused);
+    }
+
+    template<>
+    inline int
+    CreateCategory(IUnityProfiler* instance, UnityProfilerCategoryId* category, const char* name, uint32_t unused)
+    {
+        // IUnityProfiler(V1) is not supported CreateCategory.
+        *category = kUnityProfilerCategoryRender;
+        return 0;
+    }
+
     class UnityProfiler
     {
     public:
@@ -26,6 +42,7 @@ namespace webrtc
             const char* metadataName,
             UnityProfilerMarkerDataType metadataType,
             UnityProfilerMarkerDataUnit metadataUnit) = 0;
+        virtual int CreateCategory(UnityProfilerCategoryId* category, const char* name, uint32_t unused) = 0;
         virtual int RegisterThread(UnityProfilerThreadId* threadId, const char* groupName, const char* name) = 0;
         virtual int UnregisterThread(UnityProfilerThreadId threadId) = 0;
         virtual ~UnityProfiler() = default;
@@ -43,36 +60,57 @@ namespace webrtc
         }
         ~UnityProfilerImpl() = default;
 
-        void BeginSample(const UnityProfilerMarkerDesc* markerDesc)
-        {
-            profiler_->BeginSample(markerDesc);
-        }
-        virtual void BeginSample(
+        void BeginSample(const UnityProfilerMarkerDesc* markerDesc) override { profiler_->BeginSample(markerDesc); }
+
+        void BeginSample(
             const UnityProfilerMarkerDesc* markerDesc,
             uint16_t eventDataCount,
-            const UnityProfilerMarkerData* eventData) = 0;
-        virtual void EndSample(const UnityProfilerMarkerDesc* markerDesc) = 0;
-        virtual int IsAvailable() = 0;
-        virtual int CreateMarker(
+            const UnityProfilerMarkerData* eventData) override
+        {
+            profiler_->BeginSample(markerDesc, eventDataCount, eventData);
+        }
+
+        void EndSample(const UnityProfilerMarkerDesc* markerDesc) override { profiler_->EndSample(markerDesc); }
+
+        int IsAvailable() override { return profiler_->IsAvailable(); }
+
+        int CreateMarker(
             const UnityProfilerMarkerDesc** desc,
             const char* name,
             UnityProfilerCategoryId category,
             UnityProfilerMarkerFlags flags,
-            int eventDataCount) = 0;
-        virtual int SetMarkerMetadataName(
+            int eventDataCount) override
+        {
+            return profiler_->CreateMarker(desc, name, category, flags, eventDataCount);
+        }
+
+        int SetMarkerMetadataName(
             const UnityProfilerMarkerDesc* desc,
             int index,
             const char* metadataName,
             UnityProfilerMarkerDataType metadataType,
-            UnityProfilerMarkerDataUnit metadataUnit) = 0;
-        virtual int RegisterThread(UnityProfilerThreadId* threadId, const char* groupName, const char* name) = 0;
-        virtual int UnregisterThread(UnityProfilerThreadId threadId) = 0;
+            UnityProfilerMarkerDataUnit metadataUnit) override
+        {
+            return profiler_->SetMarkerMetadataName(desc, index, metadataName, metadataType, metadataUnit);
+        }
+
+        int CreateCategory(UnityProfilerCategoryId* category, const char* name, uint32_t unused) override
+        {
+            return unity::webrtc::CreateCategory(profiler_, category, name, unused);
+        }
+
+        int RegisterThread(UnityProfilerThreadId* threadId, const char* groupName, const char* name) override
+        {
+            return profiler_->RegisterThread(threadId, groupName, name);
+        }
+
+        int UnregisterThread(UnityProfilerThreadId threadId) override { return profiler_->UnregisterThread(threadId); }
 
     private:
         T* profiler_;
     };
 
-    std::unique_ptr<UnityProfiler> UnityProfiler::Get(IUnityInterfaces* unityInterfaces)
+    inline std::unique_ptr<UnityProfiler> UnityProfiler::Get(IUnityInterfaces* unityInterfaces)
     {
         IUnityProfilerV2* profilerV2 = unityInterfaces->Get<IUnityProfilerV2>();
         if (profilerV2)

--- a/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.h
@@ -1,0 +1,86 @@
+#include <IUnityProfiler.h>
+
+namespace unity
+{
+namespace webrtc
+{
+    class UnityProfiler
+    {
+    public:
+        virtual void BeginSample(const UnityProfilerMarkerDesc* markerDesc) = 0;
+        virtual void BeginSample(
+            const UnityProfilerMarkerDesc* markerDesc,
+            uint16_t eventDataCount,
+            const UnityProfilerMarkerData* eventData) = 0;
+        virtual void EndSample(const UnityProfilerMarkerDesc* markerDesc) = 0;
+        virtual int IsAvailable() = 0;
+        virtual int CreateMarker(
+            const UnityProfilerMarkerDesc** desc,
+            const char* name,
+            UnityProfilerCategoryId category,
+            UnityProfilerMarkerFlags flags,
+            int eventDataCount) = 0;
+        virtual int SetMarkerMetadataName(
+            const UnityProfilerMarkerDesc* desc,
+            int index,
+            const char* metadataName,
+            UnityProfilerMarkerDataType metadataType,
+            UnityProfilerMarkerDataUnit metadataUnit) = 0;
+        virtual int RegisterThread(UnityProfilerThreadId* threadId, const char* groupName, const char* name) = 0;
+        virtual int UnregisterThread(UnityProfilerThreadId threadId) = 0;
+        virtual ~UnityProfiler() = default;
+
+        static std::unique_ptr<UnityProfiler> Get(IUnityInterfaces* unityInterfaces);
+    };
+
+    template<typename T>
+    class UnityProfilerImpl : public UnityProfiler
+    {
+    public:
+        UnityProfilerImpl(T* profiler)
+            : profiler_(profiler)
+        {
+        }
+        ~UnityProfilerImpl() = default;
+
+        void BeginSample(const UnityProfilerMarkerDesc* markerDesc)
+        {
+            profiler_->BeginSample(markerDesc);
+        }
+        virtual void BeginSample(
+            const UnityProfilerMarkerDesc* markerDesc,
+            uint16_t eventDataCount,
+            const UnityProfilerMarkerData* eventData) = 0;
+        virtual void EndSample(const UnityProfilerMarkerDesc* markerDesc) = 0;
+        virtual int IsAvailable() = 0;
+        virtual int CreateMarker(
+            const UnityProfilerMarkerDesc** desc,
+            const char* name,
+            UnityProfilerCategoryId category,
+            UnityProfilerMarkerFlags flags,
+            int eventDataCount) = 0;
+        virtual int SetMarkerMetadataName(
+            const UnityProfilerMarkerDesc* desc,
+            int index,
+            const char* metadataName,
+            UnityProfilerMarkerDataType metadataType,
+            UnityProfilerMarkerDataUnit metadataUnit) = 0;
+        virtual int RegisterThread(UnityProfilerThreadId* threadId, const char* groupName, const char* name) = 0;
+        virtual int UnregisterThread(UnityProfilerThreadId threadId) = 0;
+
+    private:
+        T* profiler_;
+    };
+
+    std::unique_ptr<UnityProfiler> UnityProfiler::Get(IUnityInterfaces* unityInterfaces)
+    {
+        IUnityProfilerV2* profilerV2 = unityInterfaces->Get<IUnityProfilerV2>();
+        if (profilerV2)
+            return std::make_unique<UnityProfilerImpl<IUnityProfilerV2>>(profilerV2);
+        IUnityProfiler* profiler = unityInterfaces->Get<IUnityProfiler>();
+        if (profiler)
+            return std::make_unique<UnityProfilerImpl<IUnityProfiler>>(profiler);
+        return nullptr;
+    }
+}
+}

--- a/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityProfilerInterfaceFunctions.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <IUnityProfiler.h>
 #include <memory>
 
@@ -58,7 +60,7 @@ namespace webrtc
             : profiler_(profiler)
         {
         }
-        ~UnityProfilerImpl() = default;
+        ~UnityProfilerImpl() override = default;
 
         void BeginSample(const UnityProfilerMarkerDesc* markerDesc) override { profiler_->BeginSample(markerDesc); }
 
@@ -109,16 +111,5 @@ namespace webrtc
     private:
         T* profiler_;
     };
-
-    inline std::unique_ptr<UnityProfiler> UnityProfiler::Get(IUnityInterfaces* unityInterfaces)
-    {
-        IUnityProfilerV2* profilerV2 = unityInterfaces->Get<IUnityProfilerV2>();
-        if (profilerV2)
-            return std::make_unique<UnityProfilerImpl<IUnityProfilerV2>>(profilerV2);
-        IUnityProfiler* profiler = unityInterfaces->Get<IUnityProfiler>();
-        if (profiler)
-            return std::make_unique<UnityProfilerImpl<IUnityProfiler>>(profiler);
-        return nullptr;
-    }
 }
 }

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -6,6 +6,7 @@
 #include "GraphicsDevice/GraphicsUtility.h"
 #include "ProfilerMarkerFactory.h"
 #include "ScopedProfiler.h"
+#include "UnityProfilerInterfaceFunctions.h"
 #include "UnityVideoTrackSource.h"
 #include "VideoFrame.h"
 
@@ -31,6 +32,7 @@ namespace webrtc
     static IUnityInterfaces* s_UnityInterfaces = nullptr;
     static IUnityGraphics* s_Graphics = nullptr;
     static Context* s_context = nullptr;
+    static std::unique_ptr<UnityProfiler> s_UnityProfiler = nullptr;
     static std::unique_ptr<ProfilerMarkerFactory> s_ProfilerMarkerFactory = nullptr;
     static std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> s_mapVideoRenderer;
     static std::unique_ptr<Clock> s_clock;
@@ -214,7 +216,8 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
         RTC_LOG(LS_INFO) << "AddInterceptInitialization failed.";
     }
 #endif
-    s_ProfilerMarkerFactory = ProfilerMarkerFactory::Create(unityInterfaces);
+    s_UnityProfiler = UnityProfiler::Get(unityInterfaces);
+    s_ProfilerMarkerFactory = ProfilerMarkerFactory::Create(s_UnityProfiler.get());
 
     if (s_ProfilerMarkerFactory)
     {

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+
+#include "UnityVulkanInterfaceFunctions.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    std::unique_ptr<UnityGraphicsVulkan> UnityGraphicsVulkan::Get(IUnityInterfaces* unityInterfaces)
+    {
+        IUnityGraphicsVulkanV2* vulkanV2 = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
+        if (vulkanV2)
+            return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkanV2>>(vulkanV2);
+        IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
+        if (vulkan)
+            return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkan>>(vulkan);
+        return nullptr;
+    }
+}
+}

--- a/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
+++ b/Plugin~/WebRTCPlugin/UnityVulkanInterfaceFunctions.h
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <IUnityGraphicsVulkan.h>
+#include <memory>
 
 namespace unity
 {
@@ -60,17 +63,5 @@ namespace webrtc
     private:
         T* vulkanInterface_;
     };
-
-    std::unique_ptr<UnityGraphicsVulkan> UnityGraphicsVulkan::Get(IUnityInterfaces* unityInterfaces)
-    {
-        IUnityGraphicsVulkanV2* vulkanV2 = unityInterfaces->Get<IUnityGraphicsVulkanV2>();
-        if (vulkanV2)
-            return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkanV2>>(vulkanV2);
-        IUnityGraphicsVulkan* vulkan = unityInterfaces->Get<IUnityGraphicsVulkan>();
-        if (vulkan)
-            return std::make_unique<UnityGraphicsVulkanImpl<IUnityGraphicsVulkan>>(vulkan);
-        return nullptr;
-    }
-
 }
 }


### PR DESCRIPTION
The native profiler registration thread is the same on macOS / iOS.
By using UnityProfilerV2, it will be registered as a different thread.