### PR TITLE
fix: Fix bug when calling GetStats method multiple times at the same time

### DIFF
--- a/Plugin~/WebRTCPlugin/PeerConnectionStatsCollectorCallback.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionStatsCollectorCallback.cpp
@@ -17,7 +17,7 @@ namespace webrtc
         const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report)
     {
         m_owner->ReceiveStatsReport(report);
-        s_collectStatsCallback(m_owner, report.get());
+        s_collectStatsCallback(m_owner, this, report.get());
     }
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/PeerConnectionStatsCollectorCallback.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionStatsCollectorCallback.h
@@ -10,7 +10,9 @@ namespace unity
 namespace webrtc
 {
     class PeerConnectionObject;
-    using DelegateCollectStats = void (*)(PeerConnectionObject*, const RTCStatsReport*);
+    class PeerConnectionStatsCollectorCallback;
+    using DelegateCollectStats =
+        void (*)(PeerConnectionObject*, PeerConnectionStatsCollectorCallback*, const RTCStatsReport*);
     class PeerConnectionStatsCollectorCallback : public RTCStatsCollectorCallback
     {
     public:

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -592,20 +592,27 @@ extern "C"
         return ConvertString(str);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionGetStats(PeerConnectionObject* obj)
+    UNITY_INTERFACE_EXPORT PeerConnectionStatsCollectorCallback* PeerConnectionGetStats(PeerConnectionObject* obj)
     {
-        obj->connection->GetStats(PeerConnectionStatsCollectorCallback::Create(obj));
+        PeerConnectionStatsCollectorCallback* callback = PeerConnectionStatsCollectorCallback::Create(obj);
+        obj->connection->GetStats(callback);
+        return callback;
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionSenderGetStats(PeerConnectionObject* obj, RtpSenderInterface* selector)
+    UNITY_INTERFACE_EXPORT PeerConnectionStatsCollectorCallback*
+    PeerConnectionSenderGetStats(PeerConnectionObject* obj, RtpSenderInterface* sender)
     {
-        obj->connection->GetStats(selector, PeerConnectionStatsCollectorCallback::Create(obj));
+        PeerConnectionStatsCollectorCallback* callback = PeerConnectionStatsCollectorCallback::Create(obj);
+        obj->connection->GetStats(sender, callback);
+        return callback;
     }
 
-    UNITY_INTERFACE_EXPORT void
+    UNITY_INTERFACE_EXPORT PeerConnectionStatsCollectorCallback*
     PeerConnectionReceiverGetStats(PeerConnectionObject* obj, RtpReceiverInterface* receiver)
     {
-        obj->connection->GetStats(receiver, PeerConnectionStatsCollectorCallback::Create(obj));
+        PeerConnectionStatsCollectorCallback* callback = PeerConnectionStatsCollectorCallback::Create(obj);
+        obj->connection->GetStats(receiver, callback);
+        return callback;
     }
 
     UNITY_INTERFACE_EXPORT const RTCStats**

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -806,20 +806,20 @@ namespace Unity.WebRTC
         public RTCStatsReportAsyncOperation GetStats()
         {
             RTCStatsCollectorCallback callback = NativeMethods.PeerConnectionGetStats(GetSelfOrThrow());
-            listCollectStatsCallback.Add(callback);
+            dictCollectStatsCallback.Add(callback.DangerousGetHandle(), callback);
             return new RTCStatsReportAsyncOperation(callback);
         }
 
         internal RTCStatsReportAsyncOperation GetStats(RTCRtpSender sender)
         {
             RTCStatsCollectorCallback callback = NativeMethods.PeerConnectionSenderGetStats(GetSelfOrThrow(), sender.self);
-            listCollectStatsCallback.Add(callback);
+            dictCollectStatsCallback.Add(callback.DangerousGetHandle(), callback);
             return new RTCStatsReportAsyncOperation(callback);
         }
         internal RTCStatsReportAsyncOperation GetStats(RTCRtpReceiver receiver)
         {
             RTCStatsCollectorCallback callback = NativeMethods.PeerConnectionReceiverGetStats(GetSelfOrThrow(), receiver.self);
-            listCollectStatsCallback.Add(callback);
+            dictCollectStatsCallback.Add(callback.DangerousGetHandle(), callback);
             return new RTCStatsReportAsyncOperation(callback);
         }
 
@@ -919,20 +919,20 @@ namespace Unity.WebRTC
             }
         }
 
-        HashSet<RTCStatsCollectorCallback> listCollectStatsCallback = new HashSet<RTCStatsCollectorCallback>();
+        Dictionary<IntPtr, RTCStatsCollectorCallback> dictCollectStatsCallback = new Dictionary<IntPtr, RTCStatsCollectorCallback>();
 
         internal RTCStatsCollectorCallback FindCollectStatsCallback(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
                 throw new ArgumentException("The argument is IntPtr.Zero.", "ptr");
-            return listCollectStatsCallback.FirstOrDefault(x => x.DangerousGetHandle() == ptr);
+            return dictCollectStatsCallback[ptr];
         }
 
         internal void RemoveCollectStatsCallback(RTCStatsCollectorCallback callback)
         {
             if (callback == null)
                 throw new ArgumentNullException("callback");
-            listCollectStatsCallback.Remove(callback);
+            dictCollectStatsCallback.Remove(callback.DangerousGetHandle());
         }
 
 

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -969,8 +969,8 @@ namespace Unity.WebRTC
                 if (WebRTC.Table[ptr] is RTCPeerConnection connection)
                 {
                     RTCStatsCollectorCallback callback = connection.FindCollectStatsCallback(ptrCallback);
-                    callback.Invoke(report);
                     connection.RemoveCollectStatsCallback(callback);
+                    callback.Invoke(report);
                 }
             });
         }

--- a/Runtime/Scripts/RTCStatsCollectorCallback.cs
+++ b/Runtime/Scripts/RTCStatsCollectorCallback.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Unity.WebRTC
+{
+    internal class RTCStatsCollectorCallback : SafeHandle
+    {
+        public Action<IntPtr> onStatsDelivered;
+
+        private RTCStatsCollectorCallback()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public void Invoke(IntPtr report)
+        {
+            onStatsDelivered?.Invoke(report);
+        }
+
+        public override bool IsInvalid { get { return handle == IntPtr.Zero; } }
+
+        protected override bool ReleaseHandle()
+        {
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/RTCStatsCollectorCallback.cs.meta
+++ b/Runtime/Scripts/RTCStatsCollectorCallback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cf4684a3f82bac4c98264e8bd498e85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/WebRTC.AsyncOperation.cs
+++ b/Runtime/Scripts/WebRTC.AsyncOperation.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Unity.WebRTC
@@ -56,39 +57,16 @@ namespace Unity.WebRTC
         /// </summary>
         public RTCStatsReport Value { get; private set; }
 
-        internal RTCStatsReportAsyncOperation(RTCPeerConnection connection)
+        internal RTCStatsReportAsyncOperation(RTCStatsCollectorCallback callback)
         {
-            NativeMethods.PeerConnectionGetStats(connection.GetSelfOrThrow());
-
-            connection.OnStatsDelivered = ptr =>
-            {
-                Value = WebRTC.FindOrCreate(ptr, ptr_ => new RTCStatsReport(ptr_));
-                IsError = false;
-                this.Done();
-            };
+            callback.onStatsDelivered = OnStatsDelivered;
         }
 
-        internal RTCStatsReportAsyncOperation(RTCPeerConnection connection, RTCRtpSender sender)
+        void OnStatsDelivered(IntPtr ptr)
         {
-            NativeMethods.PeerConnectionSenderGetStats(connection.GetSelfOrThrow(), sender.self);
-
-            connection.OnStatsDelivered = ptr =>
-            {
-                Value = WebRTC.FindOrCreate(ptr, ptr_ => new RTCStatsReport(ptr_));
-                IsError = false;
-                this.Done();
-            };
-        }
-        internal RTCStatsReportAsyncOperation(RTCPeerConnection connection, RTCRtpReceiver receiver)
-        {
-            NativeMethods.PeerConnectionReceiverGetStats(connection.GetSelfOrThrow(), receiver.self);
-
-            connection.OnStatsDelivered = ptr =>
-            {
-                Value = WebRTC.FindOrCreate(ptr, ptr_ => new RTCStatsReport(ptr_));
-                IsError = false;
-                this.Done();
-            };
+            Value = WebRTC.FindOrCreate(ptr, ptr_ => new RTCStatsReport(ptr_));
+            IsError = false;
+            this.Done();
         }
     }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1080,7 +1080,7 @@ namespace Unity.WebRTC
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateCreateSDSuccess(IntPtr ptr, RTCSdpType type, [MarshalAs(UnmanagedType.LPStr)] string sdp);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void DelegateCollectStats(IntPtr ptr, IntPtr reportPtr);
+    internal delegate void DelegateCollectStats(IntPtr ptr, IntPtr ptrCallback, IntPtr reportPtr);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     internal delegate void DelegateCreateGetStats(IntPtr ptr, RTCSdpType type, [MarshalAs(UnmanagedType.LPStr)] string sdp);
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -1197,15 +1197,15 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern RTCErrorType PeerConnectionSetRemoteDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc, ref IntPtr error);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionGetStats(IntPtr ptr);
+        public static extern RTCStatsCollectorCallback PeerConnectionGetStats(IntPtr ptr);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionSenderGetStats(IntPtr ptr, IntPtr sender);
+        public static extern RTCStatsCollectorCallback PeerConnectionSenderGetStats(IntPtr ptr, IntPtr sender);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextGetSenderCapabilities(IntPtr context, TrackKind kind, out IntPtr capabilities);
         [DllImport(WebRTC.Lib)]
         public static extern void ContextGetReceiverCapabilities(IntPtr context, TrackKind kind, out IntPtr capabilities);
         [DllImport(WebRTC.Lib)]
-        public static extern void PeerConnectionReceiverGetStats(IntPtr sender, IntPtr receiver);
+        public static extern RTCStatsCollectorCallback PeerConnectionReceiverGetStats(IntPtr sender, IntPtr receiver);
         [DllImport(WebRTC.Lib)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool PeerConnectionGetLocalDescription(IntPtr ptr, ref RTCSessionDescription desc);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -972,15 +972,14 @@ namespace Unity.WebRTC.RuntimeTest
             var op3 = test.component.GetSenderStats(1, 0);
             var op4 = test.component.GetReceiverStats(1, 0);
 
-            foreach (var op in new[] { op1, op2, op3, op4 })
+            var ops = new[] { op1, op2, op3, op4 };
+            foreach (var op in ops)
             {
                 yield return op;
+                Assert.That(op.IsDone, Is.True);
+                Assert.That(op.Value, Is.Not.Null);
+                Assert.That(op.Value.Stats, Is.Not.Null);
             }
-
-            Assert.That(op1.IsDone, Is.True);
-            Assert.That(op2.IsDone, Is.True);
-            Assert.That(op3.IsDone, Is.True);
-            Assert.That(op4.IsDone, Is.True);
 
             op1.Value.Dispose();
             op2.Value.Dispose();

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -962,39 +962,37 @@ namespace Unity.WebRTC.RuntimeTest
             source.clip = AudioClip.Create("test", 480, 2, 48000, false);
             stream.AddTrack(new AudioStreamTrack(source));
 
-            yield return new WaitForSeconds(0.1f);
-
             var test = new MonoBehaviourTest<SignalingPeers>();
             test.component.AddStream(0, stream);
             yield return test;
             test.component.CoroutineUpdate();
-            yield return new WaitForSeconds(0.1f);
-            var op = test.component.GetPeerStats(0);
-            yield return op;
-            Assert.That(op.IsDone, Is.True);
-            Assert.That(op.Value.Stats, Is.Not.Empty);
-            Assert.That(op.Value.Stats.Keys, Is.Not.Empty);
-            Assert.That(op.Value.Stats.Values, Is.Not.Empty);
-            Assert.That(op.Value.Stats.Count, Is.GreaterThan(0));
 
-            foreach (RTCStats stats in op.Value.Stats.Values)
+            var op1 = test.component.GetSenderStats(0, 0);
+            var op2 = test.component.GetReceiverStats(0, 0);
+            var op3 = test.component.GetSenderStats(1, 0);
+            var op4 = test.component.GetReceiverStats(1, 0);
+
+            foreach (var op in new[] { op1, op2, op3, op4 })
             {
-                Assert.That(stats, Is.Not.Null);
-                Assert.That(stats.Timestamp, Is.GreaterThan(0));
-                Assert.That(stats.Id, Is.Not.Empty);
-                foreach (var pair in stats.Dict)
-                {
-                    Assert.That(pair.Key, Is.Not.Empty);
-                }
-                StatsCheck.Test(stats);
+                yield return op;
             }
-            op.Value.Dispose();
+
+            Assert.That(op1.IsDone, Is.True);
+            Assert.That(op2.IsDone, Is.True);
+            Assert.That(op3.IsDone, Is.True);
+            Assert.That(op4.IsDone, Is.True);
+
+            op1.Value.Dispose();
+            op2.Value.Dispose();
+            op3.Value.Dispose();
+            op4.Value.Dispose();
 
             test.component.Dispose();
             foreach (var track in stream.GetTracks())
             {
                 track.Dispose();
             }
+
             stream.Dispose();
             Object.DestroyImmediate(go);
             Object.DestroyImmediate(test.gameObject);


### PR DESCRIPTION
This PR fixes the issue that the coroutine which the return value of GetStats method, doesn't change the status when calling it multiple times at the same time.

Add `RTCStatsCollectorCallback` class which manages the native handle of the `GetStats` callback, and define the dictionary of `RTCStatsCollectorCallback` in RTCPeerConnection class.