### PR TITLE
fix: Fix RTCPeerConnection.AddTrack API

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -231,7 +231,7 @@ rtc::scoped_refptr<webrtc::I420Buffer> OpenGLGraphicsDevice::ConvertRGBToI420(IT
     // Send PBO to main memory
     GLubyte* pboPtr = static_cast<GLubyte*>(glMapBufferRange(
         GL_PIXEL_PACK_BUFFER, 0, bufferSize, GL_MAP_READ_BIT));
-    if (pboPtr != nullptr)
+    if (pboPtr)
     {
         std::memcpy(data, pboPtr, bufferSize);
         glUnmapBuffer(GL_PIXEL_PACK_BUFFER);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.h
@@ -21,7 +21,7 @@ struct OpenGLTexture2D : ITexture2D {
 public:
     using ReleaseOpenGLTextureCallback = std::function<void(OpenGLTexture2D*)>;
     OpenGLTexture2D(uint32_t w, uint32_t h, GLuint tex, ReleaseOpenGLTextureCallback callback);
-    virtual ~OpenGLTexture2D();
+    virtual ~OpenGLTexture2D() override;
 
     inline void* GetNativeTexturePtrV() override;
     inline const void* GetNativeTexturePtrV() const override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
@@ -2,7 +2,6 @@
 
 #include "GraphicsDevice/Vulkan/VulkanUtility.h"
 #include "VulkanTexture2D.h"
-#include "WebRTCMacros.h"
 
 namespace unity
 {
@@ -27,12 +26,17 @@ namespace webrtc
 
     void VulkanTexture2D::Shutdown()
     {
-        //[TODO-sin: 2019-11-20] Create an explicit Shutdown(device) function
-        VULKAN_SAFE_DESTROY_IMAGE(m_device, m_textureImage, m_allocator)
-        VULKAN_SAFE_FREE_MEMORY(m_device, m_textureImageMemory, m_allocator)
+        if(m_textureImage)
+            vkDestroyImage(m_device, m_textureImage, m_allocator);
+        if(m_textureImageMemory)
+            vkFreeMemory(m_device, m_textureImageMemory, m_allocator);
+        if(m_commandBuffer)
+            vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffer);
+        if(m_fence)
+            vkDestroyFence(m_device, m_fence, nullptr);
 
-        vkFreeCommandBuffers(m_device, m_commandPool, 1, &m_commandBuffer);
-        vkDestroyFence(m_device, m_fence, nullptr);
+        m_textureImage = nullptr;
+        m_textureImageMemory = nullptr;
         m_textureImageMemorySize = 0;
         m_device = nullptr;
         m_commandPool = nullptr;

--- a/Plugin~/WebRTCPlugin/WebRTCMacros.h
+++ b/Plugin~/WebRTCPlugin/WebRTCMacros.h
@@ -10,20 +10,6 @@
     } \
 }
 
-#define VULKAN_SAFE_DESTROY_IMAGE(device, obj, allocator) { \
-    if (VK_NULL_HANDLE!=obj) { \
-        vkDestroyImage(device, obj, allocator); \
-        obj = VK_NULL_HANDLE; \
-    } \
-}
-
-#define VULKAN_SAFE_FREE_MEMORY(device, obj, allocator) { \
-    if (VK_NULL_HANDLE!=obj) { \
-        vkFreeMemory(device, obj, allocator); \
-        obj = VK_NULL_HANDLE; \
-    } \
-}
-
 #define VULKAN_SAFE_DESTROY_COMMAND_POOL(device, obj, allocator) { \
     if (VK_NULL_HANDLE != obj) { \
         vkDestroyCommandPool(device, obj, allocator); \

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -465,7 +465,11 @@ extern "C"
     UNITY_INTERFACE_EXPORT RTCErrorType PeerConnectionAddTrack(
         PeerConnectionObject* obj, MediaStreamTrackInterface* track, const char* streamId, RtpSenderInterface** sender)
     {
-        auto result = obj->connection->AddTrack(rtc::scoped_refptr<MediaStreamTrackInterface>(track), { streamId });
+        std::vector<std::string> streams;
+        if (streamId)
+            streams.push_back(streamId);
+
+        auto result = obj->connection->AddTrack(rtc::scoped_refptr<MediaStreamTrackInterface>(track), streams);
         if (result.ok())
         {
             *sender = result.value();

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -535,7 +535,7 @@ namespace Unity.WebRTC
             if (track == null)
                 throw new ArgumentNullException("track is null.");
 
-            var streamId = stream == null ? Guid.NewGuid().ToString() : stream.Id;
+            var streamId = stream?.Id;
             RTCErrorType error = NativeMethods.PeerConnectionAddTrack(
                 GetSelfOrThrow(), track.GetSelfOrThrow(), streamId, out var ptr);
             if (error != RTCErrorType.None)


### PR DESCRIPTION
Fixed `RTCPeerConnection.AddTrack` method that stop to use generate GUID as a mediastream id when the argument of AddTrack is `null`.