### PR TITLE
refactor: Mark Obsolete WebRTC.Initialize and Dispose methods

### DIFF
--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -9,7 +9,7 @@ namespace Unity.WebRTC
 #if UNITY_EDITOR
     [InitializeOnLoad]
 #endif
-    public class ContextManager
+    class ContextManager
     {
 #if UNITY_EDITOR
         static ContextManager()

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -36,16 +36,16 @@ namespace Unity.WebRTC
         }
 
 #else
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    static void Init()
-    {
-        Application.quitting += Quit;
-        WebRTC.InitializeInternal();
-    }
-    static void Quit()
-    {
-        WebRTC.DisposeInternal();
-    }
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void Init()
+        {
+            Application.quitting += Quit;
+            WebRTC.InitializeInternal();
+        }
+        static void Quit()
+        {
+            WebRTC.DisposeInternal();
+        }
 #endif
     }
 
@@ -55,7 +55,6 @@ namespace Unity.WebRTC
         internal WeakReferenceTable table;
         internal SynchronizationContext syncContext;
         internal bool limitTextureSize;
-
 
         private int id;
         private bool disposed;

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -1,7 +1,53 @@
 using System;
+using UnityEngine;
+using UnityEditor;
 
 namespace Unity.WebRTC
 {
+    // Ensure class initializer is called whenever scripts recompile
+#if UNITY_EDITOR
+    [InitializeOnLoad]
+#endif
+    public class ContextManager
+    {
+#if UNITY_EDITOR
+        static ContextManager()
+        {
+            AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
+            AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
+            Application.quitting += Quit;
+        }
+
+        static void OnBeforeAssemblyReload()
+        {
+            WebRTC.DisposeInternal();
+        }
+
+        static void OnAfterAssemblyReload()
+        {
+            WebRTC.InitializeInternal();
+        }
+
+        static void Quit()
+        {
+            AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
+            AssemblyReloadEvents.afterAssemblyReload -= OnAfterAssemblyReload;
+        }
+
+#else
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        Application.quitting += Quit;
+        WebRTC.InitializeInternal();
+    }
+    static void Quit()
+    {
+        WebRTC.DisposeInternal();
+    }
+#endif
+    }
+
     internal class Context : IDisposable
     {
         internal IntPtr self;

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using UnityEngine;
 using UnityEditor;
 
@@ -52,6 +53,9 @@ namespace Unity.WebRTC
     {
         internal IntPtr self;
         internal WeakReferenceTable table;
+        internal SynchronizationContext syncContext;
+        internal bool limitTextureSize;
+
 
         private int id;
         private bool disposed;

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -735,7 +735,6 @@ namespace Unity.WebRTC
                 s_context.Dispose();
                 s_context = null;
             }
-            s_context.syncContext = null;
             NativeMethods.RegisterDebugLog(null, false, NativeLoggingSeverity.Info);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -721,6 +721,15 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        public static bool enableLimitTextureSize
+        {
+            get { return s_context.limitTextureSize; }
+            set { s_context.limitTextureSize = value; }
+        }
+
+        /// <summary>
         ///
         /// </summary>
         [Obsolete]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -641,30 +641,24 @@ namespace Unity.WebRTC
         private static SynchronizationContext s_syncContext;
         private static bool s_limitTextureSize;
 
-#if UNITY_EDITOR
-        internal static void OnBeforeAssemblyReload()
-        {
-            Dispose();
-        }
-#endif
-
         /// <summary>
         /// 
         /// </summary>
         /// <param name="limitTextureSize"></param>
         /// <param name="enableNativeLog"></param>
         /// <param name="nativeLoggingSeverity"></param>
+        [Obsolete]
         public static void Initialize(bool limitTextureSize = true, bool enableNativeLog = false,
+            NativeLoggingSeverity nativeLoggingSeverity = NativeLoggingSeverity.Info)
+        {
+        }
+
+        internal static void InitializeInternal(bool limitTextureSize = true, bool enableNativeLog = false,
             NativeLoggingSeverity nativeLoggingSeverity = NativeLoggingSeverity.Info)
         {
             if (s_context != null)
                 throw new InvalidOperationException("Already initialized WebRTC.");
 
-            // todo(kazuki): Add this event to avoid crash caused by hot-reload.
-            // Dispose of all before reloading assembly.
-#if UNITY_EDITOR
-            UnityEditor.AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
-#endif
             NativeMethods.RegisterDebugLog(DebugLog, enableNativeLog, nativeLoggingSeverity);
             NativeMethods.StatsCollectorRegisterCallback(OnCollectStatsCallback);
             NativeMethods.CreateSessionDescriptionObserverRegisterCallback(OnCreateSessionDesc);
@@ -730,7 +724,12 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
+        [Obsolete]
         public static void Dispose()
+        {
+        }
+
+        internal static void DisposeInternal()
         {
             if (s_context != null)
             {
@@ -739,10 +738,6 @@ namespace Unity.WebRTC
             }
             s_syncContext = null;
             NativeMethods.RegisterDebugLog(null, false, NativeLoggingSeverity.Info);
-
-#if UNITY_EDITOR
-            UnityEditor.AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
-#endif
         }
 
         internal static RTCError ValidateTextureSize(int width, int height, RuntimePlatform platform)

--- a/Samples~/Audio/AudioSample.cs
+++ b/Samples~/Audio/AudioSample.cs
@@ -60,7 +60,6 @@ namespace Unity.WebRTC
 
     void Start()
         {
-            WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
             StartCoroutine(WebRTC.Update());
             StartCoroutine(LoopStatsCoroutine());
 
@@ -122,11 +121,6 @@ namespace Unity.WebRTC
             return string.Format($"{cap.mimeType} " +
                 $"{cap.clockRate} " +
                 $"channel={cap.channels}");
-        }
-
-        void OnDestroy()
-        {
-            WebRTC.Dispose();
         }
 
         void OnStart()

--- a/Samples~/Bandwidth/BandwidthSample.cs
+++ b/Samples~/Bandwidth/BandwidthSample.cs
@@ -75,7 +75,6 @@ class BandwidthSample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         bandwidthSelector.options = bandwidthOptions
             .Select(pair => new Dropdown.OptionData{text = pair.Key })
             .ToList();
@@ -94,11 +93,6 @@ class BandwidthSample : MonoBehaviour
         hangUpButton.onClick.AddListener(HangUp);
         copyClipboard.onClick.AddListener(CopyClipboard);
         receiveStream = new MediaStream();
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/ChangeCodecs/ChangeCodecsSample.cs
+++ b/Samples~/ChangeCodecs/ChangeCodecsSample.cs
@@ -39,16 +39,10 @@ class ChangeCodecsSample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         startButton.onClick.AddListener(OnStart);
         callButton.onClick.AddListener(Call);
         hangUpButton.onClick.AddListener(HangUp);
         receiveStream = new MediaStream();
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/DataChannel/DataChannelSample.cs
+++ b/Samples~/DataChannel/DataChannelSample.cs
@@ -28,15 +28,9 @@ class DataChannelSample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         callButton.onClick.AddListener(() => { StartCoroutine(Call()); });
         hangupButton.onClick.AddListener(() => { Hangup(); });
 
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/E2ELatency/E2ELatencySample.cs
+++ b/Samples~/E2ELatency/E2ELatencySample.cs
@@ -53,7 +53,6 @@ class E2ELatencySample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         startButton.onClick.AddListener(OnStart);
         callButton.onClick.AddListener(OnCall);
         hangUpButton.onClick.AddListener(OnHangUp);
@@ -64,8 +63,6 @@ class E2ELatencySample : MonoBehaviour
         // Revert global settings
         QualitySettings.vSyncCount = vSyncCount;
         Application.targetFrameRate = targetFrameRate;
-
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/MediaStream/MediaStreamSample.cs
+++ b/Samples~/MediaStream/MediaStreamSample.cs
@@ -34,15 +34,9 @@ namespace Unity.WebRTC.Samples
 
         private void Awake()
         {
-            WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
             callButton.onClick.AddListener(Call);
             addTracksButton.onClick.AddListener(AddTracks);
             removeTracksButton.onClick.AddListener(RemoveTracks);
-        }
-
-        private void OnDestroy()
-        {
-            WebRTC.Dispose();
         }
 
         private void Start()

--- a/Samples~/MultiAudioReceive/MultiAudioReceiveSample.cs
+++ b/Samples~/MultiAudioReceive/MultiAudioReceiveSample.cs
@@ -37,17 +37,11 @@ namespace Unity.WebRTC.Samples
 
         private void Awake()
         {
-            WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
             StartCoroutine(WebRTC.Update());
             callButton.onClick.AddListener(Call);
             hangUpButton.onClick.AddListener(HangUp);
             addAudioObjectButton.onClick.AddListener(AddVideoObject);
             addTracksButton.onClick.AddListener(AddTracks);
-        }
-
-        private void OnDestroy()
-        {
-            WebRTC.Dispose();
         }
 
         private void Start()

--- a/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
+++ b/Samples~/MultiVideoReceive/MultiVideoReceiveSample.cs
@@ -40,16 +40,10 @@ namespace Unity.WebRTC.Samples
 
         private void Awake()
         {
-            WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
             callButton.onClick.AddListener(Call);
             hangUpButton.onClick.AddListener(HangUp);
             addVideoObjectButton.onClick.AddListener(AddVideoObject);
             addTracksButton.onClick.AddListener(AddTracks);
-        }
-
-        private void OnDestroy()
-        {
-            WebRTC.Dispose();
         }
 
         private void Start()

--- a/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
+++ b/Samples~/MultiplePeerConnections/MultiplePeerConnectionsSample.cs
@@ -30,16 +30,6 @@ namespace Unity.WebRTC.Samples
         private RTCPeerConnection pc1Local, pc1Remote, pc2Local, pc2Remote;
         private MediaStream sourceStream;
 
-        private void Awake()
-        {
-            WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
-        }
-
-        private void OnDestroy()
-        {
-            WebRTC.Dispose();
-        }
-
         private void Start()
         {
             StartCoroutine(WebRTC.Update());

--- a/Samples~/MungeSDP/MungeSDPSample.cs
+++ b/Samples~/MungeSDP/MungeSDPSample.cs
@@ -32,16 +32,6 @@ class MungeSDPSample : MonoBehaviour
     private MediaStream sourceVideoStream, receiveVideoStream;
     private Coroutine updateCoroutine;
 
-    private void Awake()
-    {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
-    }
-
     private void Start()
     {
         startButton.onClick.AddListener(Setup);

--- a/Samples~/PeerConnection/PeerConnectionSample.cs
+++ b/Samples~/PeerConnection/PeerConnectionSample.cs
@@ -44,17 +44,11 @@ class PeerConnectionSample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         startButton.onClick.AddListener(OnStart);
         callButton.onClick.AddListener(Call);
         restartButton.onClick.AddListener(RestartIce);
         hangUpButton.onClick.AddListener(HangUp);
         receiveStream = new MediaStream();
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/PerfectNegotiation/PerfectNegotiationSample.cs
+++ b/Samples~/PerfectNegotiation/PerfectNegotiationSample.cs
@@ -37,16 +37,10 @@ class PerfectNegotiationSample : MonoBehaviour
     private const int MAX = 120;
     private float lerp = 0.0f;
 
-    private void Awake()
-    {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
-    }
-
     private void OnDestroy()
     {
         politePeer?.Dispose();
         impolitePeer?.Dispose();
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/ReplaceTrack/ReplaceTrackSample.cs
+++ b/Samples~/ReplaceTrack/ReplaceTrackSample.cs
@@ -39,16 +39,10 @@ class ReplaceTrackSample : MonoBehaviour
     private Peer peer1, peer2;
     private Vector2Int size1, size2;
 
-    private void Awake()
-    {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
-    }
-
     private void OnDestroy()
     {
         peer1?.Dispose();
         peer2?.Dispose();
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/Scripts/SceneSelectUI.cs
+++ b/Samples~/Scripts/SceneSelectUI.cs
@@ -11,15 +11,8 @@ namespace Unity.WebRTC.Samples
         public const int DefaultStreamWidth = 1280;
         public const int DefaultStreamHeight = 720;
 
-        private static bool s_limitTextureSize = true;
         private static Vector2Int s_StreamSize = new Vector2Int(DefaultStreamWidth, DefaultStreamHeight);
         private static RTCRtpCodecCapability s_useVideoCodec = null;
-
-        public static bool LimitTextureSize
-        {
-            get { return s_limitTextureSize; }
-            set { s_limitTextureSize = value; }
-        }
 
         public static Vector2Int StreamSize
         {
@@ -75,16 +68,6 @@ namespace Unity.WebRTC.Samples
         private static readonly string[] excludeCodecMimeType = { "video/red", "video/ulpfec", "video/rtx" };
         private List<RTCRtpCodecCapability> availableCodecs;
 
-        void Awake()
-        {
-            WebRTC.Initialize();
-        }
-
-        void OnDestroy()
-        {
-            WebRTC.Dispose();
-        }
-
         void Start()
         {
             var capabilities = RTCRtpSender.GetCapabilities(TrackKind.Video);
@@ -125,7 +108,7 @@ namespace Unity.WebRTC.Samples
             textureWidthInput.onValueChanged.AddListener(OnChangeTextureWidthInput);
             textureHeightInput.onValueChanged.AddListener(OnChangeTextureHeightInput);
 
-            toggleLimitTextureSize.isOn = WebRTCSettings.LimitTextureSize;
+            toggleLimitTextureSize.isOn = WebRTC.enableLimitTextureSize;
             toggleLimitTextureSize.onValueChanged.AddListener(OnChangeLimitTextureSize);
 
             buttonPeerConnection.onClick.AddListener(OnPressedPeerConnectionButton);
@@ -203,7 +186,7 @@ namespace Unity.WebRTC.Samples
 
         private void OnChangeLimitTextureSize(bool enable)
         {
-            WebRTCSettings.LimitTextureSize = enable;
+            WebRTC.enableLimitTextureSize = enable;
         }
 
         private void OnPressedPeerConnectionButton()

--- a/Samples~/Stats/StatsSample.cs
+++ b/Samples~/Stats/StatsSample.cs
@@ -40,7 +40,6 @@ class StatsSample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         callButton.onClick.AddListener(() =>
         {
             callButton.interactable = false;
@@ -53,11 +52,6 @@ class StatsSample : MonoBehaviour
             hangupButton.interactable = false;
             Dispose();
         });
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/TrickleIce/TrickleIceSample.cs
+++ b/Samples~/TrickleIce/TrickleIceSample.cs
@@ -39,17 +39,11 @@ class TrickleIceSample : MonoBehaviour
 
     private void Awake()
     {
-        WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
         addServerButton.onClick.AddListener(OnAddServer);
         removeServerButton.onClick.AddListener(OnRemoveServer);
         resetToDefaultButton.onClick.AddListener(OnResetToDefault);
         gatherCandidatesButton.onClick.AddListener(OnGatherCandidate);
         candidatePoolSizeSlider.onValueChanged.AddListener(OnChangedCandidatePoolSize);
-    }
-
-    private void OnDestroy()
-    {
-        WebRTC.Dispose();
     }
 
     private void Start()

--- a/Samples~/VideoReceive/VideoReceiveSample.cs
+++ b/Samples~/VideoReceive/VideoReceiveSample.cs
@@ -42,7 +42,6 @@ namespace Unity.WebRTC.Samples
 
         private void Awake()
         {
-            WebRTC.Initialize(WebRTCSettings.LimitTextureSize);
             callButton.onClick.AddListener(Call);
             hangUpButton.onClick.AddListener(HangUp);
             addTracksButton.onClick.AddListener(AddTracks);
@@ -60,8 +59,6 @@ namespace Unity.WebRTC.Samples
                 webCamTexture.Stop();
                 webCamTexture = null;
             }
-
-            WebRTC.Dispose();
         }
 
         private void Start()

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -1,28 +1,14 @@
 using System;
 using System.Collections;
 using System.Linq;
-
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-using Unity.Collections;
 
 namespace Unity.WebRTC.RuntimeTest
 {
     class AudioStreamTrackTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [UnityTest]
         [Timeout(5000)]
         public IEnumerator ConstructorWithAudioSource()

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -23,49 +23,40 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.RegisterDebugLog(null, true, NativeLoggingSeverity.Verbose);
         }
 
-        [Test]
-        public void CreateAndDelete()
-        {
-            var context = Context.Create();
-            context.Dispose();
-        }
 
         [Test]
         public void CreateAndDeletePeerConnection()
         {
-            var context = Context.Create();
+            var context = WebRTC.Context;
             var peerPtr = context.CreatePeerConnection();
             context.DeletePeerConnection(peerPtr);
-            context.Dispose();
         }
 
         [Test]
         public void CreateAndDeleteDataChannel()
         {
-            var context = Context.Create();
+            var context = WebRTC.Context;
             var peerPtr = context.CreatePeerConnection();
             var init = (RTCDataChannelInitInternal) new RTCDataChannelInit();
             var channelPtr = context.CreateDataChannel(peerPtr, "test", ref init);
             context.DeleteDataChannel(channelPtr);
             context.DeletePeerConnection(peerPtr);
-            context.Dispose();
         }
 
         [Test]
         public void CreateAndDeleteAudioTrack()
         {
-            var context = Context.Create();
+            var context = WebRTC.Context;
             var source = context.CreateAudioTrackSource();
             var track = context.CreateAudioTrack("audio", source);
             context.DeleteRefPtr(track);
             context.DeleteRefPtr(source);
-            context.Dispose();
         }
 
         [Test]
         public void CreateAndDeleteVideoTrack()
         {
-            var context = Context.Create();
+            var context = WebRTC.Context;
             var width = 256;
             var height = 256;
             var format = WebRTC.GetSupportedRenderTextureFormat(UnityEngine.SystemInfo.graphicsDeviceType);
@@ -75,26 +66,22 @@ namespace Unity.WebRTC.RuntimeTest
             var track = context.CreateVideoTrack("video", source);
             context.DeleteRefPtr(track);
             context.DeleteRefPtr(source);
-            context.Dispose();
             UnityEngine.Object.DestroyImmediate(rt);
         }
 
         [Test]
         public void CreateAndDeleteAudioTrackSink()
         {
-            var context = Context.Create();
+            var context = WebRTC.Context;
             var sink = context.CreateAudioTrackSink();
             context.DeleteAudioTrackSink(sink);
-            context.Dispose();
         }
 
         [Test]
         public void DeleteStatsReportIgnoreInvalidValue()
         {
-            var context = Context.Create();
+            var context = WebRTC.Context;
             context.DeleteStatsReport(IntPtr.Zero);
-            context.Dispose();
         }
-
     }
 }

--- a/Tests/Runtime/DataChannelTest.cs
+++ b/Tests/Runtime/DataChannelTest.cs
@@ -12,19 +12,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class DataChannelTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
-
         [Test]
         public void CreateDataChannel()
         {

--- a/Tests/Runtime/IceCandidateTest.cs
+++ b/Tests/Runtime/IceCandidateTest.cs
@@ -5,18 +5,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class IceCandidateTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [Test]
         public void Construct()
         {

--- a/Tests/Runtime/MediaStreamTest.cs
+++ b/Tests/Runtime/MediaStreamTest.cs
@@ -10,18 +10,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class MediaStreamTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [Test]
         public void Construct()
         {

--- a/Tests/Runtime/MediaStreamTrackTest.cs
+++ b/Tests/Runtime/MediaStreamTrackTest.cs
@@ -10,18 +10,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class MediaStreamTrackTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [Test]
         [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
         public void Constructor()

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -10,6 +10,8 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class NativeAPITest
     {
+        IntPtr context;
+
         private static RenderTexture CreateRenderTexture(int width, int height)
         {
             var format = WebRTC.GetSupportedRenderTextureFormat(SystemInfo.graphicsDeviceType);
@@ -30,6 +32,7 @@ namespace Unity.WebRTC.RuntimeTest
 #if UNITY_IOS && !UNITY_EDITOR
             NativeMethods.RegisterRenderingWebRTCPlugin();
 #endif
+            context = WebRTC.Context.self;
         }
 
         [Test]
@@ -38,29 +41,18 @@ namespace Unity.WebRTC.RuntimeTest
         }
 
         [Test]
-        public void CreateAndDestroyContext()
-        {
-            var context = NativeMethods.ContextCreate(0);
-            NativeMethods.ContextDestroy(0);
-        }
-
-        [Test]
         public void CreateAndDeletePeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
         }
 
         [Test]
         public void RestartIcePeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             NativeMethods.PeerConnectionRestartIce(peer);
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
         }
 
         // todo(kazuki):: crash on iOS device
@@ -68,34 +60,28 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void PeerConnectionGetReceivers()
         {
-            var context = NativeMethods.ContextCreate(0);
             var connection = NativeMethods.ContextCreatePeerConnection(context);
             IntPtr buf = NativeMethods.PeerConnectionGetReceivers(context, connection, out ulong length);
             Assert.AreEqual(0, length);
             NativeMethods.ContextDeletePeerConnection(context, connection);
-            NativeMethods.ContextDestroy(0);
         }
 
         [Test]
         public void CreateAndDeleteDataChannel()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
 
             var init = (RTCDataChannelInitInternal)new RTCDataChannelInit();
             var channel = NativeMethods.ContextCreateDataChannel(context, peer, "test", ref init);
             NativeMethods.ContextDeleteDataChannel(context, channel);
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
         }
 
         [Test]
         public void CreateAndDeleteMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             NativeMethods.ContextDeleteRefPtr(context, stream);
-            NativeMethods.ContextDestroy(0);
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeMediaStreamOnAddTrack))]
@@ -107,7 +93,6 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void RegisterDelegateToMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             NativeMethods.ContextRegisterMediaStreamObserver(context, stream);
 
@@ -116,7 +101,6 @@ namespace Unity.WebRTC.RuntimeTest
 
             NativeMethods.ContextUnRegisterMediaStreamObserver(context, stream);
             NativeMethods.ContextDeleteRefPtr(context, stream);
-            NativeMethods.ContextDestroy(0);
         }
 
         [Test]
@@ -124,7 +108,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoTrack()
         {
-            var context = NativeMethods.ContextCreate(0);
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
@@ -133,8 +116,6 @@ namespace Unity.WebRTC.RuntimeTest
             var track = NativeMethods.ContextCreateVideoTrack(context, "video", source);
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, source);
-
-            NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
 
@@ -143,7 +124,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoTrackToPeerConnection()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -163,7 +143,6 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
 
@@ -172,7 +151,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public void SenderGetParameter()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             string streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -194,7 +172,6 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeleteRefPtr(context, source);
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
         }
 
         // todo(kazuki): Crash occurs when calling NativeMethods.MediaStreamRemoveTrack method on iOS device
@@ -204,7 +181,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoTrackToMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             const int width = 1280;
             const int height = 720;
@@ -230,7 +206,6 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeleteRefPtr(context, source);
-            NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
 
@@ -239,7 +214,6 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer })]
         public void AddAndRemoveAudioTrackToMediaStream()
         {
-            var context = NativeMethods.ContextCreate(0);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var source = NativeMethods.ContextCreateAudioTrackSource(context);
             var track = NativeMethods.ContextCreateAudioTrack(context, "audio", source);
@@ -265,13 +239,11 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeleteRefPtr(context, source);
-            NativeMethods.ContextDestroy(0);
         }
 
         [Test]
         public void AddAndRemoveAudioTrack()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -286,7 +258,6 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(NativeMethods.PeerConnectionRemoveTrack(peer, sender), Is.EqualTo(RTCErrorType.None));
             NativeMethods.ContextDeleteRefPtr(context, stream);
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateVideoFrameResize))]
@@ -295,10 +266,8 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void CreateAndDeleteVideoRenderer()
         {
-            var context = NativeMethods.ContextCreate(0);
             var renderer = NativeMethods.CreateVideoRenderer(context, OnVideoFrameResize, true);
             NativeMethods.DeleteVideoRenderer(context, renderer);
-            NativeMethods.ContextDestroy(0);
         }
 
         [Test]
@@ -306,7 +275,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public void AddAndRemoveVideoRendererToVideoTrack()
         {
-            var context = NativeMethods.ContextCreate(0);
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
@@ -318,17 +286,14 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.DeleteVideoRenderer(context, renderer);
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, source);
-            NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
 
         [Test]
         public void CallGetRenderEventFunc()
         {
-            var context = NativeMethods.ContextCreate(0);
             var callback = NativeMethods.GetRenderEventFunc(context);
             Assert.AreNotEqual(callback, IntPtr.Zero);
-            NativeMethods.ContextDestroy(0);
             NativeMethods.GetRenderEventFunc(IntPtr.Zero);
         }
 
@@ -361,7 +326,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CallVideoEncoderMethods()
         {
-            var context = NativeMethods.ContextCreate(0);
             var peer = NativeMethods.ContextCreatePeerConnection(context);
             var stream = NativeMethods.ContextCreateMediaStream(context, "MediaStream");
             var streamId = NativeMethods.MediaStreamGetID(stream).AsAnsiStringWithFreeMem();
@@ -390,17 +354,14 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.ContextDeleteRefPtr(context, source);
 
             NativeMethods.ContextDeletePeerConnection(context, peer);
-            NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
         }
 
         [Test]
         public void CallGetUpdateTextureFunc()
         {
-            var context = NativeMethods.ContextCreate(0);
             var callback = NativeMethods.GetUpdateTextureFunc(context);
             Assert.AreNotEqual(callback, IntPtr.Zero);
-            NativeMethods.ContextDestroy(0);
             NativeMethods.GetUpdateTextureFunc(IntPtr.Zero);
         }
 
@@ -411,7 +372,6 @@ namespace Unity.WebRTC.RuntimeTest
             "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator CallVideoDecoderMethods()
         {
-            var context = NativeMethods.ContextCreate(0);
             const int width = 1280;
             const int height = 720;
             var renderTexture = CreateRenderTexture(width, height);
@@ -444,7 +404,6 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.DeleteVideoRenderer(context, renderer);
             NativeMethods.ContextDeleteRefPtr(context, track);
             NativeMethods.ContextDeleteRefPtr(context, source);
-            NativeMethods.ContextDestroy(0);
             UnityEngine.Object.DestroyImmediate(renderTexture);
             UnityEngine.Object.DestroyImmediate(receiveTexture);
         }

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -30,18 +30,6 @@ namespace Unity.WebRTC.RuntimeTest
             return config;
         }
 
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [Test]
         public void Construct()
         {

--- a/Tests/Runtime/StatsReportTest.cs
+++ b/Tests/Runtime/StatsReportTest.cs
@@ -6,18 +6,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class StatsReportTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [Test]
         public void ConstructorThrowsException()
         {

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -8,18 +8,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class TransceiverTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
         [Test]
         public void SenderGetVideoCapabilities()
         {

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -43,14 +43,7 @@ namespace Unity.WebRTC.RuntimeTest
         [SetUp]
         public void SetUp()
         {
-            WebRTC.Initialize(true);
             SetUpCodecCapability();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
         }
 
         internal class TestValue

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -7,24 +7,6 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class WebRTCTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-            WebRTC.Initialize(true);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            WebRTC.Dispose();
-        }
-
-        [Test]
-        public void InitializeTwiceThrowException()
-        {
-            Assert.That(() => WebRTC.Initialize(), Throws.InvalidOperationException);
-        }
-
         [Test]
         public void GraphicsFormat()
         {


### PR DESCRIPTION
Up until now, we has provided `WebRTC.Initialize` and `WebRTC.Initialize` methods for managing allocation of WebRTC resources. However, to use some APIs, initialization process should be finished just after launching Unity Editor.

Therefore, we changed the specification, resource allocation of WebRTC is processed implicitly and developers don't need to invoke them.

In this PR, marked `Obsolete` two methods to keep compatibility, but we will remove them when releasing official release version.