### PR TITLE
fix: Fix the crash when passing the invalid argument to DeleteStatsReport method

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -320,11 +320,49 @@ namespace webrtc
 
     void Context::AddStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report)
     {
+        std::lock_guard<std::mutex> lock(mutexStatsReport);
         m_listStatsReport.push_back(report);
+    }
+
+    const RTCStats** Context::GetStatsList(const RTCStatsReport* report, size_t* length, uint32_t** types)
+    {
+        std::lock_guard<std::mutex> lock(mutexStatsReport);
+
+        auto result = std::find_if(
+            m_listStatsReport.begin(),
+            m_listStatsReport.end(),
+            [report](rtc::scoped_refptr<const webrtc::RTCStatsReport> it) { return it.get() == report; });
+
+        if (result == m_listStatsReport.end())
+        {
+            RTC_LOG(LS_INFO) << "Calling GetStatsList is failed. The reference of RTCStatsReport is not found.";
+            return nullptr;
+        }
+
+        const size_t size = report->size();
+        *length = size;
+        *types = static_cast<uint32_t*>(CoTaskMemAlloc(sizeof(uint32_t) * size));
+        void* buf = CoTaskMemAlloc(sizeof(RTCStats*) * size);
+        const RTCStats** ret = static_cast<const RTCStats**>(buf);
+        if (size == 0)
+        {
+            return ret;
+        }
+        int i = 0;
+        for (const auto& stats : *report)
+        {
+            ret[i] = &stats;
+            (*types)[i] = statsTypes.at(stats.type());
+            i++;
+        }
+        return ret;
+
     }
 
     void Context::DeleteStatsReport(const webrtc::RTCStatsReport* report)
     {
+        std::lock_guard<std::mutex> lock(mutexStatsReport);
+
         auto result = std::find_if(
             m_listStatsReport.begin(),
             m_listStatsReport.end(),

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -325,11 +325,17 @@ namespace webrtc
 
     void Context::DeleteStatsReport(const webrtc::RTCStatsReport* report)
     {
-        auto found = std::find_if(
+        auto result = std::find_if(
             m_listStatsReport.begin(),
             m_listStatsReport.end(),
             [report](rtc::scoped_refptr<const webrtc::RTCStatsReport> it) { return it.get() == report; });
-        m_listStatsReport.erase(found);
+        
+        if (result == m_listStatsReport.end())
+        {
+            RTC_LOG(LS_INFO) << "Calling DeleteStatsReport is failed. The reference of RTCStatsReport is not found.";
+            return;
+        }
+        m_listStatsReport.erase(result);
     }
 
     DataChannelInterface*

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -15,6 +15,28 @@ namespace webrtc
 {
     using namespace ::webrtc;
 
+    const std::map<std::string, uint32_t> statsTypes = { { "codec", 0 },
+                                                         { "inbound-rtp", 1 },
+                                                         { "outbound-rtp", 2 },
+                                                         { "remote-inbound-rtp", 3 },
+                                                         { "remote-outbound-rtp", 4 },
+                                                         { "media-source", 5 },
+                                                         { "csrc", 6 },
+                                                         { "peer-connection", 7 },
+                                                         { "data-channel", 8 },
+                                                         { "stream", 9 },
+                                                         { "track", 10 },
+                                                         { "transceiver", 11 },
+                                                         { "sender", 12 },
+                                                         { "receiver", 13 },
+                                                         { "transport", 14 },
+                                                         { "sctp-transport", 15 },
+                                                         { "candidate-pair", 16 },
+                                                         { "local-candidate", 17 },
+                                                         { "remote-candidate", 18 },
+                                                         { "certificate", 19 },
+                                                         { "ice-server", 20 } };
+
     class IGraphicsDevice;
     class ProfilerMarkerFactory;
     struct ContextDependencies
@@ -106,7 +128,9 @@ namespace webrtc
         SetSessionDescriptionObserver* GetObserver(webrtc::PeerConnectionInterface* connection);
 
         // StatsReport
+        std::mutex mutexStatsReport;
         void AddStatsReport(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report);
+        const RTCStats** GetStatsList(const RTCStatsReport* report, size_t* length, uint32_t** types);
         void DeleteStatsReport(const webrtc::RTCStatsReport* report);
 
         // DataChannel

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -608,48 +608,10 @@ extern "C"
         obj->connection->GetStats(receiver, PeerConnectionStatsCollectorCallback::Create(obj));
     }
 
-    const std::map<std::string, uint32_t> statsTypes = { { "codec", 0 },
-                                                         { "inbound-rtp", 1 },
-                                                         { "outbound-rtp", 2 },
-                                                         { "remote-inbound-rtp", 3 },
-                                                         { "remote-outbound-rtp", 4 },
-                                                         { "media-source", 5 },
-                                                         { "csrc", 6 },
-                                                         { "peer-connection", 7 },
-                                                         { "data-channel", 8 },
-                                                         { "stream", 9 },
-                                                         { "track", 10 },
-                                                         { "transceiver", 11 },
-                                                         { "sender", 12 },
-                                                         { "receiver", 13 },
-                                                         { "transport", 14 },
-                                                         { "sctp-transport", 15 },
-                                                         { "candidate-pair", 16 },
-                                                         { "local-candidate", 17 },
-                                                         { "remote-candidate", 18 },
-                                                         { "certificate", 19 },
-                                                         { "ice-server", 20 } };
-
     UNITY_INTERFACE_EXPORT const RTCStats**
-    StatsReportGetStatsList(const RTCStatsReport* report, size_t* length, uint32_t** types)
+    ContextGetStatsList(Context* context, const RTCStatsReport* report, size_t* length, uint32_t** types)
     {
-        const size_t size = report->size();
-        *length = size;
-        *types = static_cast<uint32_t*>(CoTaskMemAlloc(sizeof(uint32_t) * size));
-        void* buf = CoTaskMemAlloc(sizeof(RTCStats*) * size);
-        const RTCStats** ret = static_cast<const RTCStats**>(buf);
-        if (size == 0)
-        {
-            return ret;
-        }
-        int i = 0;
-        for (const auto& stats : *report)
-        {
-            ret[i] = &stats;
-            (*types)[i] = statsTypes.at(stats.type());
-            i++;
-        }
-        return ret;
+        return context->GetStatsList(report, length, types);
     }
 
     UNITY_INTERFACE_EXPORT void ContextDeleteStatsReport(Context* context, const RTCStatsReport* report)

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -252,6 +252,11 @@ namespace Unity.WebRTC
             NativeMethods.DeleteVideoRenderer(self, sink);
         }
 
+        public IntPtr GetStatsList(IntPtr report, out ulong length, ref IntPtr types)
+        {
+            return NativeMethods.ContextGetStatsList(self, report, out length, ref types);
+        }
+
         public void DeleteStatsReport(IntPtr report)
         {
             NativeMethods.ContextDeleteStatsReport(self, report);

--- a/Runtime/Scripts/RTCStats.cs
+++ b/Runtime/Scripts/RTCStats.cs
@@ -1840,10 +1840,10 @@ namespace Unity.WebRTC
         internal RTCStatsReport(IntPtr ptr)
         {
             self = ptr;
-            WebRTC.Table.Add(self, this);
-
             IntPtr ptrStatsTypeArray = IntPtr.Zero;
-            IntPtr ptrStatsArray = NativeMethods.StatsReportGetStatsList(self, out ulong length, ref ptrStatsTypeArray);
+            IntPtr ptrStatsArray = WebRTC.Context.GetStatsList(self, out ulong length, ref ptrStatsTypeArray);
+            if (ptrStatsArray == IntPtr.Zero)
+                throw new ArgumentException("Invalid pointer.", "ptr");
 
             IntPtr[] array = ptrStatsArray.AsArray<IntPtr>((int)length);
             uint[] types = ptrStatsTypeArray.AsArray<uint>((int)length);
@@ -1855,6 +1855,8 @@ namespace Unity.WebRTC
                 RTCStats stats = StatsFactory.Create(type, array[i]);
                 m_dictStats[stats.Id] = stats;
             }
+
+            WebRTC.Table.Add(self, this);
         }
 
         /// <summary>

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1161,6 +1161,8 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void ContextStopMediaStreamTrack(IntPtr context, IntPtr track);
         [DllImport(WebRTC.Lib)]
+        public static extern IntPtr ContextGetStatsList(IntPtr context, IntPtr report, out ulong length, ref IntPtr types);
+        [DllImport(WebRTC.Lib)]
         public static extern void ContextDeleteStatsReport(IntPtr context, IntPtr report);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextAddRefPtr(IntPtr context, IntPtr ptr);
@@ -1402,8 +1404,6 @@ namespace Unity.WebRTC
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
         public static extern void AudioSourceProcessLocalAudio(IntPtr source, IntPtr array, int sampleRate, int channels, int frames);
-        [DllImport(WebRTC.Lib)]
-        public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsGetJson(IntPtr stats);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 
 namespace Unity.WebRTC.RuntimeTest
@@ -92,5 +93,15 @@ namespace Unity.WebRTC.RuntimeTest
             context.DeleteAudioTrackSink(sink);
             context.Dispose();
         }
+
+        [Test]
+        [Category("Context")]
+        public void DeleteStatsReportIgnoreInvalidValue()
+        {
+            var context = Context.Create();
+            context.DeleteStatsReport(IntPtr.Zero);
+            context.Dispose();
+        }
+
     }
 }

--- a/Tests/Runtime/StatsReportTest.cs
+++ b/Tests/Runtime/StatsReportTest.cs
@@ -1,12 +1,32 @@
+using System;
 using UnityEngine;
-using UnityEngine.TestTools;
 using NUnit.Framework;
-using System.Linq;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace Unity.WebRTC.RuntimeTest
 {
+    class StatsReportTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            WebRTC.Initialize(true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            WebRTC.Dispose();
+        }
+
+        [Test]
+        public void ConstructorThrowsException()
+        {
+            Assert.That(() => new RTCStatsReport(IntPtr.Zero), Throws.ArgumentException);
+        }
+    }
+    
+
+
     class StatsCheck
     {
         class Ignore

--- a/Tests/Runtime/StatsReportTest.cs.meta
+++ b/Tests/Runtime/StatsReportTest.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 58cbe7a1d11171c43898ba79be53d6c9
+guid: 39f1c57a0918a08478d0c7e320283fa1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
This fix relates #542 #799.

There were issues that creating/destroying RTCStatsReport instance in native code when it works with multi threading. This fix protects the shared resources using mutex, and added some test cases to check implementations of the RTCStatsReport.