### PR TITLE
chore: Update package version 3.0.0-pre.1 to fix package validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
         What version of the package are you using?
         You can check the Unity version in Package Manager Window. See [manual](https://docs.unity3d.com/Manual/upm-ui.html).
       options:
-        - 2.4.0-pre.2
+        - 3.0.0-pre.1
         - 2.4.0-exp.11
         - 2.4.0-exp.10
         - 2.4.0-exp.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the webrtc package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.4.0-pre.2] - 2022-10-24
+## [3.0.0-pre.1] - 2022-10-28
 
 ### Changed
 

--- a/Documentation~/install.md
+++ b/Documentation~/install.md
@@ -32,7 +32,7 @@ Check Package Manager window, Click `+` button and select `Add package from git 
 Input the string below to the input field.
 
 ```
-com.unity.webrtc@2.4.0-pre.2
+com.unity.webrtc@3.0.0-pre.1
 ```
 
 The list of version string is [here](https://github.com/Unity-Technologies/com.unity.webrtc/tags). In most cases, the latest version is recommended to use.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Please read this if you have an interest to customize native code in this projec
 | `2.4.0-exp.9` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Hotfix | Aug 2022 |
 | `2.4.0-exp.10` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Hotfix | Aug 2022 |
 | `2.4.0-exp.11` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Hotfix | Sep 2022 |
-| `2.4.0-pre.2` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Fix bugs | Oct 2022 |
-| `2.4.0-pre.3` | [M104](https://groups.google.com/g/discuss-webrtc/c/PZxgk-aUFhw) | - Fix bugs | Jan 2023 |
+| `3.0.0-pre.1` | [M92](https://groups.google.com/g/discuss-webrtc/c/hks5zneZJbo/m/Z-p4AfCrCQAJ) | - Fix bugs | Dec 2022 |
+| `3.0.0-pre.2` | [M104](https://groups.google.com/g/discuss-webrtc/c/PZxgk-aUFhw) | - Fix bugs | Jan 2023 |
 
 ## Licenses
 

--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -1,10 +1,5 @@
 {
     "ErrorExceptions": [
-        {
-            "ValidationTest": "API Validation",
-            "ExceptionMessage": "Breaking changes require a new major version.",
-            "PackageVersion": "2.4.0-pre.2"
-        }        
     ],
     "WarningExceptions": [
         {

--- a/ValidationExceptions.json
+++ b/ValidationExceptions.json
@@ -5,7 +5,7 @@
         {
             "ValidationTest": "Restricted File Type Validation",
             "ExceptionMessage": "/Runtime/Plugins/x86_64/webrtc.dll should not be included in packages unless absolutely necessary. Please confirm that its inclusion is deliberate and intentional.",
-            "PackageVersion": "2.4.0-pre.2"
+            "PackageVersion": "3.0.0-pre.1"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.webrtc",
   "displayName": "WebRTC",
-  "version": "2.4.0-pre.2",
+  "version": "3.0.0-pre.1",
   "unity": "2019.4",
   "description": "The WebRTC package provides browsers and mobile applications with Real-Time Communications (RTC) capabilities.",
   "keywords": [


### PR DESCRIPTION
We are preparing the package to promote pre-release version from experimental version because make the package to official. We need Package validation test for promoting the package, and the package validation test detected API breaking changes between previous package version 2.3.3-preview.
[APIValidation.txt](https://github.com/Unity-Technologies/com.unity.webrtc/files/9884693/APIValidation.txt)

To fix this, we need to update a major version, so this PR changes the package version to 3.0.0-pre.1.
