### PR TITLE
fix: Fix crash bug when using unity2019

### DIFF
--- a/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.cpp
+++ b/Plugin~/WebRTCPlugin/ProfilerMarkerFactory.cpp
@@ -11,6 +11,7 @@ namespace webrtc
 {
     std::unique_ptr<ProfilerMarkerFactory> ProfilerMarkerFactory::Create(UnityProfiler* profiler)
     {
+        RTC_DCHECK(profiler);
         return std::unique_ptr<ProfilerMarkerFactory>(new ProfilerMarkerFactory(profiler));
     }
 

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -196,10 +196,9 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
     }
 #endif
     s_UnityProfiler = UnityProfiler::Get(unityInterfaces);
-    s_ProfilerMarkerFactory = ProfilerMarkerFactory::Create(s_UnityProfiler.get());
-
-    if (s_ProfilerMarkerFactory)
+    if (s_UnityProfiler)
     {
+        s_ProfilerMarkerFactory = ProfilerMarkerFactory::Create(s_UnityProfiler.get());
         s_MarkerEncode = s_ProfilerMarkerFactory->CreateMarker(
             "UnityVideoTrackSource.OnFrameCaptured", kUnityProfilerCategoryRender, kUnityProfilerMarkerFlagDefault, 0);
         s_MarkerDecode = s_ProfilerMarkerFactory->CreateMarker(


### PR DESCRIPTION
`UnityProfiler::Get` function returns `nullptr` when using Unity2019.4.