### PR TITLE
fix: Fix build error libux plugin because of pip command error

### DIFF
--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -11,7 +11,7 @@ curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
 
 # Install glad2
-pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad
+pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad2
 
 git clone --depth 1 --branch release/13.x https://github.com/llvm/llvm-project.git
 pushd llvm-project

--- a/BuildScripts~/test_plugin_linux.sh
+++ b/BuildScripts~/test_plugin_linux.sh
@@ -18,7 +18,7 @@ unzip -d $SOLUTION_DIR/webrtc webrtc.zip
 sudo apt install -y libglfw3-dev
 
 # Install glad2
-pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad
+pip3 install git+https://github.com/dav1dde/glad.git@glad2#egg=glad2
 
 # Build UnityRenderStreaming Plugin 
 cd "$SOLUTION_DIR"


### PR DESCRIPTION
The cause of the error is pip install commanad because of updating in third-party repository. It is [glad](https://github.com/Dav1dde/glad).

I found the changelog in the repository which can effect our build command.
https://github.com/Dav1dde/glad/commit/4a1168280e4c56e8d488f4de082a83bbc91c4fc4#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R28