### PR TITLE
fix: Fix MediaStream sample and add managed test

### DIFF
--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -130,7 +130,7 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.False(track.Enabled);
 
             // ReadyState property
-            Assert.AreEqual(track.ReadyState, TrackState.Live);
+            Assert.That(track.ReadyState, Is.EqualTo(TrackState.Live));
 
             track.Dispose();
 


### PR DESCRIPTION
This pull request contains two fixes.

- Small fix MediaStream sample
- Add testcase for `RTCPeerConnection.AddTransceiver`