### PR TITLE
fix: Fix verification test for iOS platform

### DIFF
--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -217,7 +217,8 @@ verificationtest_{{ id }}_{{ editor.version }}:
     - pip3 install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - unity-downloader-cli -u {{ editor.version }} -c editor -c iOS --fast --wait
     # run utr
-    - ./utr --suite={{ test.suite }} --platform=iOS --editor-location=.Editor --testproject=WebRTC~ --reruncount=2 --timeout=3600
+    - ./utr --suite={{ test.suite }} --platform=iOS --build-only --editor-location=.Editor --testproject=WebRTC~ --player-save-path=players --reruncount=2 --timeout=3600
+    - ./utr --suite={{ test.suite }} --platform=iOS --platform=iOS --player-load-path=players --reruncount=2 --timeout=3600
 {% endif %}
   artifacts:
     {{ id }}_{{ editor.version }}_results:

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -13,9 +13,10 @@ namespace Unity.WebRTC.RuntimeTest
     {
         protected override void SetUpCodecCapability()
         {
-            WebRTC.Initialize();
-            videoCodec = RTCRtpSender.GetCapabilities(TrackKind.Video).codecs.FirstOrDefault(c => c.mimeType.Contains("H264"));
-            WebRTC.Dispose();
+            var mimetype = "H264";
+            videoCodec = RTCRtpSender.GetCapabilities(TrackKind.Video).codecs.FirstOrDefault(c => c.mimeType.Contains(mimetype));
+            if (videoCodec == null)
+                Assert.Ignore($"{mimetype} codec is not supported this platform.");
         }
     }
 
@@ -26,9 +27,10 @@ namespace Unity.WebRTC.RuntimeTest
     {
         protected override void SetUpCodecCapability()
         {
-            WebRTC.Initialize();
-            videoCodec = RTCRtpSender.GetCapabilities(TrackKind.Video).codecs.FirstOrDefault(c => c.mimeType.Contains("VP8"));
-            WebRTC.Dispose();
+            var mimetype = "VP8";
+            videoCodec = RTCRtpSender.GetCapabilities(TrackKind.Video).codecs.FirstOrDefault(c => c.mimeType.Contains(mimetype));
+            if (videoCodec == null)
+                Assert.Ignore($"{mimetype} codec is not supported this platform.");
         }
     }
 
@@ -38,16 +40,11 @@ namespace Unity.WebRTC.RuntimeTest
 
         protected abstract void SetUpCodecCapability();
 
-        [OneTimeSetUp]
-        public void OneTimeInit()
-        {
-            SetUpCodecCapability();
-        }
-
         [SetUp]
         public void SetUp()
         {
             WebRTC.Initialize(true);
+            SetUpCodecCapability();
         }
 
         [TearDown]
@@ -109,16 +106,12 @@ namespace Unity.WebRTC.RuntimeTest
                 yield return new WaitUntilWithTimeout(() => receiveVideoTrack != null, 5000);
                 yield return new WaitUntilWithTimeout(() => receiveVideoTrack.Texture != null, 5000);
                 Assert.That(receiveVideoTrack.Texture, Is.Not.Null);
-
-                yield return new WaitForSeconds(0.1f);
-
                 test.component.Clear();
             }
 
             for (int i = 0; i < value.count; i++)
             {
                 yield return VideoReceive();
-                yield return new WaitForSeconds(0.5f);
             }
 
             Object.DestroyImmediate(test.gameObject);


### PR DESCRIPTION
This PR fixes testing for APV(A Package Verification).

- Fix verification test for iOS platform.
- Fix VideoReceiverTest that ignores test when the codec is not supported on the platform.