### PR TITLE
fix: Fix RTCPeerConnection.SetLocalDescription callback

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -233,7 +233,6 @@ namespace webrtc
 
             m_mapRefPtr.clear();
             m_mapMediaStreamObserver.clear();
-            m_mapSetSessionDescriptionObserver.clear();
             m_mapDataChannels.clear();
             m_mapVideoRenderer.clear();
 

--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -407,17 +407,6 @@ namespace webrtc
         }
     }
 
-    void Context::AddObserver(
-        const webrtc::PeerConnectionInterface* connection,
-        const rtc::scoped_refptr<SetSessionDescriptionObserver>& observer)
-    {
-        m_mapSetSessionDescriptionObserver[connection] = observer;
-    }
-
-    void Context::RemoveObserver(const webrtc::PeerConnectionInterface* connection)
-    {
-        m_mapSetSessionDescriptionObserver.erase(connection);
-    }
 
     PeerConnectionObject* Context::CreatePeerConnection(const webrtc::PeerConnectionInterface::RTCConfiguration& config)
     {
@@ -437,10 +426,6 @@ namespace webrtc
 
     void Context::DeletePeerConnection(PeerConnectionObject* obj) { m_mapClients.erase(obj); }
 
-    SetSessionDescriptionObserver* Context::GetObserver(webrtc::PeerConnectionInterface* connection)
-    {
-        return m_mapSetSessionDescriptionObserver[connection];
-    }
 
     uint32_t Context::s_rendererId = 0;
     uint32_t Context::GenerateRendererId() { return s_rendererId++; }

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -121,11 +121,6 @@ namespace webrtc
         // PeerConnection
         PeerConnectionObject* CreatePeerConnection(const webrtc::PeerConnectionInterface::RTCConfiguration& config);
         void DeletePeerConnection(PeerConnectionObject* obj);
-        void AddObserver(
-            const webrtc::PeerConnectionInterface* connection,
-            const rtc::scoped_refptr<SetSessionDescriptionObserver>& observer);
-        void RemoveObserver(const webrtc::PeerConnectionInterface* connection);
-        SetSessionDescriptionObserver* GetObserver(webrtc::PeerConnectionInterface* connection);
 
         // StatsReport
         std::mutex mutexStatsReport;

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -161,8 +161,6 @@ namespace webrtc
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
         std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;
         std::map<const webrtc::MediaStreamInterface*, std::unique_ptr<MediaStreamObserver>> m_mapMediaStreamObserver;
-        std::map<const webrtc::PeerConnectionInterface*, rtc::scoped_refptr<SetSessionDescriptionObserver>>
-            m_mapSetSessionDescriptionObserver;
         std::map<const DataChannelInterface*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
         std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
         std::map<const AudioTrackSinkAdapter*, std::unique_ptr<AudioTrackSinkAdapter>> m_mapAudioTrackAndSink;

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -124,7 +124,6 @@ namespace webrtc
 
     private:
         Context& context;
-        PeerConnectionStatsCollectorCallback* m_statsCollectorCallback;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/SetSessionDescriptionObserver.cpp
+++ b/Plugin~/WebRTCPlugin/SetSessionDescriptionObserver.cpp
@@ -7,6 +7,7 @@ namespace unity
 {
 namespace webrtc
 {
+    DelegateSetSessionDesc SetSessionDescriptionObserver::s_setSessionDescCallback = nullptr;
 
     rtc::scoped_refptr<SetSessionDescriptionObserver>
     SetSessionDescriptionObserver::Create(PeerConnectionObject* connection)
@@ -19,30 +20,14 @@ namespace webrtc
         m_connection = connection;
     }
 
-    void SetSessionDescriptionObserver::RegisterDelegateOnSuccess(DelegateSetSessionDescSuccess onSuccess)
-    {
-        m_vectorDelegateSetSDSuccess.push_back(onSuccess);
-    }
-
-    void SetSessionDescriptionObserver::RegisterDelegateOnFailure(DelegateSetSessionDescFailure onFailure)
-    {
-        m_vectorDelegateSetSDFailure.push_back(onFailure);
-    }
-
     void SetSessionDescriptionObserver::OnSuccess()
     {
-        for (auto delegate : m_vectorDelegateSetSDSuccess)
-        {
-            delegate(m_connection);
-        }
+        s_setSessionDescCallback(m_connection, this, RTCErrorType::NONE, nullptr);
     }
 
     void SetSessionDescriptionObserver::OnFailure(webrtc::RTCError error)
     {
-        for (auto delegate : m_vectorDelegateSetSDFailure)
-        {
-            delegate(m_connection, error.type(), error.message());
-        }
+        s_setSessionDescCallback(m_connection, this, error.type(), error.message());
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/SetSessionDescriptionObserver.h
+++ b/Plugin~/WebRTCPlugin/SetSessionDescriptionObserver.h
@@ -8,13 +8,15 @@ namespace unity
 {
 namespace webrtc
 {
+    class SetSessionDescriptionObserver;
+    using DelegateSetSessionDesc =
+        void (*)(PeerConnectionObject*, SetSessionDescriptionObserver*, RTCErrorType, const char*);
 
     class SetSessionDescriptionObserver : public ::webrtc::SetSessionDescriptionObserver
     {
     public:
         static rtc::scoped_refptr<SetSessionDescriptionObserver> Create(PeerConnectionObject* connection);
-        void RegisterDelegateOnSuccess(DelegateSetSessionDescSuccess onSuccess);
-        void RegisterDelegateOnFailure(DelegateSetSessionDescFailure onFailure);
+        static void RegisterCallback(DelegateSetSessionDesc callback) { s_setSessionDescCallback = callback; }
 
         void OnSuccess() override;
         void OnFailure(webrtc::RTCError error) override;
@@ -25,8 +27,7 @@ namespace webrtc
 
     private:
         PeerConnectionObject* m_connection;
-        std::vector<DelegateSetSessionDescSuccess> m_vectorDelegateSetSDSuccess;
-        std::vector<DelegateSetSessionDescFailure> m_vectorDelegateSetSDFailure;
+        static DelegateSetSessionDesc s_setSessionDescCallback;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -443,7 +443,6 @@ extern "C"
     UNITY_INTERFACE_EXPORT void ContextDeletePeerConnection(Context* context, PeerConnectionObject* obj)
     {
         obj->Close();
-        context->RemoveObserver(obj->connection);
         context->DeletePeerConnection(obj);
     }
 
@@ -719,7 +718,6 @@ extern "C"
     }
 
     UNITY_INTERFACE_EXPORT unity::webrtc::SetSessionDescriptionObserver* PeerConnectionSetLocalDescription(
-        Context* context,
         PeerConnectionObject* obj,
         const RTCSessionDescription* desc,
         RTCErrorType* errorType,
@@ -734,17 +732,16 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT unity::webrtc::SetSessionDescriptionObserver*
     PeerConnectionSetLocalDescriptionWithoutDescription(
-        Context* context, PeerConnectionObject* obj, RTCErrorType* errorType, char* error[])
+        PeerConnectionObject* obj, RTCErrorType* errorType, char* error[])
     {
         std::string error_;
         auto observer = unity::webrtc::SetSessionDescriptionObserver::Create(obj);
-        *errorType = obj->SetLocalDescriptionWithoutDescription(context->GetObserver(obj->connection), error_);
+        *errorType = obj->SetLocalDescriptionWithoutDescription(observer, error_);
         *error = ConvertString(error_);
         return observer.get();
     }
 
     UNITY_INTERFACE_EXPORT unity::webrtc::SetSessionDescriptionObserver* PeerConnectionSetRemoteDescription(
-        Context* context,
         PeerConnectionObject* obj,
         const RTCSessionDescription* desc,
         RTCErrorType* errorType,

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -420,23 +420,12 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT void ContextDestroy(int uid) { ContextManager::GetInstance()->DestroyContext(uid); }
 
-    PeerConnectionObject*
-    _ContextCreatePeerConnection(Context* context, const PeerConnectionInterface::RTCConfiguration& config)
-    {
-        const auto obj = context->CreatePeerConnection(config);
-        if (obj == nullptr)
-            return nullptr;
-        const auto observer = unity::webrtc::SetSessionDescriptionObserver::Create(obj);
-        context->AddObserver(obj->connection, observer);
-        return obj;
-    }
-
     UNITY_INTERFACE_EXPORT PeerConnectionObject* ContextCreatePeerConnection(Context* context)
     {
         PeerConnectionInterface::RTCConfiguration config;
         config.sdp_semantics = SdpSemantics::kUnifiedPlan;
         config.enable_implicit_rollback = true;
-        return _ContextCreatePeerConnection(context, config);
+        return context->CreatePeerConnection(config);
     }
 
     UNITY_INTERFACE_EXPORT PeerConnectionObject*
@@ -448,7 +437,7 @@ extern "C"
 
         config.sdp_semantics = SdpSemantics::kUnifiedPlan;
         config.enable_implicit_rollback = true;
-        return _ContextCreatePeerConnection(context, config);
+        return context->CreatePeerConnection(config);
     }
 
     UNITY_INTERFACE_EXPORT void ContextDeletePeerConnection(Context* context, PeerConnectionObject* obj)
@@ -729,32 +718,43 @@ extern "C"
         return member->type();
     }
 
-    UNITY_INTERFACE_EXPORT RTCErrorType PeerConnectionSetLocalDescription(
-        Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc, char* error[])
+    UNITY_INTERFACE_EXPORT unity::webrtc::SetSessionDescriptionObserver* PeerConnectionSetLocalDescription(
+        Context* context,
+        PeerConnectionObject* obj,
+        const RTCSessionDescription* desc,
+        RTCErrorType* errorType,
+        char* error[])
     {
         std::string error_;
-        RTCErrorType errorType = obj->SetLocalDescription(*desc, context->GetObserver(obj->connection), error_);
+        auto observer = unity::webrtc::SetSessionDescriptionObserver::Create(obj);
+        *errorType = obj->SetLocalDescription(*desc, observer, error_);
         *error = ConvertString(error_);
-        return errorType;
+        return observer.get();
     }
 
-    UNITY_INTERFACE_EXPORT RTCErrorType
-    PeerConnectionSetLocalDescriptionWithoutDescription(Context* context, PeerConnectionObject* obj, char* error[])
+    UNITY_INTERFACE_EXPORT unity::webrtc::SetSessionDescriptionObserver*
+    PeerConnectionSetLocalDescriptionWithoutDescription(
+        Context* context, PeerConnectionObject* obj, RTCErrorType* errorType, char* error[])
     {
         std::string error_;
-        RTCErrorType errorType =
-            obj->SetLocalDescriptionWithoutDescription(context->GetObserver(obj->connection), error_);
+        auto observer = unity::webrtc::SetSessionDescriptionObserver::Create(obj);
+        *errorType = obj->SetLocalDescriptionWithoutDescription(context->GetObserver(obj->connection), error_);
         *error = ConvertString(error_);
-        return errorType;
+        return observer.get();
     }
 
-    UNITY_INTERFACE_EXPORT RTCErrorType PeerConnectionSetRemoteDescription(
-        Context* context, PeerConnectionObject* obj, const RTCSessionDescription* desc, char* error[])
+    UNITY_INTERFACE_EXPORT unity::webrtc::SetSessionDescriptionObserver* PeerConnectionSetRemoteDescription(
+        Context* context,
+        PeerConnectionObject* obj,
+        const RTCSessionDescription* desc,
+        RTCErrorType* errorType,
+        char* error[])
     {
         std::string error_;
-        RTCErrorType errorType = obj->SetRemoteDescription(*desc, context->GetObserver(obj->connection), error_);
+        auto observer = unity::webrtc::SetSessionDescriptionObserver::Create(obj);
+        *errorType = obj->SetRemoteDescription(*desc, observer, error_);
         *error = ConvertString(error_);
-        return errorType;
+        return observer.get();
     }
 
     UNITY_INTERFACE_EXPORT bool
@@ -879,10 +879,9 @@ extern "C"
         obj->RegisterIceCandidate(callback);
     }
 
-    UNITY_INTERFACE_EXPORT void
-    PeerConnectionRegisterCallbackCollectStats(Context* context, DelegateCollectStats onGetStats)
+    UNITY_INTERFACE_EXPORT void StatsCollectorRegisterCallback(DelegateCollectStats callback)
     {
-        PeerConnectionStatsCollectorCallback::RegisterOnGetStats(onGetStats);
+        PeerConnectionStatsCollectorCallback::RegisterOnGetStats(callback);
     }
 
     UNITY_INTERFACE_EXPORT void PeerConnectionRegisterCallbackCreateSD(
@@ -891,16 +890,9 @@ extern "C"
         obj->RegisterCallbackCreateSD(onSuccess, onFailure);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionRegisterOnSetSessionDescSuccess(
-        Context* context, PeerConnectionObject* obj, DelegateSetSessionDescSuccess onSuccess)
+    UNITY_INTERFACE_EXPORT void SetSessionDescriptionObserverRegisterCallback(DelegateSetSessionDesc callback)
     {
-        context->GetObserver(obj->connection)->RegisterDelegateOnSuccess(onSuccess);
-    }
-
-    UNITY_INTERFACE_EXPORT void PeerConnectionRegisterOnSetSessionDescFailure(
-        Context* context, PeerConnectionObject* obj, DelegateSetSessionDescFailure onFailure)
-    {
-        context->GetObserver(obj->connection)->RegisterDelegateOnFailure(onFailure);
+        unity::webrtc::SetSessionDescriptionObserver::RegisterCallback(callback);
     }
 
     UNITY_INTERFACE_EXPORT bool

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -24,8 +24,6 @@ namespace webrtc
     using DelegateSetResolution = void (*)(int32_t*, int32_t*);
     using DelegateMediaStreamOnAddTrack = void (*)(MediaStreamInterface*, MediaStreamTrackInterface*);
     using DelegateMediaStreamOnRemoveTrack = void (*)(MediaStreamInterface*, MediaStreamTrackInterface*);
-    using DelegateSetSessionDescSuccess = void (*)(PeerConnectionObject*);
-    using DelegateSetSessionDescFailure = void (*)(PeerConnectionObject*, RTCErrorType, const char*);
     using DelegateVideoFrameResize = void (*)(UnityVideoRenderer* renderer, int width, int height);
 
     void debugLog(const char* buf);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -89,38 +89,6 @@ namespace Unity.WebRTC
             NativeMethods.ContextDeletePeerConnection(self, ptr);
         }
 
-        public SetSessionDescriptionObserver PeerConnectionSetLocalDescription(
-            IntPtr ptr, ref RTCSessionDescription desc, out RTCError error)
-        {
-            IntPtr ptrError = IntPtr.Zero;
-            SetSessionDescriptionObserver observer =
-                NativeMethods.PeerConnectionSetLocalDescription(self, ptr, ref desc, out var errorType, ref ptrError);
-            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            error = new RTCError { errorType = errorType, message = message };
-            return observer;
-        }
-
-        public SetSessionDescriptionObserver PeerConnectionSetLocalDescription(IntPtr ptr, out RTCError error)
-        {
-            IntPtr ptrError = IntPtr.Zero;
-            SetSessionDescriptionObserver observer =
-                NativeMethods.PeerConnectionSetLocalDescriptionWithoutDescription(self, ptr, out var errorType, ref ptrError);
-            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            error = new RTCError { errorType = errorType, message = message };
-            return observer;
-        }
-
-        public SetSessionDescriptionObserver PeerConnectionSetRemoteDescription(
-            IntPtr ptr, ref RTCSessionDescription desc, out RTCError error)
-        {
-            IntPtr ptrError = IntPtr.Zero;
-            SetSessionDescriptionObserver observer =
-                NativeMethods.PeerConnectionSetRemoteDescription(self, ptr, ref desc, out var errorType, ref ptrError);
-            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            error = new RTCError { errorType = errorType, message = message };
-            return observer;
-        }
-
         public IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length)
         {
             return NativeMethods.PeerConnectionGetReceivers(self, ptr, out length);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -89,43 +89,36 @@ namespace Unity.WebRTC
             NativeMethods.ContextDeletePeerConnection(self, ptr);
         }
 
-        public RTCError PeerConnectionSetLocalDescription(
-            IntPtr ptr, ref RTCSessionDescription desc)
+        public SetSessionDescriptionObserver PeerConnectionSetLocalDescription(
+            IntPtr ptr, ref RTCSessionDescription desc, out RTCError error)
         {
             IntPtr ptrError = IntPtr.Zero;
-            RTCErrorType errorType = NativeMethods.PeerConnectionSetLocalDescription(
-                self, ptr, ref desc, ref ptrError);
+            SetSessionDescriptionObserver observer =
+                NativeMethods.PeerConnectionSetLocalDescription(self, ptr, ref desc, out var errorType, ref ptrError);
             string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            return new RTCError { errorType = errorType, message = message };
+            error = new RTCError { errorType = errorType, message = message };
+            return observer;
         }
 
-        public RTCError PeerConnectionSetLocalDescription(IntPtr ptr)
+        public SetSessionDescriptionObserver PeerConnectionSetLocalDescription(IntPtr ptr, out RTCError error)
         {
             IntPtr ptrError = IntPtr.Zero;
-            RTCErrorType errorType =
-                NativeMethods.PeerConnectionSetLocalDescriptionWithoutDescription(self, ptr, ref ptrError);
+            SetSessionDescriptionObserver observer =
+                NativeMethods.PeerConnectionSetLocalDescriptionWithoutDescription(self, ptr, out var errorType, ref ptrError);
             string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            return new RTCError { errorType = errorType, message = message };
+            error = new RTCError { errorType = errorType, message = message };
+            return observer;
         }
 
-        public RTCError PeerConnectionSetRemoteDescription(
-            IntPtr ptr, ref RTCSessionDescription desc)
+        public SetSessionDescriptionObserver PeerConnectionSetRemoteDescription(
+            IntPtr ptr, ref RTCSessionDescription desc, out RTCError error)
         {
             IntPtr ptrError = IntPtr.Zero;
-            RTCErrorType errorType = NativeMethods.PeerConnectionSetRemoteDescription(
-                self, ptr, ref desc, ref ptrError);
+            SetSessionDescriptionObserver observer =
+                NativeMethods.PeerConnectionSetRemoteDescription(self, ptr, ref desc, out var errorType, ref ptrError);
             string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
-            return new RTCError { errorType = errorType, message = message };
-        }
-
-        public void PeerConnectionRegisterOnSetSessionDescSuccess(IntPtr ptr, DelegateNativePeerConnectionSetSessionDescSuccess callback)
-        {
-            NativeMethods.PeerConnectionRegisterOnSetSessionDescSuccess(self, ptr, callback);
-        }
-
-        public void PeerConnectionRegisterOnSetSessionDescFailure(IntPtr ptr, DelegateNativePeerConnectionSetSessionDescFailure callback)
-        {
-            NativeMethods.PeerConnectionRegisterOnSetSessionDescFailure(self, ptr, callback);
+            error = new RTCError { errorType = errorType, message = message };
+            return observer;
         }
 
         public IntPtr PeerConnectionGetReceivers(IntPtr ptr, out ulong length)

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -704,7 +704,7 @@ namespace Unity.WebRTC
                 throw new ArgumentException("sdp is null or empty");
 
             SetSessionDescriptionObserver observer =
-                WebRTC.Context.PeerConnectionSetLocalDescription(GetSelfOrThrow(), ref desc, out var error);
+                PeerConnectionSetLocalDescription(GetSelfOrThrow(), ref desc, out var error);
             return SetDescription(observer, error);
         }
 
@@ -715,7 +715,7 @@ namespace Unity.WebRTC
         public RTCSetSessionDescriptionAsyncOperation SetLocalDescription()
         {
             SetSessionDescriptionObserver observer =
-                WebRTC.Context.PeerConnectionSetLocalDescription(GetSelfOrThrow(), out var error);
+                PeerConnectionSetLocalDescription(GetSelfOrThrow(), out var error);
             return SetDescription(observer, error);
         }
 
@@ -744,7 +744,7 @@ namespace Unity.WebRTC
                 throw new ArgumentException("sdp is null or empty");
 
             SetSessionDescriptionObserver observer =
-                WebRTC.Context.PeerConnectionSetRemoteDescription(GetSelfOrThrow(), ref desc, out var error);
+                PeerConnectionSetRemoteDescription(GetSelfOrThrow(), ref desc, out var error);
             return SetDescription(observer, error);
         }
 
@@ -933,6 +933,38 @@ namespace Unity.WebRTC
         internal void RemoveObserver(SetSessionDescriptionObserver observer)
         {
             dictSetSessionDescriptionObserver.Remove(observer.DangerousGetHandle());
+        }
+
+        static SetSessionDescriptionObserver PeerConnectionSetLocalDescription(
+            IntPtr ptr, ref RTCSessionDescription desc, out RTCError error)
+        {
+            IntPtr ptrError = IntPtr.Zero;
+            SetSessionDescriptionObserver observer =
+                NativeMethods.PeerConnectionSetLocalDescription(ptr, ref desc, out var errorType, ref ptrError);
+            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
+            error = new RTCError { errorType = errorType, message = message };
+            return observer;
+        }
+
+        static SetSessionDescriptionObserver PeerConnectionSetLocalDescription(IntPtr ptr, out RTCError error)
+        {
+            IntPtr ptrError = IntPtr.Zero;
+            SetSessionDescriptionObserver observer =
+                NativeMethods.PeerConnectionSetLocalDescriptionWithoutDescription(ptr, out var errorType, ref ptrError);
+            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
+            error = new RTCError { errorType = errorType, message = message };
+            return observer;
+        }
+
+        static SetSessionDescriptionObserver PeerConnectionSetRemoteDescription(
+            IntPtr ptr, ref RTCSessionDescription desc, out RTCError error)
+        {
+            IntPtr ptrError = IntPtr.Zero;
+            SetSessionDescriptionObserver observer =
+                NativeMethods.PeerConnectionSetRemoteDescription(ptr, ref desc, out var errorType, ref ptrError);
+            string message = ptrError != IntPtr.Zero ? ptrError.AsAnsiStringWithFreeMem() : null;
+            error = new RTCError { errorType = errorType, message = message };
+            return observer;
         }
 
         static IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init)

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -486,7 +486,6 @@ namespace Unity.WebRTC
         void InitCallback()
         {
             NativeMethods.PeerConnectionRegisterCallbackCreateSD(self, OnSuccessCreateSessionDesc, OnFailureCreateSessionDesc);
-            NativeMethods.PeerConnectionRegisterCallbackCollectStats(self, OnStatsDeliveredCallback);
             NativeMethods.PeerConnectionRegisterIceConnectionChange(self, PCOnIceConnectionChange);
             NativeMethods.PeerConnectionRegisterConnectionStateChange(self, PCOnConnectionStateChange);
             NativeMethods.PeerConnectionRegisterIceGatheringChange(self, PCOnIceGatheringChange);
@@ -495,10 +494,6 @@ namespace Unity.WebRTC
             NativeMethods.PeerConnectionRegisterOnRenegotiationNeeded(self, PCOnNegotiationNeeded);
             NativeMethods.PeerConnectionRegisterOnTrack(self, PCOnTrack);
             NativeMethods.PeerConnectionRegisterOnRemoveTrack(self, PCOnRemoveTrack);
-            WebRTC.Context.PeerConnectionRegisterOnSetSessionDescSuccess(
-                self, OnSetSessionDescSuccess);
-            WebRTC.Context.PeerConnectionRegisterOnSetSessionDescFailure(
-                self, OnSetSessionDescFailure);
         }
 
         /// <summary>
@@ -933,28 +928,9 @@ namespace Unity.WebRTC
             dictCollectStatsCallback.Remove(callback.DangerousGetHandle());
         }
 
-        SetSessionDescriptionObserver FindObserver(IntPtr ptr)
-        {
-            return dictSetSessionDescriptionObserver[ptr];
-        }
-
         internal void RemoveObserver(SetSessionDescriptionObserver observer)
         {
             dictSetSessionDescriptionObserver.Remove(observer.DangerousGetHandle());
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(DelegateCollectStats))]
-        static void OnStatsDeliveredCallback(IntPtr ptr, IntPtr ptrCallback, IntPtr report)
-        {
-            WebRTC.Sync(ptr, () =>
-            {
-                if (WebRTC.Table[ptr] is RTCPeerConnection connection)
-                {
-                    RTCStatsCollectorCallback callback = connection.FindCollectStatsCallback(ptrCallback);
-                    connection.RemoveCollectStatsCallback(callback);
-                    callback.Invoke(report);
-                }
-            });
         }
 
         static IntPtr PeerConnectionAddTransceiver(IntPtr pc, IntPtr track, RTCRtpTransceiverInit init)

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -705,10 +705,7 @@ namespace Unity.WebRTC
 
             SetSessionDescriptionObserver observer =
                 WebRTC.Context.PeerConnectionSetLocalDescription(GetSelfOrThrow(), ref desc, out var error);
-            dictSetSessionDescriptionObserver.Add(observer.DangerousGetHandle(), observer);
-            if (error.errorType != RTCErrorType.None)
-                throw new RTCErrorException(ref error);
-            return new RTCSetSessionDescriptionAsyncOperation(observer);
+            return SetDescription(observer, error);
         }
 
         /// <summary>
@@ -719,10 +716,7 @@ namespace Unity.WebRTC
         {
             SetSessionDescriptionObserver observer =
                 WebRTC.Context.PeerConnectionSetLocalDescription(GetSelfOrThrow(), out var error);
-            dictSetSessionDescriptionObserver.Add(observer.DangerousGetHandle(), observer);
-            if (error.errorType != RTCErrorType.None)
-                throw new RTCErrorException(ref error);
-            return new RTCSetSessionDescriptionAsyncOperation(observer);
+            return SetDescription(observer, error);
         }
 
         /// <summary>
@@ -751,10 +745,7 @@ namespace Unity.WebRTC
 
             SetSessionDescriptionObserver observer =
                 WebRTC.Context.PeerConnectionSetRemoteDescription(GetSelfOrThrow(), ref desc, out var error);
-            dictSetSessionDescriptionObserver.Add(observer.DangerousGetHandle(), observer);
-            if (error.errorType != RTCErrorType.None)
-                throw new RTCErrorException(ref error);
-            return new RTCSetSessionDescriptionAsyncOperation(observer);
+            return SetDescription(observer, error);
         }
 
         /// <summary>
@@ -908,6 +899,17 @@ namespace Unity.WebRTC
         internal SetSessionDescriptionObserver FindObserver(IntPtr ptr)
         {
             return dictSetSessionDescriptionObserver[ptr];
+        }
+
+        RTCSetSessionDescriptionAsyncOperation SetDescription(SetSessionDescriptionObserver observer, RTCError error)
+        {
+            if (error.errorType != RTCErrorType.None)
+                throw new RTCErrorException(ref error);
+
+            IntPtr ptr = observer.DangerousGetHandle();
+            if (!dictSetSessionDescriptionObserver.ContainsKey(ptr))
+                dictSetSessionDescriptionObserver.Add(ptr, observer);
+            return new RTCSetSessionDescriptionAsyncOperation(observer);
         }
 
         Dictionary<IntPtr, RTCStatsCollectorCallback> dictCollectStatsCallback = new Dictionary<IntPtr, RTCStatsCollectorCallback>();

--- a/Runtime/Scripts/SetSessionDescriptionObserver.cs
+++ b/Runtime/Scripts/SetSessionDescriptionObserver.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Unity.WebRTC
+{
+    class SetSessionDescriptionObserver : SafeHandle
+    {
+        public Action<RTCErrorType, string> onSetSessionDescription;
+
+        private SetSessionDescriptionObserver()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public void Invoke(RTCErrorType type, string message)
+        {
+            onSetSessionDescription?.Invoke(type, message);
+        }
+
+        public override bool IsInvalid { get { return handle == IntPtr.Zero; } }
+
+        protected override bool ReleaseHandle()
+        {
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/SetSessionDescriptionObserver.cs
+++ b/Runtime/Scripts/SetSessionDescriptionObserver.cs
@@ -21,6 +21,7 @@ namespace Unity.WebRTC
 
         protected override bool ReleaseHandle()
         {
+            onSetSessionDescription = null;
             return true;
         }
     }

--- a/Runtime/Scripts/SetSessionDescriptionObserver.cs.meta
+++ b/Runtime/Scripts/SetSessionDescriptionObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ddf8535c4d087b4085b78763a602cb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/WebRTC.AsyncOperation.cs
+++ b/Runtime/Scripts/WebRTC.AsyncOperation.cs
@@ -86,19 +86,16 @@ namespace Unity.WebRTC
     /// </summary>
     public class RTCSetSessionDescriptionAsyncOperation : AsyncOperationBase
     {
-        internal RTCSetSessionDescriptionAsyncOperation(RTCPeerConnection connection)
+        internal RTCSetSessionDescriptionAsyncOperation(SetSessionDescriptionObserver observer)
         {
-            connection.OnSetSessionDescriptionSuccess = () =>
-            {
-                IsError = false;
-                this.Done();
-            };
-            connection.OnSetSessionDescriptionFailure = (error) =>
-            {
-                IsError = true;
-                Error = error;
-                this.Done();
-            };
+            observer.onSetSessionDescription = OnSetSessionDescription;
+        }
+
+        void OnSetSessionDescription(RTCErrorType errorType, string error)
+        {
+            IsError = errorType != RTCErrorType.None;
+            Error = new RTCError() { errorType = errorType, message = error };
+            this.Done();
         }
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1055,13 +1055,16 @@ namespace Unity.WebRTC
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeSetSessionDesc))]
         static void OnSetSessionDesc(IntPtr ptr, IntPtr ptrObserver, RTCErrorType type, string message)
         {
-            WebRTC.Sync(ptr, () =>
+            Sync(ptr, () =>
             {
-                if (WebRTC.Table[ptr] is RTCPeerConnection connection)
+                if (Table[ptr] is RTCPeerConnection connection)
                 {
                     var observer = connection.FindObserver(ptrObserver);
+                    if (observer == null)
+                        return;
                     connection.RemoveObserver(observer);
                     observer.Invoke(type, message);
+                    observer.Dispose();
                 }
             });
         }
@@ -1069,10 +1072,10 @@ namespace Unity.WebRTC
         [AOT.MonoPInvokeCallback(typeof(DelegateCollectStats))]
         static void OnCollectStatsCallback(IntPtr ptr, IntPtr ptrCallback, IntPtr ptrReport)
         {
-            WebRTC.Sync(ptr, () =>
+            Sync(ptr, () =>
             {
                 RTCStatsReport report = WebRTC.FindOrCreate(ptrReport, ptr_ => new RTCStatsReport(ptr_));
-                if (WebRTC.Table[ptr] is RTCPeerConnection connection)
+                if (Table[ptr] is RTCPeerConnection connection)
                 {
                     RTCStatsCollectorCallback callback = connection.FindCollectStatsCallback(ptrCallback);
                     if (callback == null)
@@ -1083,7 +1086,6 @@ namespace Unity.WebRTC
                 }
             });
         }
-
 
         internal static Context Context { get { return s_context; } }
         internal static WeakReferenceTable Table { get { return s_context?.table; } }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1224,11 +1224,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void PeerConnectionRegisterOnIceCandidate(IntPtr ptr, DelegateNativeOnIceCandidate callback);
         [DllImport(WebRTC.Lib)]
-        public static extern SetSessionDescriptionObserver PeerConnectionSetLocalDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc, out RTCErrorType errorType, ref IntPtr error);
+        public static extern SetSessionDescriptionObserver PeerConnectionSetLocalDescription(IntPtr ptr, ref RTCSessionDescription desc, out RTCErrorType errorType, ref IntPtr error);
         [DllImport(WebRTC.Lib)]
-        public static extern SetSessionDescriptionObserver PeerConnectionSetLocalDescriptionWithoutDescription(IntPtr context, IntPtr ptr, out RTCErrorType errorType, ref IntPtr error);
+        public static extern SetSessionDescriptionObserver PeerConnectionSetLocalDescriptionWithoutDescription(IntPtr ptr, out RTCErrorType errorType, ref IntPtr error);
         [DllImport(WebRTC.Lib)]
-        public static extern SetSessionDescriptionObserver PeerConnectionSetRemoteDescription(IntPtr context, IntPtr ptr, ref RTCSessionDescription desc, out RTCErrorType errorType, ref IntPtr error);
+        public static extern SetSessionDescriptionObserver PeerConnectionSetRemoteDescription(IntPtr ptr, ref RTCSessionDescription desc, out RTCErrorType errorType, ref IntPtr error);
         [DllImport(WebRTC.Lib)]
         public static extern RTCStatsCollectorCallback PeerConnectionGetStats(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -89,7 +89,6 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        [Category("Context")]
         public void DeleteStatsReportIgnoreInvalidValue()
         {
             var context = Context.Create();

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -63,28 +63,6 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.ContextDestroy(0);
         }
 
-        [AOT.MonoPInvokeCallback(typeof(DelegateNativePeerConnectionSetSessionDescSuccess))]
-        static void PeerConnectionSetSessionDescSuccess(IntPtr connection)
-        {
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(DelegateNativePeerConnectionSetSessionDescFailure))]
-        static void PeerConnectionSetSessionDescFailure(IntPtr connection, RTCErrorType type, string message)
-        {
-        }
-
-        [Test]
-        public void RegisterDelegateToPeerConnection()
-        {
-            var context = NativeMethods.ContextCreate(0);
-            var connection = NativeMethods.ContextCreatePeerConnection(context);
-
-            NativeMethods.PeerConnectionRegisterOnSetSessionDescSuccess(context, connection, PeerConnectionSetSessionDescSuccess);
-            NativeMethods.PeerConnectionRegisterOnSetSessionDescFailure(context, connection, PeerConnectionSetSessionDescFailure);
-            NativeMethods.ContextDeletePeerConnection(context, connection);
-            NativeMethods.ContextDestroy(0);
-        }
-
         // todo(kazuki):: crash on iOS device
         [Test]
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -622,6 +622,56 @@ namespace Unity.WebRTC.RuntimeTest
             peer2.Dispose();
         }
 
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator SetDescriptionInParallel()
+        {
+            RTCConfiguration config = default;
+            config.iceServers = new[] { new RTCIceServer { urls = new[] { "stun:stun.l.google.com:19302" } } };
+            var peer1 = new RTCPeerConnection(ref config);
+            var peer2 = new RTCPeerConnection(ref config);
+
+            var neededNegotiationPeer1 = false;
+            var neededNegotiationPeer2 = false;
+            peer1.OnIceCandidate = candidate => { peer2.AddIceCandidate(candidate); };
+            peer2.OnIceCandidate = candidate => { peer1.AddIceCandidate(candidate); };
+            peer1.OnNegotiationNeeded += () => neededNegotiationPeer1 = true;
+            peer2.OnNegotiationNeeded += () => neededNegotiationPeer2 = true;
+
+            peer1.AddTransceiver(TrackKind.Audio);
+
+            yield return new WaitUntil(() => neededNegotiationPeer1);
+
+            var op1 = peer1.SetLocalDescription();
+            yield return op1;
+            RTCSessionDescription desc = peer1.LocalDescription;
+            Assert.That(desc.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(peer1.SignalingState, Is.EqualTo(RTCSignalingState.HaveLocalOffer));
+
+            peer2.AddTransceiver(TrackKind.Audio);
+            yield return new WaitUntil(() => neededNegotiationPeer2);
+
+            var op2 = peer2.SetLocalDescription();
+            var op3 = peer2.SetRemoteDescription(ref desc);
+
+            yield return op2;
+            yield return op3;
+            Assert.That(peer2.RemoteDescription.type, Is.EqualTo(RTCSdpType.Offer));
+            Assert.That(peer2.SignalingState, Is.EqualTo(RTCSignalingState.HaveRemoteOffer));
+
+            var op4 = peer2.SetLocalDescription();
+            yield return op4;
+            desc = peer2.LocalDescription;
+            Assert.That(desc.type, Is.EqualTo(RTCSdpType.Answer));
+            Assert.That(peer2.SignalingState, Is.EqualTo(RTCSignalingState.Stable));
+
+            var op5 = peer1.SetRemoteDescription(ref desc);
+            yield return op5;
+
+            peer1.Close();
+            peer2.Close();
+        }
+
         [Test]
         public void SetRemoteDescriptionThrowException()
         {


### PR DESCRIPTION
This pull request fixes the bug that the coroutine of `RTCPeerConnection.SetLocalDescription` and `RTCPeerConnection.SetRemoteDescription` doesn't complete sometimes.

This issue would be occurred when calling methods above multiple times at the same time.