### PR TITLE
fix: Fix crash on Android device Pixel4a

### DIFF
--- a/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
+++ b/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
@@ -39,12 +39,18 @@ namespace webrtc
 
     rtc::scoped_refptr<webrtc::I420BufferInterface> VideoFrameAdapter::ScaledBuffer::ToI420()
     {
-        return parent_->GetOrCreateFrameBufferForSize(Size(width_, height_))->ToI420();
+        auto buffer = parent_->GetOrCreateFrameBufferForSize(Size(width_, height_));
+        if(!buffer)
+            return nullptr;
+        return buffer->ToI420();
     }
 
     const I420BufferInterface* VideoFrameAdapter::ScaledBuffer::GetI420() const
     {
-        return parent_->GetOrCreateFrameBufferForSize(Size(width_, height_))->GetI420();
+        auto buffer = parent_->GetOrCreateFrameBufferForSize(Size(width_, height_));
+        if(!buffer)
+            return nullptr;
+        return buffer->GetI420();
     }
 
     rtc::scoped_refptr<VideoFrameBuffer>


### PR DESCRIPTION
We found the issue that occurring crash on specific Android devices like Pixel4a when streaming high resolution video.
We got the crash log below.

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Version '2020.3.43f1 (75bff06b76bf)', Build type 'Development', Scripting Backend 'il2cpp', CPU 'arm64-v8a'
Build fingerprint: 'google/sunfish/sunfish:13/TP1A.220905.004/8927612:user/release-keys'
Revision: 'MP1.0'
ABI: 'arm64'
Timestamp: 2022-12-23 10:34:43+0900
pid: 28577, tid: 28626, name: UnityGfxDeviceW  >>> com.DefaultCompany.RenderStreaming <<<
uid: 10385
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xfb20507950
    x0  b400007ba0676a90  x1  000000000000000a  x2  b400007b004b7510  x3  0000000000000001
    x4  000000000000002e  x5  0000000000000002  x6  00000007fe35fa30  x7  0000000000000001
    x8  000000000000006b  x9  b400007ae04f9790  x10 0000000000000002  x11 0000000000000000
    x12 0000000000000066  x13 0000000000000000  x14 b400007bc0480920  x15 00000007fe35f978
    x16 000000794d24d000  x17 000000000000006b  x18 00000000ac3b7fa9  x19 b400007b205079d0
    x20 b400007b704d71b0  x21 b400007b704d71b0  x22 0000000000000001  x23 000000000000a000
    x24 0000000000000001  x25 00000000ffffffff  x26 0000007fffffff80  x27 0000000000000000
    x28 000000794cf40d80  x29 000000794cf413b0
    sp  000000794cf40c50  lr  000000794d2cbe70  pc  000000794d2cbe7c
backtrace:
      #00 pc 000000000008ae7c  /vendor/lib64/hw/vulkan.adreno.so (BuildId: 193dfefaf1d55b1fb7c1edff7bf769a2)
      #01 pc 000000000007adf0  /vendor/lib64/hw/vulkan.adreno.so (qglinternal::vkCmdBlitImage(VkCommandBuffer_T*, VkImage_T*, VkImageLayout, VkImage_T*, VkImageLayout, unsigned int, VkImageBlit const*, VkFilter)+376) (BuildId: 193dfefaf1d55b1fb7c1edff7bf769a2)
      #02 pc 000000000007c524  /vendor/lib64/hw/vulkan.adreno.so (qglinternal::vkCmdCopyImage(VkCommandBuffer_T*, VkImage_T*, VkImageLayout, VkImage_T*, VkImageLayout, unsigned int, VkImageCopy const*)+2684) (BuildId: 193dfefaf1d55b1fb7c1edff7bf769a2)
      #03 pc 0000000000131a18  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libwebrtc.so (unity::webrtc::VulkanUtility::CopyImage(VkCommandBuffer_T*, VkImage_T*, VkImage_T*, unsigned int, unsigned int)+96)
      #04 pc 00000000001305ac  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libwebrtc.so (unity::webrtc::VulkanGraphicsDevice::CopyResourceFromNativeV(unity::webrtc::ITexture2D*, void*)+404)
      #05 pc 0000000000133544  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libwebrtc.so (unity::webrtc::GpuMemoryBufferFromUnity::CopyBuffer(void*)+44)
      #06 pc 000000000012d9a0  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libwebrtc.so (unity::webrtc::GpuMemoryBufferPool::GetOrCreateFrameResources(void*, unity::webrtc::Size const&, UnityRenderingExtTextureFormat)+400)
      #07 pc 000000000012d604  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libwebrtc.so (unity::webrtc::GpuMemoryBufferPool::CreateFrame(void*, unity::webrtc::Size const&, UnityRenderingExtTextureFormat, webrtc::Timestamp)+44)
      #08 pc 0000000000116f48  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libwebrtc.so (OnRenderEvent(int, void*)+300)
      #09 pc 0000000000dba458  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libunity.so (GfxDeviceVK::InsertCustomMarkerCallbackAndData(void (*)(int, void*), int, void*, unsigned long)+132) (BuildId: f51bfd265c481bcb9db390b5dbc6062921da6724)
      #10 pc 00000000013eee1c  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libunity.so (GfxDeviceWorker::RunCommand(ThreadedStreamBuffer&)+29532) (BuildId: f51bfd265c481bcb9db390b5dbc6062921da6724)
      #11 pc 00000000013ef6a4  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libunity.so (GfxDeviceWorker::RunExt(ThreadedStreamBuffer&)+44) (BuildId: f51bfd265c481bcb9db390b5dbc6062921da6724)
      #12 pc 00000000013ef66c  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libunity.so (GfxDeviceWorker::Run()+136) (BuildId: f51bfd265c481bcb9db390b5dbc6062921da6724)
      #13 pc 00000000013e78a8  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libunity.so (GfxDeviceWorker::RunGfxDeviceWorker(void*)+4) (BuildId: f51bfd265c481bcb9db390b5dbc6062921da6724)
      #14 pc 0000000000b30b70  /data/app/~~Cn-1W7BX24HENJVlxgZexA==/com.DefaultCompany.RenderStreaming-Vy0esMa-4kBeKUH2WD978g==/lib/arm64/libunity.so (Thread::RunThreadWrapper(void*)+512) (BuildId: f51bfd265c481bcb9db390b5dbc6062921da6724)
      #15 pc 00000000000b62b8  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 058e3ec96fa600fb840a6a6956c6b64e)
      #16 pc 0000000000052fb8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 058e3ec96fa600fb840a6a6956c6b64e)
```

It looks the crash is occuerred by the `vkCmdBlitImage` function, but it should be a red herring.