### PR TITLE
test: Add test category to exclude test cases which take long time 

### DIFF
--- a/Tests/Runtime/Attribute.cs
+++ b/Tests/Runtime/Attribute.cs
@@ -1,0 +1,10 @@
+using System;
+using NUnit.Framework;
+
+namespace Unity.WebRTC.RuntimeTest
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    internal class LongRunningAttribute : CategoryAttribute
+    {
+    }
+}

--- a/Tests/Runtime/Attribute.cs.meta
+++ b/Tests/Runtime/Attribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 257fb59511fea8a4fa81cad4f8f169ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -23,7 +23,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void CreateAndDelete()
         {
             var context = Context.Create();
@@ -31,7 +30,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void CreateAndDeletePeerConnection()
         {
             var context = Context.Create();
@@ -41,7 +39,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void CreateAndDeleteDataChannel()
         {
             var context = Context.Create();
@@ -54,7 +51,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void CreateAndDeleteAudioTrack()
         {
             var context = Context.Create();
@@ -66,7 +62,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void CreateAndDeleteVideoTrack()
         {
             var context = Context.Create();
@@ -84,7 +79,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void CreateAndDeleteAudioTrackSink()
         {
             var context = Context.Create();

--- a/Tests/Runtime/IceCandidateTest.cs
+++ b/Tests/Runtime/IceCandidateTest.cs
@@ -18,14 +18,12 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("IceCandidate")]
         public void Construct()
         {
             Assert.Throws<ArgumentException>(() => new RTCIceCandidate());
         }
 
         [Test]
-        [Category("IceCandidate")]
         public void ConstructWithOption()
         {
             var option = new RTCIceCandidateInit

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -23,7 +23,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("MediaStream")]
         public void Construct()
         {
             var stream = new MediaStream();
@@ -32,7 +31,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("MediaStream")]
         public void EqualId()
         {
             var guid = Guid.NewGuid().ToString();
@@ -43,7 +41,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("MediaStream")]
         public void AccessAfterDisposed()
         {
             var stream = new MediaStream();
@@ -52,7 +49,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("MediaStream")]
         public void RegisterDelegate()
         {
             var stream = new MediaStream();
@@ -64,7 +60,6 @@ namespace Unity.WebRTC.RuntimeTest
         // todo(kazuki): Crash on Android and Linux standalone player
         [UnityTest]
         [Timeout(5000)]
-        [Category("MediaStream")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.Android })]
         public IEnumerator VideoStreamAddTrackAndRemoveTrack()
         {

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -106,7 +106,6 @@ namespace Unity.WebRTC.RuntimeTest
         // todo(kazuki): Crash on windows standalone player
         [UnityTest]
         [Timeout(5000)]
-        [Category("MediaStreamTrack")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer })]
         public IEnumerator VideoStreamTrackEnabled()
         {
@@ -143,7 +142,6 @@ namespace Unity.WebRTC.RuntimeTest
         // todo::(kazuki) Test execution timed out on linux standalone
         [UnityTest]
         [Timeout(5000)]
-        [Category("MediaStreamTrack")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public IEnumerator CaptureStreamTrack()
         {
@@ -160,7 +158,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("MediaStreamTrack")]
         public void CaptureStreamTrackThrowExeption()
         {
             var camObj = new GameObject("Camera");
@@ -172,7 +169,6 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        [Category("MediaStreamTrack")]
         public void AddAndRemoveAudioStreamTrack()
         {
             GameObject obj = new GameObject("audio");
@@ -194,7 +190,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("MediaStreamTrack")]
         public void VideoStreamTrackDisposeImmediately()
         {
             var width = 256;
@@ -208,9 +203,8 @@ namespace Unity.WebRTC.RuntimeTest
             Object.DestroyImmediate(rt);
         }
 
-        [UnityTest]
+        [UnityTest, LongRunning]
         [Timeout(5000)]
-        [Category("MediaStreamTrack")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
         public IEnumerator VideoStreamTrackInstantiateMultiple()
         {

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -368,7 +368,7 @@ namespace Unity.WebRTC.RuntimeTest
             instance.Dispose();
         }
 
-        [UnityTest]
+        [UnityTest, LongRunning]
         public IEnumerator CallVideoEncoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -414,7 +414,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.GetUpdateTextureFunc(IntPtr.Zero);
         }
 
-        [UnityTest]
+        [UnityTest, LongRunning]
         [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoDecoderMethods.UpdateRendererTexture is not supported on Direct3D12.")]
         public IEnumerator CallVideoDecoderMethods()

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -43,7 +43,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void Construct()
         {
             var peer = new RTCPeerConnection();
@@ -64,7 +63,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void AccessAfterDisposed()
         {
             var peer = new RTCPeerConnection();
@@ -73,7 +71,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void GetConfiguration()
         {
             var config = GetDefaultConfiguration();
@@ -98,7 +95,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void ConstructWithConfigThrowException()
         {
 
@@ -113,7 +109,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void SetConfiguration()
         {
             var peer = new RTCPeerConnection();
@@ -157,7 +152,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void AddTransceiver()
         {
             var peer = new RTCPeerConnection();
@@ -200,7 +194,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void GetTransceiversReturnsNotEmptyAfterDisposingTransceiver()
         {
             // `RTCPeerConnection.AddTransceiver` method is not intuitive. Moreover, we don't have the API to remove
@@ -214,7 +207,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void GetTransceiversReturnsNotEmptyAfterCallingRemoveTrack()
         {
             // Also, `RTCPeerConnection.AddTrack` and `RTCPeerConnection.RemoveTrack` method is not intuitive.
@@ -234,7 +226,6 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        [Category("PeerConnection")]
         public void AddTransceiverThrowException()
         {
             var peer = new RTCPeerConnection();
@@ -243,7 +234,6 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        [Category("PeerConnection")]
         public void AddTransceiverTrackKindAudio()
         {
             var peer = new RTCPeerConnection();
@@ -265,7 +255,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void AddTransceiverTrackKindVideo()
         {
             var peer = new RTCPeerConnection();
@@ -287,7 +276,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void AddTransceiverWithInit()
         {
             var peer = new RTCPeerConnection();
@@ -320,7 +308,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void AddTransceiverWithKindAndInit()
         {
             var peer = new RTCPeerConnection();
@@ -360,7 +347,6 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
-        [Category("PeerConnection")]
         public void GetAndSetDirectionTransceiver()
         {
             var peer = new RTCPeerConnection();
@@ -376,7 +362,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void GetTransceivers()
         {
             var peer = new RTCPeerConnection();
@@ -397,7 +382,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator CurrentDirection()
         {
@@ -501,7 +485,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         public IEnumerator CreateOffer()
         {
             var config = GetDefaultConfiguration();
@@ -518,7 +501,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         public IEnumerator CreateAnswerFailed()
         {
             var config = GetDefaultConfiguration();
@@ -538,7 +520,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         public IEnumerator CreateAnswer()
         {
             var config = GetDefaultConfiguration();
@@ -568,7 +549,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         public IEnumerator SetLocalDescription()
         {
             var peer = new RTCPeerConnection();
@@ -592,7 +572,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void SetLocalDescriptionThrowException()
         {
             var peer = new RTCPeerConnection();
@@ -607,7 +586,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.OSXPlayer })]
         public IEnumerator SetRemoteDescription()
         {
@@ -644,7 +622,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("PeerConnection")]
         public void SetRemoteDescriptionThrowException()
         {
             var peer = new RTCPeerConnection();
@@ -660,7 +637,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         public IEnumerator SetLocalDescriptionFailed()
         {
             var peer = new RTCPeerConnection();
@@ -694,7 +670,6 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(1000)]
-        [Category("PeerConnection")]
         public IEnumerator SetRemoteDescriptionFailed()
         {
             var config = GetDefaultConfiguration();

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -21,7 +21,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpSender")]
         public void SenderGetVideoCapabilities()
         {
             RTCRtpCapabilities capabilities = RTCRtpSender.GetCapabilities(TrackKind.Video);
@@ -44,7 +43,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpSender")]
         public void SenderGetAudioCapabilities()
         {
             RTCRtpCapabilities capabilities = RTCRtpSender.GetCapabilities(TrackKind.Audio);
@@ -67,7 +65,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpReceiver")]
         public void ReceiverGetVideoCapabilities()
         {
             RTCRtpCapabilities capabilities = RTCRtpReceiver.GetCapabilities(TrackKind.Video);
@@ -90,7 +87,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpReceiver")]
         public void ReceiverGetAudioCapabilities()
         {
             RTCRtpCapabilities capabilities = RTCRtpReceiver.GetCapabilities(TrackKind.Audio);
@@ -113,7 +109,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpTransceiver")]
         public void TransceiverSetVideoCodecPreferences()
         {
             var peer = new RTCPeerConnection();
@@ -124,7 +119,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpTransceiver")]
         public void TransceiverSetAudioCodecPreferences()
         {
             var peer = new RTCPeerConnection();
@@ -135,7 +129,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpReceiver")]
         public void ReceiverGetTrackReturnsVideoTrack()
         {
             var peer = new RTCPeerConnection();
@@ -158,7 +151,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("RTCRtpReceiver")]
         public void ReceiverGetTrackReturnsAudioTrack()
         {
             var peer = new RTCPeerConnection();

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -78,7 +78,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         // not supported TestCase attribute on UnityTest
         // refer to https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-tests-parameterized.html
-        [UnityTest]
+        [UnityTest, LongRunning]
         [Timeout(15000)]
         [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoStreamTrack.UpdateReceiveTexture is not supported on Direct3D12")]


### PR DESCRIPTION
This PR arranges test categories to exclude test cases taking long time to run.

![image](https://user-images.githubusercontent.com/1132081/191419941-9b55768a-dc72-46ed-976e-d31d11cd9270.png)

Some test cases takes long time because they run asyncnously using coroutine, and also need many frames to find low reproducable issues. Many developers would abstain from running test case to avoid waiting long time.

Note: Unity Test Runner doesn't support filtering that can exclude test cases which developers specify categories. Therefore, we can set only one category per test cases.
