### PR TITLE
fix: Use stdlib TaskQueue instead of GCD TaskQueue

### DIFF
--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -28,7 +28,7 @@ patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
 # disable GCD taskqueue, use stdlib taskqueue instead
 # This is because GCD cannot measure with UnityProfiler
-patch -N "src/api/task_queu/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queue_gcd.patch"
+patch -N "src/api/task_queue/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queue_gcd.patch"
 
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -26,6 +26,10 @@ fi
 # add jsoncpp
 patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
+# disable GCD taskqueue, use stdlib taskqueue instead
+# This is because GCD cannot measure with UnityProfiler
+patch -N "src/api/task_queu/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queue_gcd.patch"
+
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -28,7 +28,7 @@ patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
 # disable GCD taskqueue, use stdlib taskqueue instead
 # This is because GCD cannot measure with UnityProfiler
-patch -N "src/api/task_queu/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queue_gcd.patch"
+patch -N "src/api/task_queue/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queue_gcd.patch"
 
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -26,6 +26,10 @@ fi
 # add jsoncpp
 patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
+# disable GCD taskqueue, use stdlib taskqueue instead
+# This is because GCD cannot measure with UnityProfiler
+patch -N "src/api/task_queu/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queue_gcd.patch"
+
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 

--- a/BuildScripts~/patches/README.md
+++ b/BuildScripts~/patches/README.md
@@ -89,7 +89,7 @@ T data_;
 ^
 ```
 
-Patch file
+### Patch file
 
 - fix_abseil.patch
 
@@ -99,4 +99,36 @@ Patch file
 # `src` is a root directory of libwebrtc.
 
 patch -N "src\third_party\abseil-cpp/absl/base/config.h" < "BuildScripts~\patches\fix_abseil.patch"
+```
+
+## Workaround for crash when encoding Full HD resolution or higher using VideoToolbox on macOS(Intel)
+
+Crash occurs when encoding FullHD or higher resolutions using VideoToolbox. This workaround referred from [here](https://groups.google.com/g/discuss-webrtc/c/AVeyMXnM0gY).
+
+### Patch file
+
+- avoid_crashusingvideoencoderh264.patch
+
+### Example
+
+```
+# `src` is a root directory of libwebrtc.
+
+patch -N "src/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm" < "BuildScripts~/patches/avoid_crashusingvideoencoderh264.patch"
+```
+
+## Workaround for can't be profiled correctly encode/decode process on macOS/iOS
+
+Task queuing in libwebrtc is implemented differently on each platform. macOS/iOS is implemented using [GCD (Global Central Dispatch)](https://developer.apple.com/documentation/DISPATCH). GCD makes no guarantees about which thread it uses to execute a task. Referenced [here](https://developer.apple.com/documentation/dispatch/dispatchqueue). Since UnityProfiler is implemented assuming execution in the same thread, it was changed to use TaskQueue implementation by STDLIB which is executed in the same thread.
+
+### Patch file
+
+- disable_task_queue_gcd.patch
+
+### Example
+
+```
+# `src` is a root directory of libwebrtc.
+
+patch -N "src/api/task_queue/BUILD.gn" < "BuildScripts~/patches/disable_task_queue_gcd.patch"
 ```

--- a/BuildScripts~/patches/disable_task_queue_gcd.patch
+++ b/BuildScripts~/patches/disable_task_queue_gcd.patch
@@ -1,0 +1,15 @@
+--- BUILD.gn	2022-11-30 15:53:16.000000000 +0900
++++ BUILD.gn.patch	2022-11-30 14:19:37.000000000 +0900
+@@ -103,9 +103,9 @@
+       sources += [ "default_task_queue_factory_libevent.cc" ]
+       deps += [ "../../rtc_base:rtc_task_queue_libevent" ]
+     }
+-  } else if (is_mac || is_ios) {
+-    sources += [ "default_task_queue_factory_gcd.cc" ]
+-    deps += [ "../../rtc_base:rtc_task_queue_gcd" ]
++#  } else if (is_mac || is_ios) {
++#    sources += [ "default_task_queue_factory_gcd.cc" ]
++#    deps += [ "../../rtc_base:rtc_task_queue_gcd" ]
+   } else if (is_win && current_os != "winuwp") {
+     sources += [ "default_task_queue_factory_win.cc" ]
+     deps += [ "../../rtc_base:rtc_task_queue_win" ]


### PR DESCRIPTION
Task queuing in libwebrtc is implemented differently on each platform. 
macOS/iOS is implemented using [GCD (Global Central Dispatch)](https://developer.apple.com/documentation/DISPATCH). 
GCD makes no guarantees about which thread it uses to execute a task. Referenced [here](https://developer.apple.com/documentation/dispatch/dispatchqueue). 

Since UnityProfiler is implemented assuming execution in the same thread, it was changed to use TaskQueue implementation by STDLIB which is executed in the same thread.

No performance degradation when using STDLIB Task Queue.