### PR TITLE
fix: Fix crash when streaming video between different platforms

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.h
+++ b/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.h
@@ -28,10 +28,15 @@ namespace webrtc
     Factory* FindCodecFactory(
         const std::map<std::string, std::unique_ptr<Factory>>& factories, const webrtc::SdpVideoFormat& format)
     {
-        auto it = format.parameters.find(kSdpKeyNameCodecImpl);
-        std::string impl = it == format.parameters.end() ? nullptr : it->second;
-        auto it2 = factories.find(impl);
-        return it2->second.get();
+        for (const auto& pair : factories)
+        {
+            for (const webrtc::SdpVideoFormat& other : pair.second->GetSupportedFormats())
+            {
+                if (format.IsSameCodec(other))
+                    return pair.second.get();
+            }
+        }
+        return nullptr;
     }
 
     template<typename Factory>

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(WebRTCLibTest
     pch.cpp
     pch.h
     ContextTest.cpp
+    CreateVideoCodecFactoryTest.cpp
     FrameGenerator.cpp
     FrameGenerator.h
     GpuMemoryBufferTest.cpp

--- a/Plugin~/WebRTCPluginTest/CreateVideoCodecFactoryTest.cpp
+++ b/Plugin~/WebRTCPluginTest/CreateVideoCodecFactoryTest.cpp
@@ -1,0 +1,93 @@
+#include "pch.h"
+
+#include "Codec/CreateVideoCodecFactory.h"
+#include "GraphicsDeviceContainer.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    class CreateVideoCodecFactoryTest : public testing::TestWithParam<UnityGfxRenderer>
+    {
+    public:
+        CreateVideoCodecFactoryTest()
+            : container_(CreateGraphicsDeviceContainer(GetParam()))
+            , device_(container_->device())
+        {
+            arrayImpl_ = {
+                kInternalImpl, kNvCodecImpl, kAndroidMediaCodecImpl, kVideoToolboxImpl
+            };
+        }
+
+    protected:
+        void SetUp() override
+        {
+            if (!device_)
+                GTEST_SKIP() << "The graphics driver is not installed on the device.";
+        }
+        std::unique_ptr<GraphicsDeviceContainer> container_;
+        std::vector<std::string> arrayImpl_; 
+        IGraphicsDevice* device_;
+    };
+
+    TEST_P(CreateVideoCodecFactoryTest, CreateVideoEncoderFactory)
+    {
+        std::map<std::string, std::unique_ptr<VideoEncoderFactory>> factories;
+        for (auto impl : arrayImpl_)
+        {
+            auto factory = CreateVideoEncoderFactory(impl, device_, nullptr);
+            if (factory)
+                factories.emplace(impl, factory);
+        }
+        EXPECT_GT(factories.size(), 0);
+    }
+
+    TEST_P(CreateVideoCodecFactoryTest, CreateVideoDecoderFactory)
+    {
+        std::map<std::string, std::unique_ptr<VideoDecoderFactory>> factories;
+
+        for (auto impl : arrayImpl_)
+        {
+            auto factory = CreateVideoDecoderFactory(impl, device_, nullptr);
+            if (factory)
+                factories.emplace(impl, factory);
+        }
+        EXPECT_GT(factories.size(), 0);
+    }
+
+    TEST_P(CreateVideoCodecFactoryTest, FindCodecFactory)
+    {
+        std::map<std::string, std::unique_ptr<VideoEncoderFactory>> factories;
+        for (auto impl : arrayImpl_)
+        {
+            auto factory = CreateVideoEncoderFactory(impl, device_, nullptr);
+            if (factory)
+                factories.emplace(impl, factory);
+        }
+
+        // return nullptr when unknown mimetype
+        SdpVideoFormat format("test");
+        EXPECT_TRUE(!FindCodecFactory(factories, format));
+
+        // return value when unknown implementation_name
+        SdpVideoFormat format2("VP8");
+        format.parameters.emplace(kSdpKeyNameCodecImpl, "unknown");
+        EXPECT_TRUE(FindCodecFactory(factories, format2));
+    }
+
+    TEST_P(CreateVideoCodecFactoryTest, GetSupportedFormatsInFactories)
+    {
+        std::map<std::string, std::unique_ptr<VideoEncoderFactory>> factories;
+        for (auto impl : arrayImpl_)
+        {
+            auto factory = CreateVideoEncoderFactory(impl, device_, nullptr);
+            if (factory)
+                factories.emplace(impl, factory);
+        }
+
+        std::vector <webrtc::SdpVideoFormat> formats = GetSupportedFormatsInFactories(factories);
+        EXPECT_GT(formats.size(), 0);
+    }
+    INSTANTIATE_TEST_SUITE_P(GfxDevice, CreateVideoCodecFactoryTest, testing::ValuesIn(supportedGfxDevices));
+} // namespace webrtc
+} // namespace unity

--- a/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
+++ b/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
@@ -30,5 +30,28 @@ namespace webrtc
         EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel5_2, 3840 * 2160), 60);
     }
 
+    const char kProfileLevelId[] = "profile-level-id";
+
+    TEST(H264ProfileLevelId, H264IsSameProfile)
+    {
+        SdpVideoFormat format1("H264");
+        H264ProfileLevelId id1(H264Profile::kProfileBaseline, H264Level::kLevel4_1);
+        format1.parameters.emplace(kProfileLevelId, H264ProfileLevelIdToString(id1).value());
+
+        SdpVideoFormat format2("H264");
+        H264ProfileLevelId id2(H264Profile::kProfileBaseline, H264Level::kLevel5_1);
+        format2.parameters.emplace(kProfileLevelId, H264ProfileLevelIdToString(id2).value());
+
+        // ignore level 
+        EXPECT_TRUE(H264IsSameProfile(format1.parameters, format2.parameters));
+
+        SdpVideoFormat format3("H264");
+        H264ProfileLevelId id3(H264Profile::kProfileHigh, H264Level::kLevel4_1);
+        format3.parameters.emplace(kProfileLevelId, H264ProfileLevelIdToString(id3).value());
+
+        // not ignore profile
+        EXPECT_FALSE(H264IsSameProfile(format1.parameters, format3.parameters));
+
+    }
 }
 }


### PR DESCRIPTION
This pull request fixes the crash bug when streaming video between peers on macOS and Windows.

This crash occurs the difference of the "codec implementation" property in the `SdpVideoFormat` parameter.
`SdpVideoFormat`, the argument of `FindCodecFactory` function comes from another peer to negotiate available media codecs. The parameter "codec implementation" is used for determine codec, however, This determination process is wrong. It must be determined with the codec mimetype and profiles, not codec implementation.

We will release the hotfix version because this bug affects many users.