### PR TITLE
chore: Fix issue caused by updating upm-ci-utils command

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -458,6 +458,8 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
     model: {{ target.model }}
 {% endif %}    
   commands:
+    - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
+    - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
     - upm-ci package test -u {{ editor.version }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-editor-arg {{ gfx_type.extra-editor-arg }}
   artifacts:


### PR DESCRIPTION
The stable version of upm-ci command is updated `1.28.0` with the changes that deprecated downloading unity-downloader-cli on the fly.

This fix adds the command line in the CI process that install unity-downloader-cli with pip.