### PR TITLE
test: Downgrade Code Coverage package 1.1.1 for increasing test coverage score

### DIFF
--- a/.yamato/coverage.yml
+++ b/.yamato/coverage.yml
@@ -2,6 +2,9 @@
 
 editor_version: 2021.3
 
+# todo(kazuki): Use old version because Code Coverage 1.2.2 has some issues.
+coverage-pkg-version: 1.1.1
+
 platforms:
   - name: win
     type: Unity::VM
@@ -31,7 +34,7 @@ codecoverage_{{ package.name }}_{{ platform.name }}_{{ editor_version }}:
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-    - upm-ci package test -u {{ editor_version }} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.WebRTC"
+    - upm-ci package test -u {{ editor_version }} --enable-code-coverage --code-coverage-options --extra-utr-arg=--coverage-pkg-version={{ coverage-pkg-version }} "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.WebRTC"
   artifacts:
     {{ editor_version }}_{{ platform.name }}_coverage_results: 
       paths:
@@ -62,7 +65,7 @@ codecoverage_{{ package.name }}_{{ platform.name }}_{{ editor_version }}:
     - scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -pr ./utr/ bokken@$BOKKEN_DEVICE_IP:~/com.unity.webrtc/
     - ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP '$(/usr/local/bin/python3 -m site --user-base)/bin/unity-downloader-cli -u {{ editor.version }} -c editor --wait --published'
     - |
-      ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP 'cd ~/com.unity.webrtc/WebRTC~ && ~/com.unity.webrtc/utr/utr --suite=editor --suite=playmode --testproject=/Users/bokken/com.unity.webrtc/WebRTC~ --editor-location=/Users/bokken/.Editor --artifacts_path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results --extra-editor-arg="-enablePackageManagerTraces" --enable-code-coverage --coverage-results-path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results --coverage-options="generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.WebRTC"'
+      ssh -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" bokken@$BOKKEN_DEVICE_IP 'cd ~/com.unity.webrtc/WebRTC~ && ~/com.unity.webrtc/utr/utr --suite=editor --suite=playmode --testproject=/Users/bokken/com.unity.webrtc/WebRTC~ --editor-location=/Users/bokken/.Editor --artifacts_path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results --coverage-pkg-version={{ coverage-pkg-version }} --extra-editor-arg="-enablePackageManagerTraces" --enable-code-coverage --coverage-results-path=/Users/bokken/com.unity.webrtc/WebRTC~/test-results --coverage-options="generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.WebRTC"'
       UTR_RESULT=$?
       mkdir -p upm-ci~/test-results/
       scp -i ~/.ssh/id_rsa_macmini -o "StrictHostKeyChecking=no" -r bokken@$BOKKEN_DEVICE_IP:/Users/bokken/com.unity.webrtc/WebRTC~/test-results/ upm-ci~/test-results/

--- a/.yamato/coverage.yml
+++ b/.yamato/coverage.yml
@@ -34,7 +34,7 @@ codecoverage_{{ package.name }}_{{ platform.name }}_{{ editor_version }}:
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - npm install upm-ci-utils@{{ upm.package_version }} -g --registry {{ upm.registry_url }}
-    - upm-ci package test -u {{ editor_version }} --enable-code-coverage --code-coverage-options --extra-utr-arg=--coverage-pkg-version={{ coverage-pkg-version }} "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.WebRTC"
+    - upm-ci package test -u {{ editor_version }} --extra-utr-arg=--coverage-pkg-version={{ coverage-pkg-version }} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:-UnityEngine.*,+Unity.WebRTC"
   artifacts:
     {{ editor_version }}_{{ platform.name }}_coverage_results: 
       paths:

--- a/Editor/PeerStatsView.cs
+++ b/Editor/PeerStatsView.cs
@@ -74,12 +74,14 @@ namespace Unity.WebRTC.Editor
                         case RTCStatsType.DataChannel:
                             container.Add(CreateDataChannelView(id));
                             break;
+#pragma warning disable 0612
                         case RTCStatsType.Stream:
                             container.Add(CreateStreamView(id));
                             break;
                         case RTCStatsType.Track:
                             container.Add(CreateTrackView(id));
                             break;
+#pragma warning restore 0612
                         case RTCStatsType.Transceiver:
                             container.Add(CreateTransceiverView(id));
                             break;
@@ -497,12 +499,15 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
+
+#pragma warning disable 0612
                 if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCMediaStreamStats streamStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Stream}"));
                     return;
                 }
+#pragma warning restore 0612
 
                 container.Add(new Label($"{nameof(streamStats.Id)}: {streamStats.Id}"));
                 container.Add(new Label($"{nameof(streamStats.Timestamp)}: {streamStats.Timestamp}"));
@@ -519,7 +524,9 @@ namespace Unity.WebRTC.Editor
             var container = new VisualElement();
             root.Add(container);
 
+#pragma warning disable 0612
             var trackGraph = new MediaStreamTrackGraphView();
+#pragma warning restore 0612
 
             m_parent.OnStats += (peer, report) =>
             {
@@ -529,12 +536,14 @@ namespace Unity.WebRTC.Editor
                 }
 
                 container.Clear();
+#pragma warning disable 0612
                 if (!report.TryGetValue(id, out var stats) ||
                     !(stats is RTCMediaStreamTrackStats trackStats))
                 {
                     container.Add(new Label($"no stats report about {RTCStatsType.Track}"));
                     return;
                 }
+#pragma warning restore 0612
 
                 container.Add(new Label($"{nameof(trackStats.Id)}: {trackStats.Id}"));
                 container.Add(new Label($"{nameof(trackStats.Timestamp)}: {trackStats.Timestamp}"));

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -35,8 +35,7 @@ namespace Unity.WebRTC
             {
                 if (_source != null)
                     return _source;
-                return _streamRenderer.Source;
-
+                return _streamRenderer?.Source;
             }
         }
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -17,9 +17,7 @@ namespace Unity.WebRTC
 #if UNITY_EDITOR
         static ContextManager()
         {
-            AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
-            AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
-            EditorApplication.quitting += Quit;
+            Init();
         }
 
         static void OnBeforeAssemblyReload()
@@ -32,24 +30,28 @@ namespace Unity.WebRTC
             WebRTC.InitializeInternal();
         }
 
-        static void Quit()
+        internal static void Init()
         {
-            AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
-            AssemblyReloadEvents.afterAssemblyReload -= OnAfterAssemblyReload;
-            WebRTC.DisposeInternal();
+            AssemblyReloadEvents.beforeAssemblyReload += OnBeforeAssemblyReload;
+            AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
+            EditorApplication.quitting += Quit;
         }
 #else
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        static void Init()
+        internal static void Init()
         {
             Application.quitting += Quit;
             WebRTC.InitializeInternal();
         }
-        static void Quit()
+#endif
+        internal static void Quit()
         {
+#if UNITY_EDITOR
+            AssemblyReloadEvents.beforeAssemblyReload -= OnBeforeAssemblyReload;
+            AssemblyReloadEvents.afterAssemblyReload -= OnAfterAssemblyReload;
+#endif
             WebRTC.DisposeInternal();
         }
-#endif
     }
 
     internal class Context : IDisposable

--- a/Runtime/Scripts/Internal/IntPtrExtension.cs
+++ b/Runtime/Scripts/Internal/IntPtrExtension.cs
@@ -113,8 +113,8 @@ namespace Unity.WebRTC
         {
             Dictionary<string, T> ret = new Dictionary<string, T>();
 
-            string[] keys = ptr.AsArray<string>(length);
-            T[] values = valuesPtr.AsArray<T>(length);
+            string[] keys = ptr.AsArray<string>(length, freePtr);
+            T[] values = valuesPtr.AsArray<T>(length, freePtr);
 
             for(int i = 0; i < length; i++)
             {

--- a/Runtime/Scripts/RTCPeerConnection.cs
+++ b/Runtime/Scripts/RTCPeerConnection.cs
@@ -270,10 +270,6 @@ namespace Unity.WebRTC
             return self;
         }
 
-        internal DelegateSetSessionDescSuccess OnSetSessionDescriptionSuccess { get; set; }
-
-        internal DelegateSetSessionDescFailure OnSetSessionDescriptionFailure { get; set; }
-
         [AOT.MonoPInvokeCallback(typeof(DelegateNativeOnIceCandidate))]
         static void PCOnIceCandidate(IntPtr ptr, string sdp, string sdpMid, int sdpMlineIndex)
         {

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -23,6 +23,13 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.RegisterDebugLog(null, true, NativeLoggingSeverity.Verbose);
         }
 
+        [Test]
+        public void QuitAndInitContextManager()
+        {
+            // ContextManager.Init is already called when the process reaches here.
+            ContextManager.Quit();
+            ContextManager.Init();
+        }
 
         [Test]
         public void CreateAndDeletePeerConnection()

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -30,8 +30,10 @@ namespace Unity.WebRTC.RuntimeTest
             ContextManager.Quit();
             ContextManager.Init();
 
+#if UNITY_EDITOR
             // Reinitialize
             WebRTC.InitializeInternal();
+#endif
         }
 
         [Test]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -29,6 +29,9 @@ namespace Unity.WebRTC.RuntimeTest
             // ContextManager.Init is already called when the process reaches here.
             ContextManager.Quit();
             ContextManager.Init();
+
+            // Reinitialize
+            WebRTC.InitializeInternal();
         }
 
         [Test]

--- a/Tests/Runtime/IntPtrTest.cs
+++ b/Tests/Runtime/IntPtrTest.cs
@@ -15,14 +15,15 @@ namespace Unity.WebRTC.RuntimeTest
         public void AsAnsiStringWithFreeMemThrowException()
         {
             IntPtr ptr = IntPtr.Zero;
-            Assert.Throws<ArgumentException>(() => { ptr.AsAnsiStringWithFreeMem();  });
+            Assert.That(() => { ptr.AsAnsiStringWithFreeMem(); }, Throws.TypeOf<ArgumentException>());
+
         }
 
         [Test]
         public void AsAnsiStringWithoutFreeMemThrowException()
         {
             IntPtr ptr = IntPtr.Zero;
-            Assert.Throws<ArgumentException>(() => { ptr.AsAnsiStringWithoutFreeMem(); });
+            Assert.That(() => { ptr.AsAnsiStringWithoutFreeMem(); }, Throws.TypeOf<ArgumentException>());
         }
 
         [Test]
@@ -31,8 +32,8 @@ namespace Unity.WebRTC.RuntimeTest
             string source = "test";
             IntPtr ptr = Marshal.StringToCoTaskMemAnsi(source);
             string dest = ptr.AsAnsiStringWithoutFreeMem();
-            Assert.IsNotEmpty(dest);
-            Assert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
             Marshal.FreeCoTaskMem(ptr);
         }
 
@@ -42,8 +43,8 @@ namespace Unity.WebRTC.RuntimeTest
             string source = "test";
             IntPtr ptr = Marshal.StringToCoTaskMemAnsi(source);
             string dest = ptr.AsAnsiStringWithFreeMem();
-            Assert.IsNotEmpty(dest);
-            Assert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -52,8 +53,8 @@ namespace Unity.WebRTC.RuntimeTest
             byte[] source = { 1, 2, 3 };
             IntPtr ptr = source.ToPtr();
             byte[] dest = ptr.AsArray<byte>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -62,8 +63,8 @@ namespace Unity.WebRTC.RuntimeTest
             int[] source = {1, 2, 3};
             IntPtr ptr = source.ToPtr();
             int[] dest = ptr.AsArray<int>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -72,8 +73,8 @@ namespace Unity.WebRTC.RuntimeTest
             uint[] source = { 1, 2, 3 };
             IntPtr ptr = source.ToPtr();
             uint[] dest = ptr.AsArray<uint>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -82,8 +83,8 @@ namespace Unity.WebRTC.RuntimeTest
             long[] source = { 1, 2, 3 };
             IntPtr ptr = source.ToPtr();
             long[] dest = ptr.AsArray<long>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -92,8 +93,8 @@ namespace Unity.WebRTC.RuntimeTest
             ulong[] source = { 1, 2, 3 };
             IntPtr ptr = source.ToPtr();
             ulong[] dest = ptr.AsArray<ulong>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -102,8 +103,8 @@ namespace Unity.WebRTC.RuntimeTest
             double[] source = { 0.1, 0.2, 0.3 };
             IntPtr ptr = source.ToPtr();
             double[] dest = ptr.AsArray<double>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -112,8 +113,8 @@ namespace Unity.WebRTC.RuntimeTest
             float[] source = { 0.1f, 0.2f, 0.3f };
             IntPtr ptr = source.ToPtr();
             float[] dest = ptr.AsArray<float>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -122,8 +123,8 @@ namespace Unity.WebRTC.RuntimeTest
             bool[] source = { true, false, true };
             IntPtr ptr = source.ToPtr();
             bool[] dest = ptr.AsArray<bool>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
         }
 
         [Test]
@@ -132,8 +133,21 @@ namespace Unity.WebRTC.RuntimeTest
             string[] source = { "red", "blue", "yellow" };
             IntPtr ptr = source.ToPtr();
             string[] dest = ptr.AsArray<string>(source.Length);
-            Assert.IsNotEmpty(dest);
-            CollectionAssert.AreEqual(source, dest);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(source, Is.EqualTo(dest));
+        }
+
+        [Test]
+        public void AsMapReturnsDictionary()
+        {
+            string[] keys = { "red", "blue", "yellow" };
+            IntPtr ptr1 = keys.ToPtr();
+            ulong[] values = { 1, 2, 3 };
+            IntPtr ptr2 = values.ToPtr();
+            Dictionary<string, ulong> dest = ptr1.AsMap<ulong>(ptr2, values.Length);
+            Assert.That(dest, Is.Not.Null);
+            Assert.That(dest.Keys, Is.EqualTo(keys));
+            Assert.That(dest.Values, Is.EqualTo(values));
         }
     }
 }

--- a/Tests/Runtime/PeerConnectionTest.cs
+++ b/Tests/Runtime/PeerConnectionTest.cs
@@ -483,7 +483,7 @@ namespace Unity.WebRTC.RuntimeTest
         {
             var config = GetDefaultConfiguration();
             var peer = new RTCPeerConnection(ref config);
-            var op = peer.CreateOffer();
+            var op = peer.CreateOffer(ref RTCOfferAnswerOptions.Default);
 
             yield return op;
             Assert.True(op.IsDone);
@@ -529,7 +529,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return op2;
             var op3 = peer2.SetRemoteDescription(ref desc);
             yield return op3;
-            var op4 = peer2.CreateAnswer();
+            var op4 = peer2.CreateAnswer(ref RTCOfferAnswerOptions.Default);
             yield return op4;
 
             Assert.True(op4.IsDone);

--- a/WebRTC~/Packages/manifest.json
+++ b/WebRTC~/Packages/manifest.json
@@ -2,11 +2,11 @@
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.ext.nunit": "1.0.6",
-    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.rider": "3.0.16",
     "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",
-    "com.unity.testtools.codecoverage": "1.2.0-exp.7",
+    "com.unity.testtools.codecoverage": "1.1.1",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.audio": "1.0.0",

--- a/WebRTC~/Packages/packages-lock.json
+++ b/WebRTC~/Packages/packages-lock.json
@@ -15,7 +15,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.15",
+      "version": "3.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -40,7 +40,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "1.0.1",
+      "version": "2.0.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -58,7 +58,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.2.0-exp.7",
+      "version": "1.1.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/WebRTC~/Packages/packages-lock.json
+++ b/WebRTC~/Packages/packages-lock.json
@@ -40,7 +40,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "2.0.1",
+      "version": "1.0.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
This pull request improves test coverage. 

I found the main reason of decreasing the coverage score is the issue of Code Coverage package.
The latest version 1.2.2 of Code Coverage package has issues which ignores the covering some code. So it decreased the coverage score. This issue is not reproduced with the previous version 1.1.1 so I downgraded the package.

I got the result below after improving.

- Line coverage: 83.5%
- Method coverage: 80.3%

![image](https://user-images.githubusercontent.com/1132081/206076094-3fdb21f6-4b8d-4cd5-8986-f51eb61a9aa0.png)
