### PR TITLE
fix: Release video frame buffers when destroying context instance

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -229,7 +229,6 @@ struct EncodeData
 // Notice: When DebugLog is used in a method called from RenderingThread,
 // it hangs when attempting to leave PlayMode and re-enter PlayMode.
 // So, we comment out `DebugLog`.
-
 static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
 {
     if (!s_context)
@@ -269,9 +268,7 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
             auto frame = s_bufferPool->CreateFrame(ptr, size, encodeData->format, timestamp);
             source->OnFrameCaptured(std::move(frame));
         }
-
         s_bufferPool->ReleaseStaleBuffers(timestamp);
-
         return;
     }
     default:
@@ -281,10 +278,21 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
     }
 }
 
+static void UNITY_INTERFACE_API OnReleaseBuffers(int eventID, void* data)
+{
+    // Release all buffers.
+    s_bufferPool->ReleaseStaleBuffers(Timestamp::PlusInfinity());
+}
+
 extern "C" UnityRenderingEventAndData UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetRenderEventFunc(Context* context)
 {
     s_context = context;
     return OnRenderEvent;
+}
+
+extern "C" UnityRenderingEventAndData UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetReleaseBuffersFunc(Context* context)
+{
+    return OnReleaseBuffers;
 }
 
 static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -246,36 +246,23 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
     RTC_DCHECK_GT(encodeData->width, 0);
     RTC_DCHECK_GT(encodeData->height, 0);
 
-    const VideoStreamRenderEventID event = static_cast<VideoStreamRenderEventID>(eventID);
-
-    switch (event)
-    {
-    case VideoStreamRenderEventID::Encode:
-    {
-        UnityVideoTrackSource* source = encodeData->source;
-        if (!s_context->ExistsRefPtr(source))
-            return;
-        Timestamp timestamp = s_clock->CurrentTime();
-        IGraphicsDevice* device = Plugin::GraphicsDevice();
-        UnityGfxRenderer gfxRenderer = device->GetGfxRenderer();
-        void* ptr = GraphicsUtility::TextureHandleToNativeGraphicsPtr(encodeData->texture, device, gfxRenderer);
-        unity::webrtc::Size size(encodeData->width, encodeData->height);
-        {
-            std::unique_ptr<const ScopedProfiler> profiler;
-            if (s_ProfilerMarkerFactory)
-                profiler = s_ProfilerMarkerFactory->CreateScopedProfiler(*s_MarkerEncode);
-
-            auto frame = s_bufferPool->CreateFrame(ptr, size, encodeData->format, timestamp);
-            source->OnFrameCaptured(std::move(frame));
-        }
-        s_bufferPool->ReleaseStaleBuffers(timestamp);
+    UnityVideoTrackSource* source = encodeData->source;
+    if (!s_context->ExistsRefPtr(source))
         return;
-    }
-    default:
+    Timestamp timestamp = s_clock->CurrentTime();
+    IGraphicsDevice* device = Plugin::GraphicsDevice();
+    UnityGfxRenderer gfxRenderer = device->GetGfxRenderer();
+    void* ptr = GraphicsUtility::TextureHandleToNativeGraphicsPtr(encodeData->texture, device, gfxRenderer);
+    unity::webrtc::Size size(encodeData->width, encodeData->height);
     {
-        RTC_DCHECK(0);
+        std::unique_ptr<const ScopedProfiler> profiler;
+        if (s_ProfilerMarkerFactory)
+            profiler = s_ProfilerMarkerFactory->CreateScopedProfiler(*s_MarkerEncode);
+
+        auto frame = s_bufferPool->CreateFrame(ptr, size, encodeData->format, timestamp);
+        source->OnFrameCaptured(std::move(frame));
     }
-    }
+    s_bufferPool->ReleaseStaleBuffers(timestamp);
 }
 
 static void UNITY_INTERFACE_API OnReleaseBuffers(int eventID, void* data)

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -398,10 +398,12 @@ namespace Unity.WebRTC
         /// <returns></returns>
         public static IEnumerator Update()
         {
+            var instruction = new WaitForEndOfFrame();
+
             while (true)
             {
                 // Wait until all frame rendering is done
-                yield return new WaitForEndOfFrame();
+                yield return instruction;
                 {
                     var tempTextureActive = RenderTexture.active;
                     RenderTexture.active = null;
@@ -1115,6 +1117,8 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetRenderEventFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
+        public static extern IntPtr GetReleaseBuffersFunc(IntPtr context);
+        [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
         public static extern void AudioSourceProcessLocalAudio(IntPtr source, IntPtr array, int sampleRate, int channels, int frames);
@@ -1179,6 +1183,13 @@ namespace Unity.WebRTC
         public static void Encode(IntPtr callback, IntPtr data)
         {
             _command.IssuePluginEventAndData(callback, (int)VideoStreamRenderEventId.Encode, data);
+            Graphics.ExecuteCommandBuffer(_command);
+            _command.Clear();
+        }
+
+        public static void ReleaseBuffers(IntPtr callback)
+        {
+            _command.IssuePluginEventAndData(callback, 0, IntPtr.Zero);
             Graphics.ExecuteCommandBuffer(_command);
             _command.Clear();
         }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1175,14 +1175,10 @@ namespace Unity.WebRTC
     internal static class VideoEncoderMethods
     {
         static CommandBuffer _command = new CommandBuffer();
-        enum VideoStreamRenderEventId
-        {
-            Encode = 1,
-        }
 
         public static void Encode(IntPtr callback, IntPtr data)
         {
-            _command.IssuePluginEventAndData(callback, (int)VideoStreamRenderEventId.Encode, data);
+            _command.IssuePluginEventAndData(callback, 0, data);
             Graphics.ExecuteCommandBuffer(_command);
             _command.Clear();
         }


### PR DESCRIPTION
This fix releases video frame buffers on the rendering thread in destructor of `Context` class.