### PR TITLE
fix: Fix CreateOffer and CreateAnswer to execute in parallel

### DIFF
--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(WebRTCLib
   PRIVATE
     Context.cpp
     Context.h
+    CreateSessionDescriptionObserver.cpp
+    CreateSessionDescriptionObserver.h
     DataChannelObject.cpp
     DataChannelObject.h
     DummyAudioDevice.cpp

--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -159,7 +159,7 @@ namespace webrtc
         rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> m_peerConnectionFactory;
         rtc::scoped_refptr<DummyAudioDevice> m_audioDevice;
         std::vector<rtc::scoped_refptr<const webrtc::RTCStatsReport>> m_listStatsReport;
-        std::map<const PeerConnectionObject*, rtc::scoped_refptr<PeerConnectionObject>> m_mapClients;
+        std::map<const PeerConnectionObject*, std::unique_ptr<PeerConnectionObject>> m_mapClients;
         std::map<const webrtc::MediaStreamInterface*, std::unique_ptr<MediaStreamObserver>> m_mapMediaStreamObserver;
         std::map<const DataChannelInterface*, std::unique_ptr<DataChannelObject>> m_mapDataChannels;
         std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> m_mapVideoRenderer;
@@ -171,8 +171,5 @@ namespace webrtc
     };
 
     extern bool Convert(const std::string& str, webrtc::PeerConnectionInterface::RTCConfiguration& config);
-    extern webrtc::SdpType ConvertSdpType(RTCSdpType type);
-    extern RTCSdpType ConvertSdpType(webrtc::SdpType type);
-
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/CreateSessionDescriptionObserver.cpp
+++ b/Plugin~/WebRTCPlugin/CreateSessionDescriptionObserver.cpp
@@ -1,0 +1,37 @@
+#include "pch.h"
+
+#include "PeerConnectionObject.h"
+#include "CreateSessionDescriptionObserver.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    DelegateCreateSessionDesc CreateSessionDescriptionObserver::s_createSessionDescCallback = nullptr;
+
+    rtc::scoped_refptr<CreateSessionDescriptionObserver>
+    CreateSessionDescriptionObserver::Create(PeerConnectionObject* connection)
+    {
+        return new rtc::RefCountedObject<CreateSessionDescriptionObserver>(connection);
+    }
+
+    CreateSessionDescriptionObserver::CreateSessionDescriptionObserver(PeerConnectionObject* connection)
+    {
+        m_connection = connection;
+    }
+
+    void CreateSessionDescriptionObserver::OnSuccess(SessionDescriptionInterface* desc)
+    {
+        std::string out;
+        desc->ToString(&out);
+        const auto sdpType = ConvertSdpType(desc->GetType());
+        s_createSessionDescCallback(m_connection, this, sdpType, out.c_str(), RTCErrorType::NONE, nullptr);
+    }
+
+    void CreateSessionDescriptionObserver::OnFailure(webrtc::RTCError error)
+    {
+        s_createSessionDescCallback(m_connection, this, RTCSdpType(), nullptr, error.type(), error.message());
+    }
+
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPlugin/CreateSessionDescriptionObserver.h
+++ b/Plugin~/WebRTCPlugin/CreateSessionDescriptionObserver.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <api/jsep.h>
+
+#include "WebRTCPlugin.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    class CreateSessionDescriptionObserver;
+    using DelegateCreateSessionDesc = void (*)(
+        PeerConnectionObject*, CreateSessionDescriptionObserver*, RTCSdpType, const char*, RTCErrorType, const char*);
+
+    class CreateSessionDescriptionObserver : public ::webrtc::CreateSessionDescriptionObserver
+    {
+    public:
+        static rtc::scoped_refptr<CreateSessionDescriptionObserver> Create(PeerConnectionObject* connection);
+        static void RegisterCallback(DelegateCreateSessionDesc callback) { s_createSessionDescCallback = callback; }
+
+        void OnSuccess(SessionDescriptionInterface* desc) override;
+        void OnFailure(webrtc::RTCError error) override;
+
+    protected:
+        explicit CreateSessionDescriptionObserver(PeerConnectionObject* connection);
+        ~CreateSessionDescriptionObserver() override = default;
+
+    private:
+        PeerConnectionObject* m_connection;
+        static DelegateCreateSessionDesc s_createSessionDescCallback;
+    };
+
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.h
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.h
@@ -12,6 +12,9 @@ namespace webrtc
 {
     using namespace ::webrtc;
 
+    extern webrtc::SdpType ConvertSdpType(RTCSdpType type);
+    extern RTCSdpType ConvertSdpType(webrtc::SdpType type);
+
     using DelegateCreateSDSuccess = void (*)(PeerConnectionObject*, RTCSdpType, const char*);
     using DelegateCreateSDFailure = void (*)(PeerConnectionObject*, RTCErrorType, const char*);
     using DelegateLocalSdpReady = void (*)(PeerConnectionObject*, const char*, const char*);
@@ -25,7 +28,7 @@ namespace webrtc
     using DelegateOnTrack = void (*)(PeerConnectionObject*, RtpTransceiverInterface*);
     using DelegateOnRemoveTrack = void (*)(PeerConnectionObject*, RtpReceiverInterface*);
 
-    class PeerConnectionObject : public CreateSessionDescriptionObserver, public PeerConnectionObserver
+    class PeerConnectionObject : public PeerConnectionObserver
     {
     public:
         PeerConnectionObject(Context& context);
@@ -41,8 +44,8 @@ namespace webrtc
         bool GetSessionDescription(const SessionDescriptionInterface* sdp, RTCSessionDescription& desc) const;
         RTCErrorType SetConfiguration(const std::string& config);
         std::string GetConfiguration() const;
-        void CreateOffer(const RTCOfferAnswerOptions& options);
-        void CreateAnswer(const RTCOfferAnswerOptions& options);
+        void CreateOffer(const RTCOfferAnswerOptions& options, CreateSessionDescriptionObserver* observer);
+        void CreateAnswer(const RTCOfferAnswerOptions& options, CreateSessionDescriptionObserver* observer);
         void ReceiveStatsReport(const rtc::scoped_refptr<const RTCStatsReport>& report);
 
         void RegisterCallbackCreateSD(DelegateCreateSDSuccess onSuccess, DelegateCreateSDFailure onFailure)
@@ -64,12 +67,6 @@ namespace webrtc
         void RegisterOnTrack(DelegateOnTrack callback) { onTrack = callback; }
         void RegisterOnRemoveTrack(DelegateOnRemoveTrack callback) { onRemoveTrack = callback; }
 
-        // webrtc::CreateSessionDescriptionObserver
-        // This callback transfers the ownership of the |desc|.
-        void OnSuccess(SessionDescriptionInterface* desc) override;
-        // The OnFailure callback takes an RTCError, which consists of an
-        // error code and a string.
-        void OnFailure(RTCError error) override;
         // webrtc::PeerConnectionObserver
         // Triggered when the SignalingState changed.
         void OnSignalingChange(PeerConnectionInterface::SignalingState new_state) override;

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "Context.h"
+#include "CreateSessionDescriptionObserver.h"
 #include "GraphicsDevice/GraphicsUtility.h"
 #include "MediaStreamObserver.h"
 #include "PeerConnectionObject.h"
@@ -811,16 +812,20 @@ extern "C"
         return ConvertPtrArrayFromRefPtrArray<RtpTransceiverInterface>(transceivers, length);
     }
 
-    UNITY_INTERFACE_EXPORT void
+    UNITY_INTERFACE_EXPORT unity::webrtc::CreateSessionDescriptionObserver*
     PeerConnectionCreateOffer(PeerConnectionObject* obj, const RTCOfferAnswerOptions* options)
     {
-        obj->CreateOffer(*options);
+        auto observer = unity::webrtc::CreateSessionDescriptionObserver::Create(obj);
+        obj->CreateOffer(*options, observer);
+        return observer;
     }
 
-    UNITY_INTERFACE_EXPORT void
+    UNITY_INTERFACE_EXPORT unity::webrtc::CreateSessionDescriptionObserver*
     PeerConnectionCreateAnswer(PeerConnectionObject* obj, const RTCOfferAnswerOptions* options)
     {
-        obj->CreateAnswer(*options);
+        auto observer = unity::webrtc::CreateSessionDescriptionObserver::Create(obj);
+        obj->CreateAnswer(*options, observer);
+        return observer;
     }
 
     struct RTCDataChannelInit
@@ -881,10 +886,9 @@ extern "C"
         PeerConnectionStatsCollectorCallback::RegisterOnGetStats(callback);
     }
 
-    UNITY_INTERFACE_EXPORT void PeerConnectionRegisterCallbackCreateSD(
-        PeerConnectionObject* obj, DelegateCreateSDSuccess onSuccess, DelegateCreateSDFailure onFailure)
+    UNITY_INTERFACE_EXPORT void CreateSessionDescriptionObserverRegisterCallback(DelegateCreateSessionDesc callback)
     {
-        obj->RegisterCallbackCreateSD(onSuccess, onFailure);
+        unity::webrtc::CreateSessionDescriptionObserver::RegisterCallback(callback);
     }
 
     UNITY_INTERFACE_EXPORT void SetSessionDescriptionObserverRegisterCallback(DelegateSetSessionDesc callback)

--- a/Runtime/Scripts/CreateSessionDescriptionObserver.cs
+++ b/Runtime/Scripts/CreateSessionDescriptionObserver.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Unity.WebRTC
+{
+    class CreateSessionDescriptionObserver  : SafeHandle
+    {
+        public Action<RTCSdpType, string, RTCErrorType, string> onCreateSessionDescription;
+
+        private CreateSessionDescriptionObserver ()
+            : base(IntPtr.Zero, true)
+        {
+        }
+
+        public void Invoke(RTCSdpType type, string sdp, RTCErrorType errorType, string message)
+        {
+            onCreateSessionDescription?.Invoke(type, sdp, errorType, message);
+        }
+
+        public override bool IsInvalid { get { return handle == IntPtr.Zero; } }
+
+        protected override bool ReleaseHandle()
+        {
+            onCreateSessionDescription = null;
+            return true;
+        }
+    }
+}

--- a/Runtime/Scripts/CreateSessionDescriptionObserver.cs.meta
+++ b/Runtime/Scripts/CreateSessionDescriptionObserver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db1fd45132407974b8e3d501d1a44065
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/WebRTC.AsyncOperation.cs
+++ b/Runtime/Scripts/WebRTC.AsyncOperation.cs
@@ -79,6 +79,19 @@ namespace Unity.WebRTC
         /// 
         /// </summary>
         public RTCSessionDescription Desc { get; internal set; }
+
+        internal RTCSessionDescriptionAsyncOperation(CreateSessionDescriptionObserver observer)
+        {
+            observer.onCreateSessionDescription = OnCreateSessionDescription;
+        }
+
+        void OnCreateSessionDescription(RTCSdpType type, string sdp, RTCErrorType errorType, string error)
+        {
+            IsError = errorType != RTCErrorType.None;
+            Error = new RTCError() { errorType = errorType, message = error };
+            Desc = new RTCSessionDescription() { type = type, sdp = sdp};
+            this.Done();
+        }
     }
 
     /// <summary>

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -687,6 +687,7 @@ namespace Unity.WebRTC
 
             NativeMethods.RegisterDebugLog(DebugLog, enableNativeLog, nativeLoggingSeverity);
             NativeMethods.StatsCollectorRegisterCallback(OnCollectStatsCallback);
+            NativeMethods.CreateSessionDescriptionObserverRegisterCallback(OnCreateSessionDesc);
             NativeMethods.SetSessionDescriptionObserverRegisterCallback(OnSetSessionDesc);
 #if UNITY_IOS && !UNITY_EDITOR
             NativeMethods.RegisterRenderingWebRTCPlugin();
@@ -1227,6 +1228,8 @@ namespace Unity.WebRTC
         public static extern CreateSessionDescriptionObserver PeerConnectionCreateAnswer(IntPtr ptr, ref RTCOfferAnswerOptions options);
         [DllImport(WebRTC.Lib)]
         public static extern void StatsCollectorRegisterCallback(DelegateCollectStats onCollectStats);
+        [DllImport(WebRTC.Lib)]
+        public static extern void CreateSessionDescriptionObserverRegisterCallback(DelegateNativeCreateSessionDesc callback);
         [DllImport(WebRTC.Lib)]
         public static extern void SetSessionDescriptionObserverRegisterCallback(DelegateNativeSetSessionDesc callback);
         [DllImport(WebRTC.Lib)]


### PR DESCRIPTION
Related issue #792.

This issues occurred when running process of `CreateOffer` / `CreateAnswer` methods of `RTCPeerConnection` class in parallel.