### PR TITLE
fix: Exclude unit-tests for macOS plattform with OpenGL

### DIFF
--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -206,7 +206,7 @@ verificationtest_{{ id }}_{{ editor.version }}:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor.version }} -c editor --fast --wait
     # run utr
-    - utr.bat --suite={{ test.suite }} --editor-location=".Editor" --testproject="WebRTC~" --reruncount=2 --timeout=3600
+    - utr --suite={{ test.suite }} --editor-location=.Editor --testproject=./WebRTC~ --reruncount=2 --timeout=3600
 {% elsif platform.group == "ios" %}
     #install utr
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr; chmod a+x ./utr

--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -207,6 +207,7 @@ verificationtest_{{ id }}_{{ editor.version }}:
     - unity-downloader-cli -u {{ editor.version }} -c editor --fast --wait
     # run utr
     - git config --local core.symlinks true
+    - git checkout -f --detach FETCH_HEAD
     - utr --suite={{ test.suite }} --editor-location=.Editor --testproject=./WebRTC~ --reruncount=2 --timeout=3600
 {% elsif platform.group == "ios" %}
     #install utr

--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -206,6 +206,7 @@ verificationtest_{{ id }}_{{ editor.version }}:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor.version }} -c editor --fast --wait
     # run utr
+    - git config --local core.symlinks true
     - utr --suite={{ test.suite }} --editor-location=.Editor --testproject=./WebRTC~ --reruncount=2 --timeout=3600
 {% elsif platform.group == "ios" %}
     #install utr

--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -207,7 +207,7 @@ verificationtest_{{ id }}_{{ editor.version }}:
     - unity-downloader-cli -u {{ editor.version }} -c editor --fast --wait
     # run utr
     - git config --local core.symlinks true
-    - git checkout -f --detach FETCH_HEAD
+    - gsudo git checkout -f --detach FETCH_HEAD
     - utr --suite={{ test.suite }} --editor-location=.Editor --testproject=./WebRTC~ --reruncount=2 --timeout=3600
 {% elsif platform.group == "ios" %}
     #install utr

--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -206,7 +206,7 @@ verificationtest_{{ id }}_{{ editor.version }}:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor.version }} -c editor --fast --wait
     # run utr
-    - utr.bat --suite={{ test.suite }} --editor-location=.Editor --testproject=C:\build\output\Unity-Technologies\com.unity.webrtc\WebRTC~ --reruncount=2 --timeout=3600
+    - utr.bat --suite={{ test.suite }} --editor-location=".Editor" --testproject="WebRTC~" --reruncount=2 --timeout=3600
 {% elsif platform.group == "ios" %}
     #install utr
     - curl -s https://artifactory.prd.it.unity3d.com/artifactory/unity-tools/utr-standalone/utr --output utr; chmod a+x ./utr

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
@@ -59,8 +59,8 @@ namespace webrtc
 
 #if CUDA_PLATFORM
         bool IsCudaSupport() override { return false; }
-        CUcontext GetCUcontext() { return 0; }
-        NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() { return NV_ENC_BUFFER_FORMAT_UNDEFINED; }
+        CUcontext GetCUcontext() override { return 0; }
+        NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_UNDEFINED; }
 #endif
     };
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 
-#include "GraphicsDevice.h"
 #include "GpuMemoryBuffer.h"
+#include "GraphicsDevice.h"
 
 #if SUPPORT_D3D11 && SUPPORT_D3D12
 #include "D3D11/D3D11GraphicsDevice.h"
@@ -39,33 +39,74 @@ namespace webrtc
         ITexture2D*
         CreateDefaultTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) override
         {
+            RTC_NOTREACHED();
             return nullptr;
         }
-        void* GetEncodeDevicePtrV() override { return nullptr; }
-        bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override { return true; }
-        bool CopyResourceFromNativeV(ITexture2D* dest, NativeTexPtr nativeTexturePtr) override { return true; }
+        void* GetEncodeDevicePtrV() override
+        {
+            RTC_NOTREACHED();
+            return nullptr;
+        }
+        bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override
+        {
+            RTC_NOTREACHED();
+            return true;
+        }
+        bool CopyResourceFromNativeV(ITexture2D* dest, NativeTexPtr nativeTexturePtr) override
+        {
+            RTC_NOTREACHED();
+            return true;
+        }
         UnityGfxRenderer GetGfxRenderer() const override { return m_gfxRenderer; }
-        std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override { return nullptr; }
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override { return true; }
-        bool ResetSync(const ITexture2D* texture) override { return true; }
-        bool WaitIdleForTest() override { return true; }
+        std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override
+        {
+            RTC_NOTREACHED();
+            return nullptr;
+        }
+        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override
+        {
+            RTC_NOTREACHED();
+            return true;
+        }
+        bool ResetSync(const ITexture2D* texture) override
+        {
+            RTC_NOTREACHED();
+            return true;
+        }
+        bool WaitIdleForTest() override
+        {
+            RTC_NOTREACHED();
+            return true;
+        }
         // Required for software encoding
         ITexture2D*
         CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) override
         {
+            RTC_NOTREACHED();
             return nullptr;
         }
-        rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override { return nullptr; }
+        rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override
+        {
+            RTC_NOTREACHED();
+            return nullptr;
+        }
 
 #if CUDA_PLATFORM
         bool IsCudaSupport() override { return false; }
-        CUcontext GetCUcontext() override { return 0; }
-        NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_UNDEFINED; }
+        CUcontext GetCUcontext() override
+        {
+            RTC_NOTREACHED();
+            return 0;
+        }
+        NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override
+        {
+            RTC_NOTREACHED();
+            return NV_ENC_BUFFER_FORMAT_UNDEFINED;
+        }
 #endif
     };
 
-    GraphicsDevice&
-    GraphicsDevice::GetInstance()
+    GraphicsDevice& GraphicsDevice::GetInstance()
     {
         static GraphicsDevice device;
         return device;

--- a/Plugin~/WebRTCPlugin/PlatformBase.h
+++ b/Plugin~/WebRTCPlugin/PlatformBase.h
@@ -50,7 +50,7 @@
 #define SUPPORT_D3D11 1 // comment this out if you don't have D3D11 header/library files
 #define SUPPORT_D3D12 1 // comment this out if you don't have D3D12 header/library files
 #define SUPPORT_OPENGL_UNIFIED 1
-#define SUPPORT_OPENGL_CORE 1
+// #define SUPPORT_OPENGL_CORE 1
 #define SUPPORT_VULKAN 1 // Requires Vulkan SDK to be installed
 #elif UNITY_ANDROID
 #ifndef SUPPORT_OPENGL_ES
@@ -62,9 +62,6 @@
 #define SUPPORT_OPENGL_UNIFIED 1
 #define SUPPORT_OPENGL_CORE 1
 #define SUPPORT_VULKAN 1
-#elif UNITY_OSX
-#define SUPPORT_OPENGL_UNIFIED 1
-#define SUPPORT_OPENGL_CORE 1
 #endif
 
 #if UNITY_IOS || UNITY_OSX || UNITY_IOS_SIMULATOR

--- a/Plugin~/WebRTCPlugin/PlatformBase.h
+++ b/Plugin~/WebRTCPlugin/PlatformBase.h
@@ -50,9 +50,8 @@
 #define SUPPORT_D3D11 1 // comment this out if you don't have D3D11 header/library files
 #define SUPPORT_D3D12 1 // comment this out if you don't have D3D12 header/library files
 #define SUPPORT_OPENGL_UNIFIED 1
-// #define SUPPORT_OPENGL_CORE 1
+#define SUPPORT_OPENGL_CORE 1
 #define SUPPORT_VULKAN 1 // Requires Vulkan SDK to be installed
-#define SUPPORT_SOFTWARE_ENCODER 1
 #elif UNITY_ANDROID
 #ifndef SUPPORT_OPENGL_ES
 #define SUPPORT_OPENGL_ES 1
@@ -64,7 +63,8 @@
 #define SUPPORT_OPENGL_CORE 1
 #define SUPPORT_VULKAN 1
 #elif UNITY_OSX
-#define SUPPORT_SOFTWARE_ENCODER 1
+#define SUPPORT_OPENGL_UNIFIED 1
+#define SUPPORT_OPENGL_CORE 1
 #endif
 
 #if UNITY_IOS || UNITY_OSX || UNITY_IOS_SIMULATOR

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -665,26 +665,6 @@ namespace Unity.WebRTC
 #if UNITY_EDITOR
             UnityEditor.AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
 #endif
-            // OpenGL APIs on windows/osx are not supported
-            if (Application.platform == RuntimePlatform.WindowsEditor ||
-                Application.platform == RuntimePlatform.WindowsPlayer ||
-                Application.platform == RuntimePlatform.OSXEditor ||
-                Application.platform == RuntimePlatform.OSXPlayer)
-            {
-                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
-                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
-                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3)
-                {
-                    Debug.LogError($"Not Support OpenGL API on {Application.platform}.");
-#if UNITY_EDITOR
-                    UnityEditor.EditorApplication.isPlaying = false;
-                    return;
-#else
-                    throw new NotSupportedException($"Not Support OpenGL API on {Application.platform} in Unity WebRTC.");
-#endif
-                }
-            }
-
             NativeMethods.RegisterDebugLog(DebugLog, enableNativeLog, nativeLoggingSeverity);
 #if UNITY_IOS && !UNITY_EDITOR
             NativeMethods.RegisterRenderingWebRTCPlugin();

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -1,12 +1,20 @@
 using UnityEngine;
-using UnityEngine.Rendering;
 using UnityEngine.TestTools;
+using UnityEngine.Rendering;
 
 namespace Unity.WebRTC.RuntimeTest
 {
     internal class ConditionalIgnore
     {
+        /// <summary>
+        /// On Direct3D12 platform, CommandBuffer.IssuePluginCustomTextureUpdateV2 method doesn't work.
+        /// </summary>
         public const string UnsupportedPlatformVideoDecoder = "IgnoreUnsupportedPlatformVideoDecoder";
+
+        /// <summary>
+        /// On Windows and macOS platform, VideoStreamTrack class doesn't work.
+        /// </summary>
+        public const string UnsupportedPlatformOpenGL = "IgnoreUnsupportedPlatformOpenGL";
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static void OnLoad()
@@ -15,6 +23,14 @@ namespace Unity.WebRTC.RuntimeTest
             ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedPlatformVideoDecoder,
                 SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D12);
 #endif
+            ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedPlatformOpenGL,
+                (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
+                SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
+                SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3) &&
+                (Application.platform == RuntimePlatform.WindowsEditor ||
+                Application.platform == RuntimePlatform.WindowsPlayer ||
+                Application.platform == RuntimePlatform.OSXEditor ||
+                Application.platform == RuntimePlatform.OSXPlayer));
         }
     }
 }

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -1,9 +1,23 @@
+using System;
 using UnityEngine;
 using UnityEngine.TestTools;
+
+#if !UNITY_2020_1_OR_NEWER
 using UnityEngine.Rendering;
+#endif
 
 namespace Unity.WebRTC.RuntimeTest
 {
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    class ConditionalIgnoreMultipleAttribute : ConditionalIgnoreAttribute
+    {
+        public ConditionalIgnoreMultipleAttribute(string conditionKey, string ignoreReason)
+            : base(conditionKey, ignoreReason)
+        {
+        }
+    }
+
+
     internal class ConditionalIgnore
     {
         /// <summary>
@@ -24,13 +38,7 @@ namespace Unity.WebRTC.RuntimeTest
                 SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D12);
 #endif
             ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedPlatformOpenGL,
-                (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore ||
-                SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
-                SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3) &&
-                (Application.platform == RuntimePlatform.WindowsEditor ||
-                Application.platform == RuntimePlatform.WindowsPlayer ||
-                Application.platform == RuntimePlatform.OSXEditor ||
-                Application.platform == RuntimePlatform.OSXPlayer));
+                !VideoStreamTrack.IsSupported(Application.platform, SystemInfo.graphicsDeviceType));
         }
     }
 }

--- a/Tests/Runtime/ConditionalIgnore.cs
+++ b/Tests/Runtime/ConditionalIgnore.cs
@@ -30,9 +30,15 @@ namespace Unity.WebRTC.RuntimeTest
         /// </summary>
         public const string UnsupportedPlatformOpenGL = "IgnoreUnsupportedPlatformOpenGL";
 
+        static bool s_loaded = false;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static void OnLoad()
         {
+            if (s_loaded)
+                return;
+            s_loaded = true;
+
 #if !UNITY_2020_1_OR_NEWER
             ConditionalIgnoreAttribute.AddConditionalIgnoreMapping(UnsupportedPlatformVideoDecoder,
                 SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D12);

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -60,6 +60,7 @@ namespace Unity.WebRTC.RuntimeTest
         // todo(kazuki): Crash on Android and Linux standalone player
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.Android })]
         public IEnumerator VideoStreamAddTrackAndRemoveTrack()
         {
@@ -130,6 +131,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CameraCaptureStream()
         {
             var camObj = new GameObject("Camera");
@@ -151,6 +153,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CaptureStream()
         {
             var camObj = new GameObject("Camera");
@@ -393,6 +396,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(5000)]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator OnAddTrackDelegatesWithEvent()
         {
             var camObj = new GameObject("Camera");

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -180,6 +180,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator SenderGetStats()
         {
             if (SystemInfo.processorType == "Apple M1")
@@ -226,6 +227,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator ReceiverGetStats()
         {
             var camObj = new GameObject("Camera");
@@ -268,6 +270,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator SetParametersReturnNoError()
         {
             var camObj = new GameObject("Camera");
@@ -359,6 +362,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator AddAndRemoveTrack()
         {
             var camObj = new GameObject("Camera");

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -23,7 +23,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void Construct()
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
+        public void Constructor()
         {
             var width = 256;
             var height = 256;
@@ -37,6 +38,23 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        public void ConstructorThrowException()
+        {
+            if(VideoStreamTrack.IsSupported(Application.platform, SystemInfo.graphicsDeviceType))
+                Assert.Ignore();
+
+            var width = 256;
+            var height = 256;
+            var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
+            var rt = new RenderTexture(width, height, 0, format);
+            rt.Create();
+            Assert.That(() => { var track = new VideoStreamTrack(rt); }, Throws.TypeOf<NotSupportedException>());
+            Object.DestroyImmediate(rt);
+        }
+
+
+        [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void EqualIdWithAudioTrack()
         {
             var guid = Guid.NewGuid().ToString();
@@ -49,6 +67,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void EqualIdWithVideoTrack()
         {
             var guid = Guid.NewGuid().ToString();
@@ -61,6 +80,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void AccessAfterDisposed()
         {
             var width = 256;
@@ -76,6 +96,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void ConstructorThrowsExceptionWhenInvalidGraphicsFormat()
         {
             var width = 256;
@@ -90,6 +111,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [Test]
         [UnityPlatform(RuntimePlatform.Android)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void ConstructThrowsExceptionWhenSmallTexture()
         {
             var width = 50;
@@ -107,6 +129,8 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(5000)]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer })]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
+
         public IEnumerator VideoStreamTrackEnabled()
         {
             var width = 256;
@@ -143,6 +167,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest]
         [Timeout(5000)]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CaptureStreamTrack()
         {
             var camObj = new GameObject("Camera");
@@ -158,6 +183,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void CaptureStreamTrackThrowExeption()
         {
             var camObj = new GameObject("Camera");
@@ -190,6 +216,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void VideoStreamTrackDisposeImmediately()
         {
             var width = 256;
@@ -206,6 +233,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest, LongRunning]
         [Timeout(5000)]
         [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator VideoStreamTrackInstantiateMultiple()
         {
             var width = 256;

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -142,6 +142,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoTrack()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -159,6 +161,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoTrackToPeerConnection()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -186,6 +190,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public void SenderGetParameter()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -216,6 +222,8 @@ namespace Unity.WebRTC.RuntimeTest
         // todo(kazuki): Crash occurs when calling NativeMethods.MediaStreamRemoveTrack method on iOS device
         [Test]
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoTrackToMediaStream()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -316,6 +324,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoRendererToVideoTrack()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -369,6 +379,8 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest, LongRunning]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CallVideoEncoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);
@@ -415,8 +427,10 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [UnityTest, LongRunning]
-        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
+        [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoDecoderMethods.UpdateRendererTexture is not supported on Direct3D12.")]
+        [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CallVideoDecoderMethods()
         {
             var context = NativeMethods.ContextCreate(0);

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -313,6 +313,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void AddTransceiverWithKindAndInit()
         {
             var peer = new RTCPeerConnection();

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -196,6 +196,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void GetTransceiversReturnsNotEmptyAfterDisposingTransceiver()
         {
             // `RTCPeerConnection.AddTransceiver` method is not intuitive. Moreover, we don't have the API to remove

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -120,6 +120,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void AddTrack()
         {
             var peer = new RTCPeerConnection();
@@ -152,6 +153,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void AddTransceiver()
         {
             var peer = new RTCPeerConnection();
@@ -207,6 +209,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void GetTransceiversReturnsNotEmptyAfterCallingRemoveTrack()
         {
             // Also, `RTCPeerConnection.AddTrack` and `RTCPeerConnection.RemoveTrack` method is not intuitive.
@@ -255,6 +258,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void AddTransceiverTrackKindVideo()
         {
             var peer = new RTCPeerConnection();
@@ -276,6 +280,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void AddTransceiverWithInit()
         {
             var peer = new RTCPeerConnection();
@@ -952,6 +957,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator GetStatsReturnsReport()
         {
             if (SystemInfo.processorType == "Apple M1")

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -353,6 +353,7 @@ namespace Unity.WebRTC.RuntimeTest
 
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void GetAndSetDirectionTransceiver()
         {
             var peer = new RTCPeerConnection();

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -129,6 +129,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void ReceiverGetTrackReturnsVideoTrack()
         {
             var peer = new RTCPeerConnection();
@@ -175,6 +176,7 @@ namespace Unity.WebRTC.RuntimeTest
 
         [UnityTest]
         [Timeout(5000)]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator TransceiverStop()
         {
             if (SystemInfo.processorType == "Apple M1")

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -109,6 +109,7 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void TransceiverSetVideoCodecPreferences()
         {
             var peer = new RTCPeerConnection();

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -8,6 +8,7 @@ namespace Unity.WebRTC.RuntimeTest
 {
     [TestFixture]
     [UnityPlatform(exclude = new[] { RuntimePlatform.Android, RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxPlayer })]
+    [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
     class VideoReceiveTestWithH264Codec : VideoReceiveTestBase
     {
         protected override void SetUpCodecCapability()
@@ -20,6 +21,7 @@ namespace Unity.WebRTC.RuntimeTest
 
     [TestFixture]
     [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxPlayer })]
+    [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
     class VideoReceiveTestWithVP8Codec : VideoReceiveTestBase
     {
         protected override void SetUpCodecCapability()
@@ -80,8 +82,10 @@ namespace Unity.WebRTC.RuntimeTest
         // refer to https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/reference-tests-parameterized.html
         [UnityTest, LongRunning]
         [Timeout(15000)]
-        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
+        [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
             "VideoStreamTrack.UpdateReceiveTexture is not supported on Direct3D12")]
+        [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator VideoReceive([ValueSource(nameof(range))]int index)
         {
             if(SystemInfo.processorType == "Apple M1")

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -52,6 +52,8 @@ namespace Unity.WebRTC.RuntimeTest
 #if WEBRTC_TEST_PROJECT
         [Test]
         [UnityPlatform(exclude = new[] {RuntimePlatform.Android, RuntimePlatform.IPhonePlayer})]
+        [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformOpenGL,
+            "Not support VideoStreamTrack for OpenGL")]
         public void WebCamTextureFormat()
         {
             var webCam = new WebCamTexture(10, 10);

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -52,7 +52,7 @@ namespace Unity.WebRTC.RuntimeTest
 #if WEBRTC_TEST_PROJECT
         [Test]
         [UnityPlatform(exclude = new[] {RuntimePlatform.Android, RuntimePlatform.IPhonePlayer})]
-        [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformOpenGL,
+        [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL,
             "Not support VideoStreamTrack for OpenGL")]
         public void WebCamTextureFormat()
         {


### PR DESCRIPTION
This pull request changes the behaviour of WebRTC initialization when using OpenGL on macOS or Windows.

After the change, `WebRTC.Initialize` method doesn't throw `NotSupportedException` even if you use OpenGL on all platforms. Alternatively, the constructor of `VideoStreamTrack` throws exception when using OpenGL graphics type on macOS and Windows.

It will makes availale to use the package for audio or data streaming with no supported graphics device.