### PR TITLE
fix: Fix UnityException when calling finalizer of VideoStreamTrack from GC

### DIFF
--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -107,7 +107,7 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public override void Dispose()
         {
@@ -118,11 +118,6 @@ namespace Unity.WebRTC
 
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
-                if (m_source != null)
-                {
-                    if (RenderTexture.active == m_source.destTexture_)
-                        RenderTexture.active = null;
-                }
                 m_renderer?.Dispose();
                 m_source?.Dispose();
 
@@ -138,12 +133,12 @@ namespace Unity.WebRTC
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public static class CameraExtension
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="cam"></param>
         /// <param name="width"></param>
@@ -178,7 +173,7 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="cam"></param>
         /// <param name="width"></param>

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -101,9 +101,10 @@ namespace Unity.WebRTC.RuntimeTest
             yield return op2;
 
             track.Dispose();
-
             stream.Dispose();
             Object.DestroyImmediate(rt);
+
+            Assert.That(RenderTexture.active, Is.Null);
         }
 
         [Test]


### PR DESCRIPTION
The property `RenderTexture.active` throws `UnityException` when accessing on the thread except of main thread.