### PR TITLE
doc: Update documentation for build settings for mobile platforms 

### DIFF
--- a/Documentation~/requirements.md
+++ b/Documentation~/requirements.md
@@ -37,3 +37,9 @@ To build the apk file for **Android platform**, you need to configure player set
 
 > [!NOTE]
 > Set disable **Optimized Frame Pacing** in Player Settings Window. ( Known issues https://github.com/Unity-Technologies/com.unity.webrtc/issues/437)
+
+### Build on iOS
+
+You must disable the bitcode option in Xcode project exported from Unity.
+
+- On the Xcode **Build Settings** tab, in the **Build Options** group, set Enable Bitcode to **No**.

--- a/Documentation~/requirements.md
+++ b/Documentation~/requirements.md
@@ -34,6 +34,7 @@ To build the apk file for **Android platform**, you need to configure player set
 
 - Choose **IL2CPP** for **Scripting backend** in Player Settings Window.
 - Set enadle **ARM64** and Set disable **ARMv7** for **Target Architectures** setting in Player Settings Window.
+- Choose **Require** for **Internet Access** in Player Setting Window.
 
 > [!NOTE]
 > Set disable **Optimized Frame Pacing** in Player Settings Window. ( Known issues https://github.com/Unity-Technologies/com.unity.webrtc/issues/437)

--- a/Documentation~/requirements.md
+++ b/Documentation~/requirements.md
@@ -44,3 +44,5 @@ To build the apk file for **Android platform**, you need to configure player set
 You must disable the bitcode option in Xcode project exported from Unity.
 
 - On the Xcode **Build Settings** tab, in the **Build Options** group, set Enable Bitcode to **No**.
+
+Or refer to the Unity Support's answer. https://support.unity.com/hc/en-us/articles/207942813-How-can-I-disable-Bitcode-support-


### PR DESCRIPTION
for Android
- Choose **Require** for **Internet Access** in Player Setting Window.

for iOS
- On the Xcode **Build Settings** tab, in the **Build Options** group, set Enable Bitcode to **No**.