### PR TITLE
fix: Drop frame when the video broadcaster don't need the new frame

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.cpp
@@ -15,13 +15,6 @@ namespace webrtc
         return new rtc::RefCountedObject<UnityVideoTrackSource>(is_screencast, needs_denoising, taskQueueFactory);
     }
 
-    ::webrtc::VideoFrame BlackFrame(int width, int height)
-    {
-        rtc::scoped_refptr<webrtc::I420Buffer> buffer = webrtc::I420Buffer::Create(width, height);
-        webrtc::I420Buffer::SetBlack(buffer.get());
-        return ::webrtc::VideoFrame::Builder().set_video_frame_buffer(buffer).build();
-    }
-
     UnityVideoTrackSource::UnityVideoTrackSource(
         bool is_screencast, absl::optional<bool> needs_denoising, TaskQueueFactory* taskQueueFactory)
         : AdaptedVideoTrackSource(/*required_alignment=*/1)

--- a/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityVideoTrackSource.h
@@ -25,21 +25,21 @@ namespace webrtc
     class UnityVideoTrackSource : public rtc::AdaptedVideoTrackSource
     {
     public:
-        // struct FrameAdaptationParams
-        //{
-        //    bool should_drop_frame;
-        //    int crop_x;
-        //    int crop_y;
-        //    int crop_width;
-        //    int crop_height;
-        //    int scale_to_width;
-        //    int scale_to_height;
-        //};
+        struct FrameAdaptationParams
+        {
+            bool should_drop_frame;
+            int crop_x;
+            int crop_y;
+            int crop_width;
+            int crop_height;
+            int scale_to_width;
+            int scale_to_height;
+        };
 
         UnityVideoTrackSource(
             bool is_screencast, absl::optional<bool> needs_denoising, TaskQueueFactory* taskQueueFactory);
         ~UnityVideoTrackSource() override;
-
+        // void SetState(SourceState state);
         SourceState state() const override;
 
         bool remote() const override;
@@ -56,9 +56,9 @@ namespace webrtc
     private:
         void CaptureNextFrame();
         void SendFeedback();
-        // FrameAdaptationParams ComputeAdaptationParams(int width,
-        //                                            int height,
-        //                                            int64_t time_us);
+         FrameAdaptationParams ComputeAdaptationParams(int width,
+                                                    int height,
+                                                    int64_t time_us);
 
         // Delivers |frame| to base class method
         // rtc::AdaptedVideoTrackSource::OnFrame(). If the cropping (given via
@@ -81,7 +81,7 @@ namespace webrtc
 
         std::unique_ptr<rtc::TaskQueue> taskQueue_;
         std::unique_ptr<VideoFrameScheduler> scheduler_;
-        ::webrtc::VideoFrame videoFrame_;
+        rtc::scoped_refptr<unity::webrtc::VideoFrame> frame_;
     };
 
 } // end namespace webrtc


### PR DESCRIPTION
`AdaptedVideoTrackSource::AdaptFrame` method skips encoding video frame when the video broadcaster not needed. 
