### PR TITLE
fix: Add Audio module for dependency to solve the issue of isolation test and compilation test

### DIFF
--- a/.yamato/compile-package.yml
+++ b/.yamato/compile-package.yml
@@ -1,5 +1,7 @@
 {% metadata_file .yamato/package.metafile %}
 
+---
+
 {% for editor in editors %}
 compile_test_{{ editor.version }}:
   name: Compilation Test {{ editor.version }}

--- a/.yamato/compile-package.yml
+++ b/.yamato/compile-package.yml
@@ -1,0 +1,29 @@
+{% metadata_file .yamato/package.metafile %}
+
+{% for editor in editors %}
+compile_test:
+  name: Compilation Test {{ editor.version }}
+  agent:
+    type: Unity::VM
+    flavor: b1.large
+    image: package-ci/win10:v4
+  variables:
+    PACKAGE_VERSION: 2.4.0-exp.11
+  commands:
+    # When unity-config will be part of the image, this will turn into a no-op
+    - |
+      where /q unity-config
+      if ERRORLEVEL 1 (
+        %GSUDO% choco install unity-config -y -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
+      )
+    - unity-downloader-cli -c editor -u {{ editor.version }} --wait
+    - .Editor\Unity.exe -createProject CompilationTestProject -logFile logs\CreateProject.log -batchmode -quit
+    - |
+      unity-config project set registry --project-path CompilationTestProject candidates
+      unity-config project add dependency --project-path CompilationTestProject com.unity.webrtc@%PACKAGE_VERSION%
+    - .Editor\Unity.exe -projectPath CompilationTestProject -logFile logs\CompilePackage.log -batchmode -quit
+  artifacts:
+    logs:
+      paths:
+        - logs/*
+{% endfor %}

--- a/.yamato/compile-package.yml
+++ b/.yamato/compile-package.yml
@@ -1,7 +1,7 @@
 {% metadata_file .yamato/package.metafile %}
 
 {% for editor in editors %}
-compile_test:
+compile_test_{{ editor.version }}:
   name: Compilation Test {{ editor.version }}
   agent:
     type: Unity::VM

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -633,7 +633,8 @@ test_{{ package.name }}_{{ editor.version }}_nogpu:
 {% for target in test_targets %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-{% if target.is_gpu == "false" %}
+# vulkan gfx device is not supported on VMs without GPU
+{% if target.is_gpu == "false" and gfx_type.name != "vulkan" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif %}
 {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -1,4 +1,4 @@
-{% metadata_file .yamato/package.metafile -%}
+{% metadata_file .yamato/package.metafile %}
 
 editor_version_for_validate: 2019.4
 editor_version_for_trigger: 2021.3
@@ -490,7 +490,7 @@ test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name 
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-    - upm-ci package test -u {{ editor.version }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-editor-arg {{ gfx_type.extra-editor-arg }}
+    - upm-ci package test -u {{ editor.version }} --platform {{ param.platform }} --backend {{ param.backend }} --extra-editor-arg {{ gfx_type.extra-editor-arg }} --enable-load-and-test-isolation
   artifacts:
     {{ package.name }}_{{ param.backend }}_{{ editor.version }}_{{ target.name }}_test_results: 
       paths:

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -633,8 +633,8 @@ test_{{ package.name }}_{{ editor.version }}_nogpu:
 {% for target in test_targets %}
 {% for param in target.test_params %}
 {% for gfx_type in target.gfx_types %}
-# vulkan gfx device is not supported on VMs without GPU
-{% if target.is_gpu == "false" and gfx_type.name != "vulkan" %}
+# vulkan and d3d12 gfx device is not supported on VMs without GPU
+{% if target.is_gpu == "false" and gfx_type.name != "vulkan" and gfx_type.name != "d3d12" %}
     - .yamato/upm-ci-{{ package.name }}-packages.yml#test_{{ package.name }}_{{ param.platform }}_{{ param.backend }}_{{ target.name }}_{{ editor.version }}_{{ gfx_type.name }}
 {% endif %}
 {% endfor %}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "dependencies": {
     "com.unity.modules.jsonserialize": "1.0.0",
-    "com.unity.editorcoroutines": "1.0.0"
+    "com.unity.editorcoroutines": "1.0.0",
+    "com.unity.modules.audio": "1.0.0"
   },
   "samples": [{
       "displayName": "Example",


### PR DESCRIPTION
This relates the issue. https://github.com/Unity-Technologies/UnityRenderStreaming/pull/796

WebRTC package depends on Audio module which implicitly installed on Unity Editor. We need to list package dependencies on the `package.json` even if the one is installed modules.