### PR TITLE
fix: Remove libc++.so.1 dependency for Linux platform

### DIFF
--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -17,8 +17,8 @@ platforms:
   - name: linux
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.2.4-1104052
-    gpu_image: renderstreaming/ubuntu:v0.2.4-1104053
+    image: renderstreaming/ubuntu:v0.2.7-1238331
+    gpu_image: renderstreaming/ubuntu:v0.2.7-1238332
     flavor: b1.large
     model: rtx2080
     build_command: BuildScripts~/build_plugin_linux.sh
@@ -76,7 +76,7 @@ test_targets:
         platform: standalone
   - name: linux
     type: Unity::VM
-    image: renderstreaming/ubuntu:v0.2.4-1104052
+    image: renderstreaming/ubuntu:v0.2.7-1238331
     flavor: b1.large
     is_gpu: false
     gfx_types:
@@ -117,7 +117,7 @@ test_targets:
         platform: standalone
   - name: linux-gpu
     type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.2.4-1104053
+    image: renderstreaming/ubuntu:v0.2.7-1238332
     flavor: b1.large
     model: rtx2080
     is_gpu: true
@@ -352,7 +352,7 @@ pack_{{ package.name }}:
   name: Pack {{ package.packagename }}
   agent:
     type: Unity::VM
-    image: renderstreaming/ubuntu:v0.2.4-1104052
+    image: renderstreaming/ubuntu:v0.2.7-1238331
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -17,7 +17,7 @@ sudo apt install -y libglfw3-dev
 pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad
 
 # Make libc++ static library
-apt install ninja-build
+sudo apt install ninja-build
 git clone --depth 1 --branch release/13.x https://github.com/llvm/llvm-project.git
 pushd llvm-project
 mkdir build

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -10,14 +10,9 @@ source ~/.profile
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
 
-# Install glfw3
-sudo apt install -y libglfw3-dev
-
 # Install glad2
 pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad
 
-# Make libc++ static library
-sudo apt install -y ninja-build
 git clone --depth 1 --branch release/13.x https://github.com/llvm/llvm-project.git
 pushd llvm-project
 mkdir build

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -2,6 +2,7 @@
 
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M92/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
+export LIBCXX_BUILD_DIR=$(pwd)/llvm-project/build
 
 source ~/.profile
 
@@ -15,13 +16,23 @@ sudo apt install -y libglfw3-dev
 # Install glad2
 pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad
 
+# Make libc++ static library
+apt install ninja-build
+git clone --depth 1 --branch release/13.x https://github.com/llvm/llvm-project.git
+pushd llvm-project
+mkdir build
+cmake -G Ninja -S runtimes -B build -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DLLVM_ENABLE_PIC=ON -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi"
+ninja -C build cxx cxxabi
+popd
+
 # Build UnityRenderStreaming Plugin 
 cd "$SOLUTION_DIR"
 cmake . \
   -D CMAKE_C_COMPILER="clang-10" \
   -D CMAKE_CXX_COMPILER="clang++-10" \
-  -D CMAKE_CXX_FLAGS="-stdlib=libc++" \
   -D CMAKE_BUILD_TYPE="Release" \
+  -D USE_CUSTOM_LIBCXX_STATIC=ON \
+  -D CUSTOM_LIBCXX_DIR="$LIBCXX_BUILD_DIR" \
   -B build
 
 cmake \

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -17,7 +17,7 @@ sudo apt install -y libglfw3-dev
 pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad
 
 # Make libc++ static library
-sudo apt install ninja-build
+sudo apt install -y ninja-build
 git clone --depth 1 --branch release/13.x https://github.com/llvm/llvm-project.git
 pushd llvm-project
 mkdir build

--- a/Documentation~/requirements.md
+++ b/Documentation~/requirements.md
@@ -28,15 +28,6 @@ Please note that there are unsupported platforms below.
 - Building for **iOS Simulator** is not supported.
 - **WebGL** platform is not supported.
 
-### Build on Linux
-
-On Linux, `libc++1` `libc++abi1` packages should be installed.
-Please install like command below 
-
-``` 
-sudo apt install -y libc++1 libc++abi1 
-```
-
 ### Build on Android
 
 To build the apk file for **Android platform**, you need to configure player settings below.

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_policy(SET CMP0076 NEW)
 enable_testing()
 
 # Define flags to determine the build target platform
-# Windows, Linux, macOS, iOS
+# Windows, Linux, macOS, iOS, Android
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   set(Windows TRUE)
 endif()
@@ -32,6 +32,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
 endif()
 
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(XCODE)
@@ -40,6 +41,21 @@ if(XCODE)
   )
     message(FATAL_ERROR 
       "The required Xcode version is 11.0 or higher and 12.0 or higher is not supported.")
+  endif()
+endif()
+
+if(Linux)
+  option(USE_CUSTOM_LIBCXX_STATIC "Use custom libc++" OFF)
+  option(CUSTOM_LIBCXX_DIR "Set filepath for custom libc++" "${CMAKE_SOURCE_DIR}")
+
+  if(USE_CUSTOM_LIBCXX_STATIC)
+    add_compile_options("-nostdinc++")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++")
+    include_directories("${CUSTOM_LIBCXX_DIR}/include/c++/v1/")
+    link_libraries(
+      "${CUSTOM_LIBCXX_DIR}/lib/libc++.a"
+      "${CUSTOM_LIBCXX_DIR}/lib/libc++abi.a"
+    )
   endif()
 endif()
 

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -49,13 +49,11 @@ if(Linux)
   option(CUSTOM_LIBCXX_DIR "Set filepath for custom libc++" "${CMAKE_SOURCE_DIR}")
 
   if(USE_CUSTOM_LIBCXX_STATIC)
-    add_compile_options("-nostdinc++")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++")
+    add_compile_options(-nostdinc++)
+    add_link_options(-static-libstdc++)
     include_directories("${CUSTOM_LIBCXX_DIR}/include/c++/v1/")
-    link_libraries(
-      "${CUSTOM_LIBCXX_DIR}/lib/libc++.a"
-      "${CUSTOM_LIBCXX_DIR}/lib/libc++abi.a"
-    )
+    set(CXX_LIBRARY "${CUSTOM_LIBCXX_DIR}/lib/libc++.a")
+    set(CXXABI_LIBRARY "${CUSTOM_LIBCXX_DIR}/lib/libc++abi.a")
   endif()
 endif()
 

--- a/Plugin~/README.md
+++ b/Plugin~/README.md
@@ -39,7 +39,7 @@ The below commands shows the build process developing environment on Ubuntu `20.
 
 ```bash
 #install packages
-sudo apt install -y libc++1 libc++abi1 vulkan-utils libvulkan1 libvulkan-dev libglib2.0-dev python3-venv lld clang-10 libc++-10-dev libc++abi-10-dev freeglut3-dev
+sudo apt install -y vulkan-utils libvulkan1 libvulkan-dev libglib2.0-dev python3-venv lld clang-10 freeglut3-dev ninja-build
 
 # Install CUDA SDK
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -248,6 +248,8 @@ elseif(Linux)
       glad_glx_14
       ${WEBRTC_LIBRARY}
       ${GLIB_LIBRARIES}
+      ${CXX_LIBRARY}
+      ${CXXABI_LIBRARY}
   )
   target_include_directories(WebRTCLib
     SYSTEM
@@ -367,7 +369,8 @@ else()
     PRIVATE
       WebRTCLib
   )
-endif()  
+endif()
+
 target_sources(WebRTCPlugin 
   PRIVATE
     pch.cpp

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -89,6 +89,12 @@ target_compile_definitions(WebRTCLib
     $<$<CONFIG:Debug>:DEBUG>
 )
 
+set_target_properties(WebRTCLib
+  PROPERTIES 
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+
 if(iOS OR macOS)
   target_sources(WebRTCLib
     PRIVATE
@@ -97,8 +103,8 @@ if(iOS OR macOS)
 else()
   target_sources(WebRTCLib
     PRIVATE
-    UnityVulkanInterfaceFunctions.cpp
-    UnityVulkanInterfaceFunctions.h
+      UnityVulkanInterfaceFunctions.cpp
+      UnityVulkanInterfaceFunctions.h
   )
 endif()
 
@@ -160,7 +166,8 @@ if(Windows)
 
   # Select runtime library (MT, MTD) on windows platform
   set_target_properties(WebRTCLib
-    PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+    PROPERTIES 
+      MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
   )
 
   # Creare precompiled header
@@ -193,13 +200,9 @@ elseif(macOS)
   set_target_properties(WebRTCLib
     PROPERTIES 
       LINK_FLAGS "-ObjC"
-      CXX_VISIBILITY_PRESET hidden
-      VISIBILITY_INLINES_HIDDEN ON
   )  
 elseif(Linux)
-  set(PROJECT_BINARY_DIR
-    "${CMAKE_SOURCE_DIR}/../Runtime/Plugins/x86_64")
-
+  set(PROJECT_BINARY_DIR "${CMAKE_SOURCE_DIR}/../Runtime/Plugins/x86_64")
   set(GLAD_SOURCES_DIR "${CMAKE_SOURCE_DIR}/glad")
   add_subdirectory("${GLAD_SOURCES_DIR}/cmake" glad_cmake)
 
@@ -236,6 +239,7 @@ elseif(Linux)
       WEBRTC_POSIX
       VK_NO_PROTOTYPES
   )
+
   target_link_libraries(WebRTCLib
     PUBLIC
       NvCodec
@@ -336,14 +340,19 @@ target_include_directories(WebRTCLib
     .
 )
 
+add_library(WebRTCPlugin SHARED)
+
+set_target_properties(WebRTCPlugin
+  PROPERTIES 
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+
 if(iOS)
-  add_library(WebRTCPlugin SHARED)
   set_target_properties(WebRTCPlugin 
     PROPERTIES 
       FRAMEWORK TRUE
   )
-else()
-  add_library(WebRTCPlugin SHARED)
 endif()
 
 if(Windows)
@@ -385,18 +394,12 @@ if(Windows)
       LINK_FLAGS "/SUBSYSTEM:WINDOWS -delayload:nvcuda.dll -delayload:nvEncodeAPI64.dll -delayload:nvcuvid.dll"
       MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
   )
-endif()
-
-if(macOS)
+elseif(macOS)
   set_target_properties(WebRTCPlugin
-  PROPERTIES 
-    LINK_FLAGS "-ObjC"
-    CXX_VISIBILITY_PRESET hidden
-    VISIBILITY_INLINES_HIDDEN ON
+    PROPERTIES 
+      LINK_FLAGS "-ObjC"
   )
-endif()
-
-if(iOS)
+elseif(iOS)
   #
   # Build Setting Reference
   # https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html


### PR DESCRIPTION
We have experienced the runtime error of lack of dependencies on Linux because the native plugin has depended on the C++ standard library as a dynamic linking. We need to install `libc++.so.1` and `libc++abi.so.1` into the Linux to fix the issue, but it is troublesome.
This pull request contains the fix of the CMake script to statically link the standard library. 


## Before

![Screenshot from 2022-10-19 08-46-59](https://user-images.githubusercontent.com/1132081/196565723-5293841d-a4e3-458d-8cd3-a22a7663beab.png)

## After
![Screenshot from 2022-10-19 08-48-00](https://user-images.githubusercontent.com/1132081/196565716-98103ba9-b066-4e9a-8300-f7865c19ff91.png)
