### PR TITLE
CI: Switch images used for running CI jobs

### DIFF
--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -4,7 +4,7 @@ build_platforms:
   - name: win
     type: Unity::VM
     flavor: b1.large
-    image: renderstreaming/win10:v0.3.13-1084239
+    image: renderstreaming/win10:v0.5.0-1259536
     build_command: BuildScripts~/build_plugin_win.cmd
     build_testrunner_command: BuildScripts~/build_testrunner_win.cmd
     plugin_path: Runtime/Plugins/x86_64/webrtc.dll
@@ -46,15 +46,15 @@ test_platforms:
   - name: win
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/win10:v0.3.13-1084239
-    gpu_image: renderstreaming/win10:v0.3.13-1084240
+    image: renderstreaming/win10:v0.5.0-1259536
+    gpu_image: renderstreaming/win10:v0.5.0-1259773
     flavor: b1.large
     model: rtx2080
   - name: linux
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.2.9-1258156
-    gpu_image: renderstreaming/ubuntu:v0.2.9-1258158
+    image: renderstreaming/ubuntu:v0.3.1-1262596
+    gpu_image: renderstreaming/ubuntu:v0.3.1-1262597
     flavor: b1.large
     model: rtx2080
   - name: macos
@@ -159,7 +159,7 @@ test_{{ platform.name }}_gpu:
     - |
        # See False positives
        # https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow
-       export ASAN_OPTIONS=protect_shadow_gap=0:detect_leaks=1:detect_container_overflow=0
+       export ASAN_OPTIONS=protect_shadow_gap=0:detect_leaks=1:detect_container_overflow=0:alloc_dealloc_mismatch=0
        export LSAN_OPTIONS=suppressions=$(pwd)/Plugin~/tools/sanitizer/lsan_suppressions.txt
        chmod ./WebRTCLibTest
        ./WebRTCLibTest

--- a/.yamato/upm-ci-libwebrtc.yml
+++ b/.yamato/upm-ci-libwebrtc.yml
@@ -3,7 +3,7 @@
 platforms:
   - name: win
     type: Unity::VM
-    image: renderstreaming/win10:v0.4.0-1250406
+    image: renderstreaming/win10:v0.5.0-1259536
     flavor: b1.xlarge
     build_command: BuildScripts~/build_libwebrtc_win.cmd
   - name: macos

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -65,7 +65,7 @@ test_targets:
         platform: standalone
   - name: linux-gpu
     type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.2.9-1258158
+    image: renderstreaming/ubuntu:v0.3.1-1262597
     flavor: b1.large
     model: rtx2080
     is_gpu: true

--- a/.yamato/verification.yml
+++ b/.yamato/verification.yml
@@ -25,37 +25,37 @@ platforms:
   - name: Ubuntu 18.04
     agent: lin_18.04_bokken
     type: Unity::VM
-    image: katana-to-yamato/desktop-ubuntu-18.04-desktop-katana-git:v1.10-auto
+    image: desktop/ubuntu-18.04-desktop-workstation:v1.9.0
     flavor: b1.large
     group: linux
   - name: macOS 10.14
     agent: mac_test_10.14
     type: Unity::VM::osx
-    image: katana-to-yamato/automation-tooling-macos-10.14-katana-git:v1.12-auto
+    image: automation-tooling/macos-10.14:v0.1.2-1059229
     flavor: m1.mac
     group: macos
   - name: Windows 10
     agent: win10_test
     type: Unity::VM
-    image: katana-to-yamato/test-platform-win10-katana-git:v1.9-auto
+    image: test-platform/win10:v1.0.0-1094330
     flavor: b1.large
     group: windows
   - name: iOS
     agent: mac_iphone_se
     type: Unity::mobile::iPhone
-    image: katana-to-yamato/mobile-ios-macos-11-katana-se-git:v1.6-auto
+    image: mobile/ios-macos-11:v0.1.3-1255777
     flavor: m1.mac
     group: ios
   - name: Ubuntu 16.04
     agent: lin_test_ubuntu16.04
     type: Unity::VM
-    image: katana-to-yamato/test-platform-ubuntu16.04-katana-git:v1.11-auto
+    image: test-platform/ubuntu16.04:v0.4-1006434
     flavor: b1.large
     group: linux
   - name: macOS 10.13
     agent: mac_test_10.13
     type: Unity::VM::osx
-    image: katana-to-yamato/test-platform-macos-10.13-katana-git:v1.10-auto
+    image: test-platform/macos-10.13:v0.3-615368
     flavor: m1.mac
     group: macos
 

--- a/Plugin~/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/Plugin~/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of
@@ -18,9 +18,11 @@
 #include "NvDecoder/NvDecoder.h"
 
 #define START_TIMER auto start = std::chrono::high_resolution_clock::now();
-#define STOP_TIMER(print_message) std::cout << print_message << \
-    std::chrono::duration_cast<std::chrono::milliseconds>( \
-    std::chrono::high_resolution_clock::now() - start).count() \
+
+#define STOP_TIMER(print_message) int64_t elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>( \
+    std::chrono::high_resolution_clock::now() - start).count(); \
+    std::cout << print_message << \
+    elapsedTime \
     << " ms " << std::endl;
 
 #define CUDA_DRVAPI_CALL( call )                                                                                                 \
@@ -129,6 +131,8 @@ static int GetChromaPlaneCount(cudaVideoSurfaceFormat eSurfaceFormat)
 
     return numPlane;
 }
+
+std::map<int, int64_t> NvDecoder::sessionOverHead = { {0,0}, {1,0} };
 
 /**
 *   @brief  This function is used to get codec string from codec id
@@ -345,6 +349,7 @@ int NvDecoder::HandleVideoSequence(CUVIDEOFORMAT *pVideoFormat)
     NVDEC_API_CALL(cuvidCreateDecoder(&m_hDecoder, &videoDecodeCreateInfo));
     CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
     STOP_TIMER("Session Initialization Time: ");
+    NvDecoder::addDecoderSessionOverHead(getDecoderSessionID(), elapsedTime);
     return nDecodeSurface;
 }
 
@@ -495,7 +500,7 @@ int NvDecoder::setReconfigParams(const Rect *pCropRect, const Dim *pResizeDim)
         }
         else
         {
-            delete[] pFrame;
+            delete pFrame;
         }
     }
 
@@ -514,6 +519,15 @@ int NvDecoder::HandlePictureDecode(CUVIDPICPARAMS *pPicParams) {
     m_nPicNumInDecodeOrder[pPicParams->CurrPicIdx] = m_nDecodePicCnt++;
     CUDA_DRVAPI_CALL(cuCtxPushCurrent(m_cuContext));
     NVDEC_API_CALL(cuvidDecodePicture(m_hDecoder, pPicParams));
+    if (m_bForce_zero_latency && ((!pPicParams->field_pic_flag) || (pPicParams->second_field)))
+    {
+        CUVIDPARSERDISPINFO dispInfo;
+        memset(&dispInfo, 0, sizeof(dispInfo));
+        dispInfo.picture_index = pPicParams->CurrPicIdx;
+        dispInfo.progressive_frame = !pPicParams->field_pic_flag;
+        dispInfo.top_field_first = pPicParams->bottom_field_flag ^ 1;
+        HandlePictureDisplay(&dispInfo);
+    }
     CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
     return 1;
 }
@@ -528,6 +542,47 @@ int NvDecoder::HandlePictureDisplay(CUVIDPARSERDISPINFO *pDispInfo) {
     videoProcessingParameters.top_field_first = pDispInfo->top_field_first;
     videoProcessingParameters.unpaired_field = pDispInfo->repeat_first_field < 0;
     videoProcessingParameters.output_stream = m_cuvidStream;
+
+    if (m_bExtractSEIMessage)
+    {
+        if (m_SEIMessagesDisplayOrder[pDispInfo->picture_index].pSEIData)
+        {
+            // Write SEI Message
+            uint8_t *seiBuffer = (uint8_t *)(m_SEIMessagesDisplayOrder[pDispInfo->picture_index].pSEIData);
+            uint32_t seiNumMessages = m_SEIMessagesDisplayOrder[pDispInfo->picture_index].sei_message_count;
+            CUSEIMESSAGE *seiMessagesInfo = m_SEIMessagesDisplayOrder[pDispInfo->picture_index].pSEIMessage;
+            if (m_fpSEI)
+            {
+                for (uint32_t i = 0; i < seiNumMessages; i++)
+                {
+                    if (m_eCodec == cudaVideoCodec_H264 || cudaVideoCodec_H264_SVC || cudaVideoCodec_H264_MVC || cudaVideoCodec_HEVC)
+                    {    
+                        switch (seiMessagesInfo[i].sei_message_type)
+                        {
+                            case SEI_TYPE_TIME_CODE:
+                            {
+                                HEVCSEITIMECODE *timecode = (HEVCSEITIMECODE *)seiBuffer;
+                                fwrite(timecode, sizeof(HEVCSEITIMECODE), 1, m_fpSEI);
+                            }
+                            break;
+                            case SEI_TYPE_USER_DATA_UNREGISTERED:
+                            {
+                                fwrite(seiBuffer, seiMessagesInfo[i].sei_message_size, 1, m_fpSEI);
+                            }
+                            break;
+                        }            
+                    }
+                    if (m_eCodec == cudaVideoCodec_AV1)
+                    {
+                        fwrite(seiBuffer, seiMessagesInfo[i].sei_message_size, 1, m_fpSEI);
+                    }    
+                    seiBuffer += seiMessagesInfo[i].sei_message_size;
+                }
+            }
+            free(m_SEIMessagesDisplayOrder[pDispInfo->picture_index].pSEIData);
+            free(m_SEIMessagesDisplayOrder[pDispInfo->picture_index].pSEIMessage);
+        }
+    }
 
     CUdeviceptr dpSrcFrame = 0;
     unsigned int nSrcPitch = 0;
@@ -609,16 +664,67 @@ int NvDecoder::HandlePictureDisplay(CUVIDPARSERDISPINFO *pDispInfo) {
     return 1;
 }
 
+int NvDecoder::GetSEIMessage(CUVIDSEIMESSAGEINFO *pSEIMessageInfo)
+{
+    uint32_t seiNumMessages = pSEIMessageInfo->sei_message_count;
+    CUSEIMESSAGE *seiMessagesInfo = pSEIMessageInfo->pSEIMessage;
+    size_t totalSEIBufferSize = 0;
+    if ((pSEIMessageInfo->picIdx < 0) || (pSEIMessageInfo->picIdx >= MAX_FRM_CNT))
+    {
+        printf("Invalid picture index (%d)\n", pSEIMessageInfo->picIdx);
+        return 0;
+    }
+    for (uint32_t i = 0; i < seiNumMessages; i++)
+    {
+        totalSEIBufferSize += seiMessagesInfo[i].sei_message_size;
+    }
+    if (!m_pCurrSEIMessage)
+    {
+        printf("Out of Memory, Allocation failed for m_pCurrSEIMessage\n");
+        return 0;
+    }
+    m_pCurrSEIMessage->pSEIData = malloc(totalSEIBufferSize);
+    if (!m_pCurrSEIMessage->pSEIData)
+    {
+        printf("Out of Memory, Allocation failed for SEI Buffer\n");
+        return 0;
+    }
+    memcpy(m_pCurrSEIMessage->pSEIData, pSEIMessageInfo->pSEIData, totalSEIBufferSize);
+    m_pCurrSEIMessage->pSEIMessage = (CUSEIMESSAGE *)malloc(sizeof(CUSEIMESSAGE) * seiNumMessages);
+    if (!m_pCurrSEIMessage->pSEIMessage)
+    {
+        free(m_pCurrSEIMessage->pSEIData);
+        m_pCurrSEIMessage->pSEIData = NULL;
+        return 0;
+    }
+    memcpy(m_pCurrSEIMessage->pSEIMessage, pSEIMessageInfo->pSEIMessage, sizeof(CUSEIMESSAGE) * seiNumMessages);
+    m_pCurrSEIMessage->sei_message_count = pSEIMessageInfo->sei_message_count;
+    m_SEIMessagesDisplayOrder[pSEIMessageInfo->picIdx] = *m_pCurrSEIMessage;
+    return 1;
+}
+
 NvDecoder::NvDecoder(CUcontext cuContext, bool bUseDeviceFrame, cudaVideoCodec eCodec, bool bLowLatency, 
-    bool bDeviceFramePitched, const Rect *pCropRect, const Dim *pResizeDim, int maxWidth, int maxHeight, unsigned int clkRate) :
+    bool bDeviceFramePitched, const Rect *pCropRect, const Dim *pResizeDim, bool extract_user_SEI_Message,
+    int maxWidth, int maxHeight, unsigned int clkRate, bool force_zero_latency) :
     m_cuContext(cuContext), m_bUseDeviceFrame(bUseDeviceFrame), m_eCodec(eCodec), m_bDeviceFramePitched(bDeviceFramePitched),
-    m_nMaxWidth (maxWidth), m_nMaxHeight(maxHeight)
+    m_bExtractSEIMessage(extract_user_SEI_Message), m_nMaxWidth (maxWidth), m_nMaxHeight(maxHeight),
+    m_bForce_zero_latency(force_zero_latency)
 {
     if (pCropRect) m_cropRect = *pCropRect;
     if (pResizeDim) m_resizeDim = *pResizeDim;
 
     NVDEC_API_CALL(cuvidCtxLockCreate(&m_ctxLock, cuContext));
 
+    ck(cuStreamCreate(&m_cuvidStream, CU_STREAM_DEFAULT));
+
+    decoderSessionID = 0;
+
+    if (m_bExtractSEIMessage)
+    {
+        m_fpSEI = fopen("sei_message.txt", "wb");
+        m_pCurrSEIMessage = new CUVIDSEIMESSAGEINFO;
+        memset(&m_SEIMessagesDisplayOrder, 0, sizeof(m_SEIMessagesDisplayOrder));
+    }
     CUVIDPARSERPARAMS videoParserParameters = {};
     videoParserParameters.CodecType = eCodec;
     videoParserParameters.ulMaxNumDecodeSurfaces = 1;
@@ -627,14 +733,25 @@ NvDecoder::NvDecoder(CUcontext cuContext, bool bUseDeviceFrame, cudaVideoCodec e
     videoParserParameters.pUserData = this;
     videoParserParameters.pfnSequenceCallback = HandleVideoSequenceProc;
     videoParserParameters.pfnDecodePicture = HandlePictureDecodeProc;
-    videoParserParameters.pfnDisplayPicture = HandlePictureDisplayProc;
+    videoParserParameters.pfnDisplayPicture = m_bForce_zero_latency ? NULL : HandlePictureDisplayProc;
     videoParserParameters.pfnGetOperatingPoint = HandleOperatingPointProc;
+    videoParserParameters.pfnGetSEIMsg = m_bExtractSEIMessage ? HandleSEIMessagesProc : NULL;
     NVDEC_API_CALL(cuvidCreateVideoParser(&m_hParser, &videoParserParameters));
 }
 
 NvDecoder::~NvDecoder() {
 
     START_TIMER
+
+    if (m_pCurrSEIMessage) {
+        delete m_pCurrSEIMessage;
+        m_pCurrSEIMessage = NULL;
+    }
+
+    if (m_fpSEI) {
+        fclose(m_fpSEI);
+        m_fpSEI = NULL;
+    }
 
     if (m_hParser) {
         cuvidDestroyVideoParser(m_hParser);
@@ -662,6 +779,8 @@ NvDecoder::~NvDecoder() {
     cuvidCtxLockDestroy(m_ctxLock);
 
     STOP_TIMER("Session Deinitialization Time: ");
+
+    NvDecoder::addDecoderSessionOverHead(getDecoderSessionID(), elapsedTime);
 }
 
 int NvDecoder::Decode(const uint8_t *pData, int nSize, int nFlags, int64_t nTimestamp)
@@ -677,7 +796,6 @@ int NvDecoder::Decode(const uint8_t *pData, int nSize, int nFlags, int64_t nTime
         packet.flags |= CUVID_PKT_ENDOFSTREAM;
     }
     NVDEC_API_CALL(cuvidParseVideoData(m_hParser, &packet));
-    m_cuvidStream = 0;
 
     return m_nDecodedFrame;
 }

--- a/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
+++ b/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of
@@ -13,8 +13,8 @@
 
 
 NvEncoderCuda::NvEncoderCuda(CUcontext cuContext, uint32_t nWidth, uint32_t nHeight, NV_ENC_BUFFER_FORMAT eBufferFormat,
-    uint32_t nExtraOutputDelay, bool bMotionEstimationOnly, bool bOutputInVideoMemory):
-    NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, cuContext, nWidth, nHeight, eBufferFormat, nExtraOutputDelay, bMotionEstimationOnly, bOutputInVideoMemory),
+    uint32_t nExtraOutputDelay, bool bMotionEstimationOnly, bool bOutputInVideoMemory, bool bUseIVFContainer):
+    NvEncoder(NV_ENC_DEVICE_TYPE_CUDA, cuContext, nWidth, nHeight, eBufferFormat, nExtraOutputDelay, bMotionEstimationOnly, bOutputInVideoMemory, false, bUseIVFContainer),
     m_cuContext(cuContext)
 {
     if (!m_hEncoder) 
@@ -40,7 +40,7 @@ void NvEncoderCuda::AllocateInputBuffers(int32_t numInputBuffers)
         NVENC_THROW_ERROR("Encoder intialization failed", NV_ENC_ERR_ENCODER_NOT_INITIALIZED);
     }
 
-    // for MEOnly mode we need to allocate separate set of buffers for reference frame
+    // for MEOnly mode we need to allocate seperate set of buffers for reference frame
     int numCount = m_bMotionEstimationOnly ? 2 : 1;
 
     for (int count = 0; count < numCount; count++)

--- a/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
+++ b/Plugin~/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of
@@ -39,7 +39,7 @@ class NvEncoderCuda : public NvEncoder
 {
 public:
     NvEncoderCuda(CUcontext cuContext, uint32_t nWidth, uint32_t nHeight, NV_ENC_BUFFER_FORMAT eBufferFormat,
-        uint32_t nExtraOutputDelay = 3, bool bMotionEstimationOnly = false, bool bOPInVideoMemory = false);
+        uint32_t nExtraOutputDelay = 3, bool bMotionEstimationOnly = false, bool bOPInVideoMemory = false, bool bUseIVFContainer = true);
     virtual ~NvEncoderCuda();
 
     /**
@@ -62,7 +62,7 @@ public:
 
     /**
     *  @brief This is a static function to copy input data from host memory to device memory.
-    *  Application must pass a separate device pointer for each YUV plane.
+    *  Application must pass a seperate device pointer for each YUV plane.
     */
     static void CopyToDeviceFrame(CUcontext device,
         void* pSrcFrame,

--- a/Plugin~/NvCodec/Utils/BitDepth.cu
+++ b/Plugin~/NvCodec/Utils/BitDepth.cu
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of

--- a/Plugin~/NvCodec/Utils/ColorSpace.cu
+++ b/Plugin~/NvCodec/Utils/ColorSpace.cu
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of

--- a/Plugin~/NvCodec/Utils/Logger.h
+++ b/Plugin~/NvCodec/Utils/Logger.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of

--- a/Plugin~/NvCodec/Utils/Resize.cu
+++ b/Plugin~/NvCodec/Utils/Resize.cu
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of

--- a/Plugin~/NvCodec/Utils/crc.cu
+++ b/Plugin~/NvCodec/Utils/crc.cu
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 NVIDIA Corporation.  All rights reserved.
+* Copyright 2018-2022 NVIDIA Corporation.  All rights reserved.
 *
 * Please refer to the NVIDIA end user license agreement (EULA) associated
 * with this source code for terms and conditions that govern your use of

--- a/Plugin~/NvCodec/include/cuviddec.h
+++ b/Plugin~/NvCodec/include/cuviddec.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2020 NVIDIA Corporation
+ * Copyright (c) 2010-2022 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -1106,7 +1106,6 @@ extern CUresult CUDAAPI cuvidMapVideoFrame(CUvideodecoder hDecoder, int nPicIdx,
 extern CUresult CUDAAPI cuvidUnmapVideoFrame(CUvideodecoder hDecoder, unsigned int DevPtr);
 #endif
 
-#if defined(_WIN64) || defined(__LP64__) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
 /****************************************************************************************************************************/
 //! \fn CUresult CUDAAPI cuvidMapVideoFrame64(CUvideodecoder hDecoder, int nPicIdx, unsigned long long *pDevPtr, 
 //!                                           unsigned int * pPitch, CUVIDPROCPARAMS *pVPP);
@@ -1125,7 +1124,6 @@ extern CUresult CUDAAPI cuvidUnmapVideoFrame64(CUvideodecoder hDecoder, unsigned
 #if defined(__CUVID_DEVPTR64) && !defined(__CUVID_INTERNAL)
 #define cuvidMapVideoFrame      cuvidMapVideoFrame64
 #define cuvidUnmapVideoFrame    cuvidUnmapVideoFrame64
-#endif
 #endif
 
 

--- a/Plugin~/NvCodec/include/nvEncodeAPI.h
+++ b/Plugin~/NvCodec/include/nvEncodeAPI.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2020 NVIDIA Corporation
+ * Copyright (c) 2010-2022 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,7 +30,7 @@
  *   NVIDIA GPUs - beginning with the Kepler generation - contain a hardware-based encoder
  *   (referred to as NVENC) which provides fully-accelerated hardware-based video encoding.
  *   NvEncodeAPI provides the interface for NVIDIA video encoder (NVENC).
- * \date 2011-2020
+ * \date 2011-2022
  *  This file contains the interface constants, structure definitions and function prototypes.
  */
 
@@ -73,20 +73,21 @@ typedef RECT NVENC_RECT;
 #else
 #define NVENCAPI
 // =========================================================================================
-#if !defined(GUID) && !defined(GUID_DEFINED)
+#ifndef GUID_DEFINED
+#define GUID_DEFINED
 /*!
  * \struct GUID
  * Abstracts the GUID structure for non-windows platforms.
  */
 // =========================================================================================
-typedef struct
+typedef struct _GUID
 {
     uint32_t Data1;                                      /**< [in]: Specifies the first 8 hexadecimal digits of the GUID.                                */
     uint16_t Data2;                                      /**< [in]: Specifies the first group of 4 hexadecimal digits.                                   */
     uint16_t Data3;                                      /**< [in]: Specifies the second group of 4 hexadecimal digits.                                  */
     uint8_t  Data4[8];                                   /**< [in]: Array of 8 bytes. The first 2 bytes contain the third group of 4 hexadecimal digits.
                                                                     The remaining 6 bytes contain the final 12 hexadecimal digits.                       */
-} GUID;
+} GUID, *LPGUID;
 #endif // GUID
 
 /**
@@ -110,7 +111,7 @@ typedef void* NV_ENC_OUTPUT_PTR;            /**< NVENCODE API output buffer*/
 typedef void* NV_ENC_REGISTERED_PTR;        /**< A Resource that has been registered with NVENCODE API*/
 typedef void* NV_ENC_CUSTREAM_PTR;          /**< Pointer to CUstream*/
 
-#define NVENCAPI_MAJOR_VERSION 11
+#define NVENCAPI_MAJOR_VERSION 12
 #define NVENCAPI_MINOR_VERSION 0
 
 #define NVENCAPI_VERSION (NVENCAPI_MAJOR_VERSION | (NVENCAPI_MINOR_VERSION << 24))
@@ -140,8 +141,12 @@ static const GUID NV_ENC_CODEC_H264_GUID =
 { 0x6bc82762, 0x4e63, 0x4ca4, { 0xaa, 0x85, 0x1e, 0x50, 0xf3, 0x21, 0xf6, 0xbf } };
 
 // {790CDC88-4522-4d7b-9425-BDA9975F7603}
-static const GUID NV_ENC_CODEC_HEVC_GUID = 
+static const GUID NV_ENC_CODEC_HEVC_GUID =
 { 0x790cdc88, 0x4522, 0x4d7b, { 0x94, 0x25, 0xbd, 0xa9, 0x97, 0x5f, 0x76, 0x3 } };
+
+// {0A352289-0AA7-4759-862D-5D15CD16D254}
+static const GUID NV_ENC_CODEC_AV1_GUID =
+{ 0x0a352289, 0x0aa7, 0x4759, { 0x86, 0x2d, 0x5d, 0x15, 0xcd, 0x16, 0xd2, 0x54 } };
 
 
 
@@ -150,7 +155,7 @@ static const GUID NV_ENC_CODEC_HEVC_GUID =
 // =========================================================================================
 
 // {BFD6F8E7-233C-4341-8B3E-4818523803F4}
-static const GUID NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID = 
+static const GUID NV_ENC_CODEC_PROFILE_AUTOSELECT_GUID =
 { 0xbfd6f8e7, 0x233c, 0x4341, { 0x8b, 0x3e, 0x48, 0x18, 0x52, 0x38, 0x3, 0xf4 } };
 
 // {0727BCAA-78C4-4c83-8C2F-EF3DFF267C6A}
@@ -166,7 +171,7 @@ static const GUID NV_ENC_H264_PROFILE_HIGH_GUID =
 { 0xe7cbc309, 0x4f7a, 0x4b89, { 0xaf, 0x2a, 0xd5, 0x37, 0xc9, 0x2b, 0xe3, 0x10 } };
 
 // {7AC663CB-A598-4960-B844-339B261A7D52}
-static const GUID  NV_ENC_H264_PROFILE_HIGH_444_GUID = 
+static const GUID  NV_ENC_H264_PROFILE_HIGH_444_GUID =
 { 0x7ac663cb, 0xa598, 0x4960, { 0xb8, 0x44, 0x33, 0x9b, 0x26, 0x1a, 0x7d, 0x52 } };
 
 // {40847BF5-33F7-4601-9084-E8FE3C1DB8B7}
@@ -174,25 +179,29 @@ static const GUID NV_ENC_H264_PROFILE_STEREO_GUID =
 { 0x40847bf5, 0x33f7, 0x4601, { 0x90, 0x84, 0xe8, 0xfe, 0x3c, 0x1d, 0xb8, 0xb7 } };
 
 // {B405AFAC-F32B-417B-89C4-9ABEED3E5978}
-static const GUID NV_ENC_H264_PROFILE_PROGRESSIVE_HIGH_GUID = 
+static const GUID NV_ENC_H264_PROFILE_PROGRESSIVE_HIGH_GUID =
 { 0xb405afac, 0xf32b, 0x417b, { 0x89, 0xc4, 0x9a, 0xbe, 0xed, 0x3e, 0x59, 0x78 } };
 
 // {AEC1BD87-E85B-48f2-84C3-98BCA6285072}
-static const GUID NV_ENC_H264_PROFILE_CONSTRAINED_HIGH_GUID = 
+static const GUID NV_ENC_H264_PROFILE_CONSTRAINED_HIGH_GUID =
 { 0xaec1bd87, 0xe85b, 0x48f2, { 0x84, 0xc3, 0x98, 0xbc, 0xa6, 0x28, 0x50, 0x72 } };
 
 // {B514C39A-B55B-40fa-878F-F1253B4DFDEC}
-static const GUID NV_ENC_HEVC_PROFILE_MAIN_GUID = 
+static const GUID NV_ENC_HEVC_PROFILE_MAIN_GUID =
 { 0xb514c39a, 0xb55b, 0x40fa, { 0x87, 0x8f, 0xf1, 0x25, 0x3b, 0x4d, 0xfd, 0xec } };
 
 // {fa4d2b6c-3a5b-411a-8018-0a3f5e3c9be5}
-static const GUID NV_ENC_HEVC_PROFILE_MAIN10_GUID = 
+static const GUID NV_ENC_HEVC_PROFILE_MAIN10_GUID =
 { 0xfa4d2b6c, 0x3a5b, 0x411a, { 0x80, 0x18, 0x0a, 0x3f, 0x5e, 0x3c, 0x9b, 0xe5 } };
 
 // For HEVC Main 444 8 bit and HEVC Main 444 10 bit profiles only
 // {51ec32b5-1b4c-453c-9cbd-b616bd621341}
-static const GUID NV_ENC_HEVC_PROFILE_FREXT_GUID = 
+static const GUID NV_ENC_HEVC_PROFILE_FREXT_GUID =
 { 0x51ec32b5, 0x1b4c, 0x453c, { 0x9c, 0xbd, 0xb6, 0x16, 0xbd, 0x62, 0x13, 0x41 } };
+
+// {5f2a39f5-f14e-4f95-9a9e-b76d568fcf97}
+static const GUID NV_ENC_AV1_PROFILE_MAIN_GUID =
+{ 0x5f2a39f5, 0xf14e, 0x4f95, { 0x9a, 0x9e, 0xb7, 0x6d, 0x56, 0x8f, 0xcf, 0x97 } };
 
 // =========================================================================================
 // *   Preset GUIDS supported by the NvEncodeAPI interface.
@@ -210,15 +219,15 @@ NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_HQ_GUID =
 { 0x34dba71d, 0xa77b, 0x4b8f, { 0x9c, 0x3e, 0xb6, 0xd5, 0xda, 0x24, 0xc0, 0x12 } };
 
 // {82E3E450-BDBB-4e40-989C-82A90DF9EF32}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_BD_GUID  = 
+NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_BD_GUID  =
 { 0x82e3e450, 0xbdbb, 0x4e40, { 0x98, 0x9c, 0x82, 0xa9, 0xd, 0xf9, 0xef, 0x32 } };
 
 // {49DF21C5-6DFA-4feb-9787-6ACC9EFFB726}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_DEFAULT_GUID  = 
+NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_DEFAULT_GUID  =
 { 0x49df21c5, 0x6dfa, 0x4feb, { 0x97, 0x87, 0x6a, 0xcc, 0x9e, 0xff, 0xb7, 0x26 } };
 
 // {C5F733B9-EA97-4cf9-BEC2-BF78A74FD105}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_HQ_GUID  = 
+NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_HQ_GUID  =
 { 0xc5f733b9, 0xea97, 0x4cf9, { 0xbe, 0xc2, 0xbf, 0x78, 0xa7, 0x4f, 0xd1, 0x5 } };
 
 // {67082A44-4BAD-48FA-98EA-93056D150A58}
@@ -226,42 +235,42 @@ NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_HP_GUID =
 { 0x67082a44, 0x4bad, 0x48fa, { 0x98, 0xea, 0x93, 0x5, 0x6d, 0x15, 0xa, 0x58 } };
 
 // {D5BFB716-C604-44e7-9BB8-DEA5510FC3AC}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOSSLESS_DEFAULT_GUID = 
+NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOSSLESS_DEFAULT_GUID =
 { 0xd5bfb716, 0xc604, 0x44e7, { 0x9b, 0xb8, 0xde, 0xa5, 0x51, 0xf, 0xc3, 0xac } };
 
 // {149998E7-2364-411d-82EF-179888093409}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOSSLESS_HP_GUID = 
+NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOSSLESS_HP_GUID =
 { 0x149998e7, 0x2364, 0x411d, { 0x82, 0xef, 0x17, 0x98, 0x88, 0x9, 0x34, 0x9 } };
 
-// Performance degrades and quality improves as we move from P1 to P7. Presets P3 to P7 for H264 and Presets P2 to P7 for HEVC have B frames enabled by default 
+// Performance degrades and quality improves as we move from P1 to P7. Presets P3 to P7 for H264 and Presets P2 to P7 for HEVC have B frames enabled by default
 // for HIGH_QUALITY and LOSSLESS tuning info, and will not work with Weighted Prediction enabled. In case Weighted Prediction is required, disable B frames by
 // setting frameIntervalP = 1
 // {FC0A8D3E-45F8-4CF8-80C7-298871590EBF}
-static const GUID NV_ENC_PRESET_P1_GUID   = 
+static const GUID NV_ENC_PRESET_P1_GUID   =
 { 0xfc0a8d3e, 0x45f8, 0x4cf8, { 0x80, 0xc7, 0x29, 0x88, 0x71, 0x59, 0xe, 0xbf } };
 
 // {F581CFB8-88D6-4381-93F0-DF13F9C27DAB}
-static const GUID NV_ENC_PRESET_P2_GUID   = 
+static const GUID NV_ENC_PRESET_P2_GUID   =
 { 0xf581cfb8, 0x88d6, 0x4381, { 0x93, 0xf0, 0xdf, 0x13, 0xf9, 0xc2, 0x7d, 0xab } };
 
 // {36850110-3A07-441F-94D5-3670631F91F6}
-static const GUID NV_ENC_PRESET_P3_GUID   = 
+static const GUID NV_ENC_PRESET_P3_GUID   =
 { 0x36850110, 0x3a07, 0x441f, { 0x94, 0xd5, 0x36, 0x70, 0x63, 0x1f, 0x91, 0xf6 } };
 
 // {90A7B826-DF06-4862-B9D2-CD6D73A08681}
-static const GUID NV_ENC_PRESET_P4_GUID   = 
+static const GUID NV_ENC_PRESET_P4_GUID   =
 { 0x90a7b826, 0xdf06, 0x4862, { 0xb9, 0xd2, 0xcd, 0x6d, 0x73, 0xa0, 0x86, 0x81 } };
 
 // {21C6E6B4-297A-4CBA-998F-B6CBDE72ADE3}
-static const GUID NV_ENC_PRESET_P5_GUID   = 
+static const GUID NV_ENC_PRESET_P5_GUID   =
 { 0x21c6e6b4, 0x297a, 0x4cba, { 0x99, 0x8f, 0xb6, 0xcb, 0xde, 0x72, 0xad, 0xe3 } };
 
 // {8E75C279-6299-4AB6-8302-0B215A335CF5}
-static const GUID NV_ENC_PRESET_P6_GUID   = 
+static const GUID NV_ENC_PRESET_P6_GUID   =
 { 0x8e75c279, 0x6299, 0x4ab6, { 0x83, 0x2, 0xb, 0x21, 0x5a, 0x33, 0x5c, 0xf5 } };
 
 // {84848C12-6F71-4C13-931B-53E283F57974}
-static const GUID NV_ENC_PRESET_P7_GUID   = 
+static const GUID NV_ENC_PRESET_P7_GUID   =
 { 0x84848c12, 0x6f71, 0x4c13, { 0x93, 0x1b, 0x53, 0xe2, 0x83, 0xf5, 0x79, 0x74 } };
 
 /**
@@ -344,6 +353,20 @@ typedef enum _NV_ENC_PIC_STRUCT
 } NV_ENC_PIC_STRUCT;
 
 /**
+ * Display picture structure
+ * Currently, this enum is only used for deciding the number of clock timestamp sets in Picture Timing SEI / Time Code SEI
+ * Otherwise, this has no impact on encoder behavior
+ */
+typedef enum _NV_ENC_DISPLAY_PIC_STRUCT
+{
+    NV_ENC_PIC_STRUCT_DISPLAY_FRAME             = 0x00,                 /**< Field encoding top field first */
+    NV_ENC_PIC_STRUCT_DISPLAY_FIELD_TOP_BOTTOM  = 0x01,                 /**< Field encoding top field first */
+    NV_ENC_PIC_STRUCT_DISPLAY_FIELD_BOTTOM_TOP  = 0x02,                 /**< Field encoding bottom field first */
+    NV_ENC_PIC_STRUCT_DISPLAY_FRAME_DOUBLING    = 0x03,                 /**< Frame doubling */
+    NV_ENC_PIC_STRUCT_DISPLAY_FRAME_TRIPLING    = 0x04                  /**< Field tripling */
+} NV_ENC_DISPLAY_PIC_STRUCT;
+
+/**
  * Input picture type
  */
 typedef enum _NV_ENC_PIC_TYPE
@@ -355,7 +378,7 @@ typedef enum _NV_ENC_PIC_TYPE
     NV_ENC_PIC_TYPE_BI              = 0x04,    /**< Bi-directionally predicted with only Intra MBs */
     NV_ENC_PIC_TYPE_SKIPPED         = 0x05,    /**< Picture is skipped */
     NV_ENC_PIC_TYPE_INTRA_REFRESH   = 0x06,    /**< First picture in intra refresh cycle */
-    NV_ENC_PIC_TYPE_NONREF_P        = 0x07,    /**< Non reference P picture */            
+    NV_ENC_PIC_TYPE_NONREF_P        = 0x07,    /**< Non reference P picture */
     NV_ENC_PIC_TYPE_UNKNOWN         = 0xFF     /**< Picture type unknown */
 } NV_ENC_PIC_TYPE;
 
@@ -377,7 +400,7 @@ typedef enum _NV_ENC_MV_PRECISION
 typedef enum _NV_ENC_BUFFER_FORMAT
 {
     NV_ENC_BUFFER_FORMAT_UNDEFINED                       = 0x00000000,  /**< Undefined buffer format */
-                                                                       
+
     NV_ENC_BUFFER_FORMAT_NV12                            = 0x00000001,  /**< Semi-Planar YUV [Y plane followed by interleaved UV plane] */
     NV_ENC_BUFFER_FORMAT_YV12                            = 0x00000010,  /**< Planar YUV [Y plane followed by V and U planes] */
     NV_ENC_BUFFER_FORMAT_IYUV                            = 0x00000100,  /**< Planar YUV [Y plane followed by U and V planes] */
@@ -404,8 +427,8 @@ typedef enum _NV_ENC_BUFFER_FORMAT
                                                                              where a pixel is represented by a 32-bit word with R
                                                                              in the lowest 10 bits, G in the next 10 bits, B in the
                                                                              10 bits after that and A in the highest 2 bits. */
-    NV_ENC_BUFFER_FORMAT_U8                              = 0x40000000,  /**< Buffer format representing one-dimensional buffer. 
-                                                                             This format should be used only when registering the 
+    NV_ENC_BUFFER_FORMAT_U8                              = 0x40000000,  /**< Buffer format representing one-dimensional buffer.
+                                                                             This format should be used only when registering the
                                                                              resource as output buffer, which will be used to write
                                                                              the encoded bit stream or H.264 ME only mode output. */
 } NV_ENC_BUFFER_FORMAT;
@@ -421,7 +444,7 @@ typedef enum _NV_ENC_BUFFER_FORMAT
 typedef enum _NV_ENC_LEVEL
 {
     NV_ENC_LEVEL_AUTOSELECT         = 0,
-    
+
     NV_ENC_LEVEL_H264_1             = 10,
     NV_ENC_LEVEL_H264_1b            = 9,
     NV_ENC_LEVEL_H264_11            = 11,
@@ -458,7 +481,36 @@ typedef enum _NV_ENC_LEVEL
     NV_ENC_LEVEL_HEVC_62            = 186,
 
     NV_ENC_TIER_HEVC_MAIN           = 0,
-    NV_ENC_TIER_HEVC_HIGH           = 1
+    NV_ENC_TIER_HEVC_HIGH           = 1,
+
+    NV_ENC_LEVEL_AV1_2              = 0,
+    NV_ENC_LEVEL_AV1_21             = 1,
+    NV_ENC_LEVEL_AV1_22             = 2,
+    NV_ENC_LEVEL_AV1_23             = 3,
+    NV_ENC_LEVEL_AV1_3              = 4,
+    NV_ENC_LEVEL_AV1_31             = 5,
+    NV_ENC_LEVEL_AV1_32             = 6,
+    NV_ENC_LEVEL_AV1_33             = 7,
+    NV_ENC_LEVEL_AV1_4              = 8,
+    NV_ENC_LEVEL_AV1_41             = 9,
+    NV_ENC_LEVEL_AV1_42             = 10,
+    NV_ENC_LEVEL_AV1_43             = 11,
+    NV_ENC_LEVEL_AV1_5              = 12,
+    NV_ENC_LEVEL_AV1_51             = 13,
+    NV_ENC_LEVEL_AV1_52             = 14,
+    NV_ENC_LEVEL_AV1_53             = 15,
+    NV_ENC_LEVEL_AV1_6              = 16,
+    NV_ENC_LEVEL_AV1_61             = 17,
+    NV_ENC_LEVEL_AV1_62             = 18,
+    NV_ENC_LEVEL_AV1_63             = 19,
+    NV_ENC_LEVEL_AV1_7              = 20,
+    NV_ENC_LEVEL_AV1_71             = 21,
+    NV_ENC_LEVEL_AV1_72             = 22,
+    NV_ENC_LEVEL_AV1_73             = 23,
+    NV_ENC_LEVEL_AV1_AUTOSELECT         ,
+
+    NV_ENC_TIER_AV1_0               = 0,
+    NV_ENC_TIER_AV1_1               = 1
 } NV_ENC_LEVEL;
 
 /**
@@ -482,7 +534,7 @@ typedef enum _NVENCSTATUS
     NV_ENC_ERR_UNSUPPORTED_DEVICE,
 
     /**
-     * This indicates that the encoder device supplied by the client is not 
+     * This indicates that the encoder device supplied by the client is not
      * valid.
      */
     NV_ENC_ERR_INVALID_ENCODERDEVICE,
@@ -493,9 +545,9 @@ typedef enum _NVENCSTATUS
     NV_ENC_ERR_INVALID_DEVICE,
 
     /**
-     * This indicates that device passed to the API call is no longer available and 
-     * needs to be reinitialized. The clients need to destroy the current encoder  
-     * session by freeing the allocated input output buffers and destroying the device 
+     * This indicates that device passed to the API call is no longer available and
+     * needs to be reinitialized. The clients need to destroy the current encoder
+     * session by freeing the allocated input output buffers and destroying the device
      * and create a new encoding session.
      */
     NV_ENC_ERR_DEVICE_NOT_EXIST,
@@ -524,11 +576,11 @@ typedef enum _NVENCSTATUS
     NV_ENC_ERR_INVALID_CALL,
 
     /**
-     * This indicates that the API call failed because it was unable to allocate 
+     * This indicates that the API call failed because it was unable to allocate
      * enough memory to perform the requested operation.
      */
     NV_ENC_ERR_OUT_OF_MEMORY,
-    
+
     /**
      * This indicates that the encoder has not been initialized with
      * ::NvEncInitializeEncoder() or that initialization has failed.
@@ -543,8 +595,8 @@ typedef enum _NVENCSTATUS
     NV_ENC_ERR_UNSUPPORTED_PARAM,
 
     /**
-     * This indicates that the ::NvEncLockBitstream() failed to lock the output 
-     * buffer. This happens when the client makes a non blocking lock call to 
+     * This indicates that the ::NvEncLockBitstream() failed to lock the output
+     * buffer. This happens when the client makes a non blocking lock call to
      * access the output bitstream by passing NV_ENC_LOCK_BITSTREAM::doNotWait flag.
      * This is not a fatal error and client should retry the same operation after
      * few milliseconds.
@@ -552,7 +604,7 @@ typedef enum _NVENCSTATUS
     NV_ENC_ERR_LOCK_BUSY,
 
     /**
-     * This indicates that the size of the user buffer passed by the client is 
+     * This indicates that the size of the user buffer passed by the client is
      * insufficient for the requested operation.
      */
     NV_ENC_ERR_NOT_ENOUGH_BUFFER,
@@ -572,10 +624,10 @@ typedef enum _NVENCSTATUS
      * This indicates encode driver requires more input buffers to produce an output
      * bitstream. If this error is returned from ::NvEncEncodePicture() API, this
      * is not a fatal error. If the client is encoding with B frames then,
-     * ::NvEncEncodePicture() API might be buffering the input frame for re-ordering. 
-     * 
+     * ::NvEncEncodePicture() API might be buffering the input frame for re-ordering.
+     *
      * A client operating in synchronous mode cannot call ::NvEncLockBitstream()
-     * API on the output bitstream buffer if ::NvEncEncodePicture() returned the 
+     * API on the output bitstream buffer if ::NvEncEncodePicture() returned the
      * ::NV_ENC_ERR_NEED_MORE_INPUT error code.
      * The client must continue providing input frames until encode driver returns
      * ::NV_ENC_SUCCESS. After receiving ::NV_ENC_SUCCESS status the client can call
@@ -585,7 +637,7 @@ typedef enum _NVENCSTATUS
     NV_ENC_ERR_NEED_MORE_INPUT,
 
     /**
-     * This indicates that the HW encoder is busy encoding and is unable to encode  
+     * This indicates that the HW encoder is busy encoding and is unable to encode
      * the input. The client should call ::NvEncEncodePicture() again after few
      * milliseconds.
      */
@@ -601,13 +653,13 @@ typedef enum _NVENCSTATUS
      * This indicates that an unknown internal error has occurred.
      */
     NV_ENC_ERR_GENERIC,
-    
+
     /**
      * This indicates that the client is attempting to use a feature
      * that is not available for the license type for the current system.
      */
     NV_ENC_ERR_INCOMPATIBLE_CLIENT_KEY,
-    
+
     /**
      * This indicates that the client is attempting to use a feature
      * that is not implemented for the current version.
@@ -639,11 +691,11 @@ typedef enum _NVENCSTATUS
 typedef enum _NV_ENC_PIC_FLAGS
 {
     NV_ENC_PIC_FLAG_FORCEINTRA         = 0x1,   /**< Encode the current picture as an Intra picture */
-    NV_ENC_PIC_FLAG_FORCEIDR           = 0x2,   /**< Encode the current picture as an IDR picture. 
+    NV_ENC_PIC_FLAG_FORCEIDR           = 0x2,   /**< Encode the current picture as an IDR picture.
                                                      This flag is only valid when Picture type decision is taken by the Encoder
                                                      [_NV_ENC_INITIALIZE_PARAMS::enablePTD == 1]. */
     NV_ENC_PIC_FLAG_OUTPUT_SPSPPS      = 0x4,   /**< Write the sequence and picture header in encoded bitstream of the current picture */
-    NV_ENC_PIC_FLAG_EOS                = 0x8,   /**< Indicates end of the input stream */ 
+    NV_ENC_PIC_FLAG_EOS                = 0x8,   /**< Indicates end of the input stream */
 } NV_ENC_PIC_FLAGS;
 
 /**
@@ -663,7 +715,7 @@ typedef enum _NV_ENC_MEMORY_HEAP
 typedef enum _NV_ENC_BFRAME_REF_MODE
 {
     NV_ENC_BFRAME_REF_MODE_DISABLED = 0x0,          /**< B frame is not used for reference */
-    NV_ENC_BFRAME_REF_MODE_EACH     = 0x1,          /**< Each B-frame will be used for reference. currently not supported for H.264 */
+    NV_ENC_BFRAME_REF_MODE_EACH     = 0x1,          /**< Each B-frame will be used for reference */
     NV_ENC_BFRAME_REF_MODE_MIDDLE   = 0x2,          /**< Only(Number of B-frame)/2 th B-frame will be used for reference */
 } NV_ENC_BFRAME_REF_MODE;
 
@@ -741,9 +793,9 @@ typedef enum _NV_ENC_INPUT_RESOURCE_TYPE
 typedef enum _NV_ENC_BUFFER_USAGE
 {
     NV_ENC_INPUT_IMAGE              = 0x0,          /**< Registered surface will be used for input image */
-    NV_ENC_OUTPUT_MOTION_VECTOR     = 0x1,          /**< Registered surface will be used for output of H.264 ME only mode. 
+    NV_ENC_OUTPUT_MOTION_VECTOR     = 0x1,          /**< Registered surface will be used for output of H.264 ME only mode.
                                                          This buffer usage type is not supported for HEVC ME only mode. */
-    NV_ENC_OUTPUT_BITSTREAM         = 0x2           /**< Registered surface will be used for output bitstream in encoding */
+    NV_ENC_OUTPUT_BITSTREAM         = 0x2,          /**< Registered surface will be used for output bitstream in encoding */
 } NV_ENC_BUFFER_USAGE;
 
 /**
@@ -788,7 +840,7 @@ typedef enum _NV_ENC_CAPS
      */
     NV_ENC_CAPS_SUPPORTED_RATECONTROL_MODES,
 
-    /** 
+    /**
      * Indicates HW support for field mode encoding.
      * \n 0 : Interlaced mode encoding is not supported.
      * \n 1 : Interlaced field mode encoding is supported.
@@ -870,7 +922,7 @@ typedef enum _NV_ENC_CAPS
      * Maximum Encoding level supported (See ::NV_ENC_LEVEL for details).
      */
     NV_ENC_CAPS_LEVEL_MAX,
- 
+
     /**
      * Minimum Encoding level supported (See ::NV_ENC_LEVEL for details).
      */
@@ -882,12 +934,12 @@ typedef enum _NV_ENC_CAPS
      * \n 1 : Separate colour plane encoding supported.
      */
     NV_ENC_CAPS_SEPARATE_COLOUR_PLANE,
-    
+
     /**
      * Maximum output width supported.
      */
     NV_ENC_CAPS_WIDTH_MAX,
-    
+
     /**
      * Maximum output height supported.
      */
@@ -915,7 +967,7 @@ typedef enum _NV_ENC_CAPS
      * \n 1 : Dynamic Encode bitrate change supported.
      */
     NV_ENC_CAPS_SUPPORT_DYN_BITRATE_CHANGE,
-        
+
     /**
      * Indicates Forcing Constant QP On The Fly Support.
      * Support added from NvEncodeAPI version 2.0.
@@ -925,7 +977,7 @@ typedef enum _NV_ENC_CAPS
     NV_ENC_CAPS_SUPPORT_DYN_FORCE_CONSTQP,
 
     /**
-     * Indicates Dynamic rate control mode Change Support.    
+     * Indicates Dynamic rate control mode Change Support.
      * \n 0 : Dynamic rate control mode change not supported.
      * \n 1 : Dynamic rate control mode change supported.
      */
@@ -981,7 +1033,7 @@ typedef enum _NV_ENC_CAPS
      * \n 1 : Reference Picture Invalidation supported.
      */
     NV_ENC_CAPS_SUPPORT_REF_PIC_INVALIDATION,
-    
+
     /**
      * Indicates support for Pre-Processing.
      * The API return value is a bitmask of the values defined in ::NV_ENC_PREPROC_FLAGS
@@ -1018,7 +1070,7 @@ typedef enum _NV_ENC_CAPS
      * \n 1 : lossless encoding supported.
      */
     NV_ENC_CAPS_SUPPORT_LOSSLESS_ENCODE,
-    
+
      /**
      * Indicates HW support for Sample Adaptive Offset.
      * \n 0 : SAO not supported.
@@ -1067,10 +1119,10 @@ typedef enum _NV_ENC_CAPS
 
 
     /**
-     * On managed (vGPU) platforms (Windows only), this API, in conjunction with other GRID Management APIs, can be used 
-     * to estimate the residual capacity of the hardware encoder on the GPU as a percentage of the total available encoder capacity. 
-     * This API can be called at any time; i.e. during the encode session or before opening the encode session. 
-     * If the available encoder capacity is returned as zero, applications may choose to switch to software encoding 
+     * On managed (vGPU) platforms (Windows only), this API, in conjunction with other GRID Management APIs, can be used
+     * to estimate the residual capacity of the hardware encoder on the GPU as a percentage of the total available encoder capacity.
+     * This API can be called at any time; i.e. during the encode session or before opening the encode session.
+     * If the available encoder capacity is returned as zero, applications may choose to switch to software encoding
      * and continue to call this API (e.g. polling once per second) until capacity becomes available.
      *
      * On bare metal (non-virtualized GPU) and linux platforms, this API always returns 100.
@@ -1119,10 +1171,16 @@ typedef enum _NV_ENC_CAPS
      */
     NV_ENC_CAPS_NUM_ENCODER_ENGINES,
 
+    /**
+     * Indicates single slice intra refresh support.
+     */
+    NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH,
+
      /**
      * Reserved - Not to be used by clients.
      */
     NV_ENC_CAPS_EXPOSED_COUNT
+
 } NV_ENC_CAPS;
 
 /**
@@ -1136,6 +1194,89 @@ typedef enum _NV_ENC_HEVC_CUSIZE
     NV_ENC_HEVC_CUSIZE_32x32      = 3,
     NV_ENC_HEVC_CUSIZE_64x64      = 4,
 }NV_ENC_HEVC_CUSIZE;
+
+/**
+*  AV1 PART SIZE
+*/
+typedef enum _NV_ENC_AV1_PART_SIZE
+{
+    NV_ENC_AV1_PART_SIZE_AUTOSELECT    = 0,
+    NV_ENC_AV1_PART_SIZE_4x4           = 1,
+    NV_ENC_AV1_PART_SIZE_8x8           = 2,
+    NV_ENC_AV1_PART_SIZE_16x16         = 3,
+    NV_ENC_AV1_PART_SIZE_32x32         = 4,
+    NV_ENC_AV1_PART_SIZE_64x64         = 5,
+}NV_ENC_AV1_PART_SIZE;
+
+/**
+*  Enums related to fields in VUI parameters.
+*/
+typedef enum _NV_ENC_VUI_VIDEO_FORMAT
+{
+    NV_ENC_VUI_VIDEO_FORMAT_COMPONENT   = 0,
+    NV_ENC_VUI_VIDEO_FORMAT_PAL         = 1,
+    NV_ENC_VUI_VIDEO_FORMAT_NTSC        = 2,
+    NV_ENC_VUI_VIDEO_FORMAT_SECAM       = 3,
+    NV_ENC_VUI_VIDEO_FORMAT_MAC         = 4,
+    NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED = 5,
+}NV_ENC_VUI_VIDEO_FORMAT;
+
+typedef enum _NV_ENC_VUI_COLOR_PRIMARIES
+{
+    NV_ENC_VUI_COLOR_PRIMARIES_UNDEFINED   = 0,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT709       = 1,
+    NV_ENC_VUI_COLOR_PRIMARIES_UNSPECIFIED = 2,
+    NV_ENC_VUI_COLOR_PRIMARIES_RESERVED    = 3,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT470M      = 4,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT470BG     = 5,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE170M   = 6,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE240M   = 7,
+    NV_ENC_VUI_COLOR_PRIMARIES_FILM        = 8,
+    NV_ENC_VUI_COLOR_PRIMARIES_BT2020      = 9,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE428    = 10,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE431    = 11,
+    NV_ENC_VUI_COLOR_PRIMARIES_SMPTE432    = 12,
+    NV_ENC_VUI_COLOR_PRIMARIES_JEDEC_P22   = 22,
+}NV_ENC_VUI_COLOR_PRIMARIES;
+
+typedef enum _NV_ENC_VUI_TRANSFER_CHARACTERISTIC
+{
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNDEFINED     = 0,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709         = 1,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_UNSPECIFIED   = 2,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_RESERVED      = 3,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT470M        = 4,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT470BG       = 5,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE170M     = 6,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE240M     = 7,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LINEAR        = 8,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LOG           = 9,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_LOG_SQRT      = 10,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_IEC61966_2_4  = 11,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT1361_ECG    = 12,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SRGB          = 13,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT2020_10     = 14,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT2020_12     = 15,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE2084     = 16,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE428      = 17,
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC_ARIB_STD_B67  = 18,
+}NV_ENC_VUI_TRANSFER_CHARACTERISTIC;
+
+typedef enum _NV_ENC_VUI_MATRIX_COEFFS
+{
+    NV_ENC_VUI_MATRIX_COEFFS_RGB         = 0,
+    NV_ENC_VUI_MATRIX_COEFFS_BT709       = 1,
+    NV_ENC_VUI_MATRIX_COEFFS_UNSPECIFIED = 2,
+    NV_ENC_VUI_MATRIX_COEFFS_RESERVED    = 3,
+    NV_ENC_VUI_MATRIX_COEFFS_FCC         = 4,
+    NV_ENC_VUI_MATRIX_COEFFS_BT470BG     = 5,
+    NV_ENC_VUI_MATRIX_COEFFS_SMPTE170M   = 6,
+    NV_ENC_VUI_MATRIX_COEFFS_SMPTE240M   = 7,
+    NV_ENC_VUI_MATRIX_COEFFS_YCGCO       = 8,
+    NV_ENC_VUI_MATRIX_COEFFS_BT2020_NCL  = 9,
+    NV_ENC_VUI_MATRIX_COEFFS_BT2020_CL   = 10,
+    NV_ENC_VUI_MATRIX_COEFFS_SMPTE2085   = 11,
+}NV_ENC_VUI_MATRIX_COEFFS;
 
 /**
  * Input struct for querying Encoding capabilities.
@@ -1162,7 +1303,7 @@ typedef struct _NV_ENC_ENCODE_OUT_PARAMS
 } NV_ENC_ENCODE_OUT_PARAMS;
 
 /** NV_ENC_ENCODE_OUT_PARAMS struct version. */
-#define NV_ENC_ENCODE_OUT_PARAMS_VER NVENCAPI_STRUCT_VERSION(1) 
+#define NV_ENC_ENCODE_OUT_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
 
 /**
  * Creation parameters for input buffer.
@@ -1182,7 +1323,7 @@ typedef struct _NV_ENC_CREATE_INPUT_BUFFER
 } NV_ENC_CREATE_INPUT_BUFFER;
 
 /** NV_ENC_CREATE_INPUT_BUFFER struct version. */
-#define NV_ENC_CREATE_INPUT_BUFFER_VER NVENCAPI_STRUCT_VERSION(1) 
+#define NV_ENC_CREATE_INPUT_BUFFER_VER NVENCAPI_STRUCT_VERSION(1)
 
 /**
  * Creation parameters for output bitstream buffer.
@@ -1203,7 +1344,7 @@ typedef struct _NV_ENC_CREATE_BITSTREAM_BUFFER
 #define NV_ENC_CREATE_BITSTREAM_BUFFER_VER NVENCAPI_STRUCT_VERSION(1)
 
 /**
- * Structs needed for ME only mode. 
+ * Structs needed for ME only mode.
  */
 typedef struct _NV_ENC_MVECTOR
 {
@@ -1211,7 +1352,7 @@ typedef struct _NV_ENC_MVECTOR
     int16_t             mvy;               /**< the y component of MV in quarter-pel units */
 } NV_ENC_MVECTOR;
 
-/** 
+/**
  * Motion vector structure per macroblock for H264 motion estimation.
  */
 typedef struct _NV_ENC_H264_MV_DATA
@@ -1251,7 +1392,7 @@ typedef struct _NV_ENC_CREATE_MV_BUFFER
 /** NV_ENC_CREATE_MV_BUFFER struct version*/
 #define NV_ENC_CREATE_MV_BUFFER_VER NVENCAPI_STRUCT_VERSION(1)
 
-/** 
+/**
  * QP value for frames
  */
 typedef struct _NV_ENC_QP
@@ -1285,7 +1426,7 @@ typedef struct _NV_ENC_QP
     uint32_t                        zeroReorderDelay     :1;                     /**< [in]: Set this to 1 to indicate zero latency operation (no reordering delay, num_reorder_frames=0) */
     uint32_t                        enableNonRefP        :1;                     /**< [in]: Set this to 1 to enable automatic insertion of non-reference P-frames (no effect if enablePTD=0) */
     uint32_t                        strictGOPTarget      :1;                     /**< [in]: Set this to 1 to minimize GOP-to-GOP rate fluctuations */
-    uint32_t                        aqStrength           :4;                     /**< [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive). 
+    uint32_t                        aqStrength           :4;                     /**< [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive).
                                                                                             If not set, strength is auto selected by driver. */
     uint32_t                        reservedBitFields    :16;                    /**< [in]: Reserved bitfields and must be set to 0 */
     NV_ENC_QP                       minQP;                                       /**< [in]: Specifies the minimum QP used for rate control. Client must set NV_ENC_CONFIG::enableMinQP to 1. */
@@ -1297,37 +1438,69 @@ typedef struct _NV_ENC_QP
                                                                                             Applicable only for constant QP mode (NV_ENC_RC_PARAMS::rateControlMode = NV_ENC_PARAMS_RC_CONSTQP). */
     uint8_t                         targetQuality;                               /**< [in]: Target CQ (Constant Quality) level for VBR mode (range 0-51 with 0-automatic)  */
     uint8_t                         targetQualityLSB;                            /**< [in]: Fractional part of target quality (as 8.8 fixed point format) */
-    uint16_t                        lookaheadDepth;                              /**< [in]: Maximum depth of lookahead with range 0-(31 - number of B frames). 
+    uint16_t                        lookaheadDepth;                              /**< [in]: Maximum depth of lookahead with range 0-(31 - number of B frames).
                                                                                             lookaheadDepth is only used if enableLookahead=1.*/
     uint8_t                         lowDelayKeyFrameScale;                       /**< [in]: Specifies the ratio of I frame bits to P frame bits in case of single frame VBV and CBR rate control mode,
                                                                                             is set to 2 by default for low latency tuning info and 1 by default for ultra low latency tuning info  */
-    uint8_t                         reserved1[3];
+    int8_t                          yDcQPIndexOffset;                            /**< [in]: Specifies the value of 'deltaQ_y_dc' in AV1.*/
+    int8_t                          uDcQPIndexOffset;                            /**< [in]: Specifies the value of 'deltaQ_u_dc' in AV1.*/
+    int8_t                          vDcQPIndexOffset;                            /**< [in]: Specifies the value of 'deltaQ_v_dc' in AV1 (for future use only - deltaQ_v_dc is currently always internally set to same value as deltaQ_u_dc). */
     NV_ENC_QP_MAP_MODE              qpMapMode;                                   /**< [in]: This flag is used to interpret values in array specified by NV_ENC_PIC_PARAMS::qpDeltaMap.
-                                                                                            Set this to NV_ENC_QP_MAP_EMPHASIS to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as Emphasis Level Map. 
-                                                                                            Emphasis Level can be assigned any value specified in enum NV_ENC_EMPHASIS_MAP_LEVEL. 
-                                                                                            Emphasis Level Map is used to specify regions to be encoded at varying levels of quality. 
+                                                                                            Set this to NV_ENC_QP_MAP_EMPHASIS to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as Emphasis Level Map.
+                                                                                            Emphasis Level can be assigned any value specified in enum NV_ENC_EMPHASIS_MAP_LEVEL.
+                                                                                            Emphasis Level Map is used to specify regions to be encoded at varying levels of quality.
                                                                                             The hardware encoder adjusts the quantization within the image as per the provided emphasis map,
-                                                                                            by adjusting the quantization parameter (QP) assigned to each macroblock. This adjustment is commonly called “Delta QP”.
-                                                                                            The adjustment depends on the absolute QP decided by the rate control algorithm, and is applied after the rate control has decided each macroblock’s QP.
+                                                                                            by adjusting the quantization parameter (QP) assigned to each macroblock. This adjustment is commonly called "Delta QP".
+                                                                                            The adjustment depends on the absolute QP decided by the rate control algorithm, and is applied after the rate control has decided each macroblock's QP.
                                                                                             Since the Delta QP overrides rate control, enabling Emphasis Level Map may violate bitrate and VBV buffer size constraints.
                                                                                             Emphasis Level Map is useful in situations where client has a priori knowledge of the image complexity (e.g. via use of NVFBC's Classification feature) and encoding those high-complexity areas at higher quality (lower QP) is important, even at the possible cost of violating bitrate/VBV buffer size constraints
                                                                                             This feature is not supported when AQ( Spatial/Temporal) is enabled.
                                                                                             This feature is only supported for H264 codec currently.
-                                                                                            
-                                                                                            Set this to NV_ENC_QP_MAP_DELTA to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as QP Delta. This specifies QP modifier to be applied on top of the QP chosen by rate control 
-                                                                                            
+
+                                                                                            Set this to NV_ENC_QP_MAP_DELTA to treat values specified by NV_ENC_PIC_PARAMS::qpDeltaMap as QP Delta. This specifies QP modifier to be applied on top of the QP chosen by rate control
+
                                                                                             Set this to NV_ENC_QP_MAP_DISABLED to ignore NV_ENC_PIC_PARAMS::qpDeltaMap values. In this case, qpDeltaMap should be set to NULL.
-                                                                                             
+
                                                                                             Other values are reserved for future use.*/
     NV_ENC_MULTI_PASS               multiPass;                                    /**< [in]: This flag is used to enable multi-pass encoding for a given ::NV_ENC_PARAMS_RC_MODE. This flag is not valid for H264 and HEVC MEOnly mode */
-    uint32_t                        alphaLayerBitrateRatio;                       /**< [in]: Specifies the ratio in which bitrate should be split between base and alpha layer. A value 'x' for this field will split the target bitrate in a ratio of x : 1 between base and alpha layer. 
+    uint32_t                        alphaLayerBitrateRatio;                       /**< [in]: Specifies the ratio in which bitrate should be split between base and alpha layer. A value 'x' for this field will split the target bitrate in a ratio of x : 1 between base and alpha layer.
                                                                                              The default split ratio is 15.*/
-    uint32_t                        reserved[5];
+    int8_t                          cbQPIndexOffset;                              /**< [in]: Specifies the value of 'chroma_qp_index_offset' in H264 / 'pps_cb_qp_offset' in HEVC / 'deltaQ_u_ac' in AV1.*/
+    int8_t                          crQPIndexOffset;                              /**< [in]: Specifies the value of 'second_chroma_qp_index_offset' in H264 / 'pps_cr_qp_offset' in HEVC / 'deltaQ_v_ac' in AV1 (for future use only - deltaQ_v_ac is currently always internally set to same value as deltaQ_u_ac). */
+    uint16_t                        reserved2;
+    uint32_t                        reserved[4];
  } NV_ENC_RC_PARAMS;
 
 /** macro for constructing the version field of ::_NV_ENC_RC_PARAMS */
 #define NV_ENC_RC_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
- 
+
+#define MAX_NUM_CLOCK_TS    3
+
+/**
+* Clock Timestamp set parameters
+* For H264, this structure is used to populate Picture Timing SEI when NV_ENC_CONFIG_H264::enableTimeCode is set to 1.
+* For HEVC, this structure is used to populate Time Code SEI when NV_ENC_CONFIG_HEVC::enableTimeCodeSEI is set to 1.
+* For more details, refer to Annex D of ITU-T Specification.
+*/
+
+typedef struct _NV_ENC_CLOCK_TIMESTAMP_SET
+{
+    uint32_t        countingType            : 1;    /**< [in] Specifies the 'counting_type' */
+    uint32_t        discontinuityFlag       : 1;    /**< [in] Specifies the 'discontinuity_flag' */
+    uint32_t        cntDroppedFrames        : 1;    /**< [in] Specifies the 'cnt_dropped_flag' */
+    uint32_t        nFrames                 : 8;    /**< [in] Specifies the value of 'n_frames' */
+    uint32_t        secondsValue            : 6;    /**< [in] Specifies the 'seconds_value' */
+    uint32_t        minutesValue            : 6;    /**< [in] Specifies the 'minutes_value' */
+    uint32_t        hoursValue              : 5;    /**< [in] Specifies the 'hours_value' */
+    uint32_t        reserved2               : 4;    /**< [in] Reserved and must be set to 0 */
+    uint32_t        timeOffset;                     /**< [in] Specifies the 'time_offset_value' */
+} NV_ENC_CLOCK_TIMESTAMP_SET;
+
+typedef struct _NV_ENC_TIME_CODE
+{
+    NV_ENC_DISPLAY_PIC_STRUCT       displayPicStruct;                   /**< [in] Display picStruct */
+    NV_ENC_CLOCK_TIMESTAMP_SET      clockTimestamp[MAX_NUM_CLOCK_TS];   /**< [in] Clock Timestamp set */
+} NV_ENC_TIME_CODE;
 
 
 /**
@@ -1336,20 +1509,24 @@ typedef struct _NV_ENC_QP
  */
 typedef struct _NV_ENC_CONFIG_H264_VUI_PARAMETERS
 {
-    uint32_t    overscanInfoPresentFlag;              /**< [in]: if set to 1 , it specifies that the overscanInfo is present */
-    uint32_t    overscanInfo;                         /**< [in]: Specifies the overscan info(as defined in Annex E of the ITU-T Specification). */
-    uint32_t    videoSignalTypePresentFlag;           /**< [in]: If set to 1, it specifies  that the videoFormat, videoFullRangeFlag and colourDescriptionPresentFlag are present. */
-    uint32_t    videoFormat;                          /**< [in]: Specifies the source video format(as defined in Annex E of the ITU-T Specification).*/
-    uint32_t    videoFullRangeFlag;                   /**< [in]: Specifies the output range of the luma and chroma samples(as defined in Annex E of the ITU-T Specification). */
-    uint32_t    colourDescriptionPresentFlag;         /**< [in]: If set to 1, it specifies that the colourPrimaries, transferCharacteristics and colourMatrix are present. */
-    uint32_t    colourPrimaries;                      /**< [in]: Specifies color primaries for converting to RGB(as defined in Annex E of the ITU-T Specification) */
-    uint32_t    transferCharacteristics;              /**< [in]: Specifies the opto-electronic transfer characteristics to use (as defined in Annex E of the ITU-T Specification) */
-    uint32_t    colourMatrix;                         /**< [in]: Specifies the matrix coefficients used in deriving the luma and chroma from the RGB primaries (as defined in Annex E of the ITU-T Specification). */
-    uint32_t    chromaSampleLocationFlag;             /**< [in]: if set to 1 , it specifies that the chromaSampleLocationTop and chromaSampleLocationBot are present.*/
-    uint32_t    chromaSampleLocationTop;              /**< [in]: Specifies the chroma sample location for top field(as defined in Annex E of the ITU-T Specification) */
-    uint32_t    chromaSampleLocationBot;              /**< [in]: Specifies the chroma sample location for bottom field(as defined in Annex E of the ITU-T Specification) */
-    uint32_t    bitstreamRestrictionFlag;             /**< [in]: if set to 1, it specifies the bitstream restriction parameters are present in the bitstream.*/
-    uint32_t    reserved[15];
+    uint32_t                            overscanInfoPresentFlag;        /**< [in]: If set to 1 , it specifies that the overscanInfo is present */
+    uint32_t                            overscanInfo;                   /**< [in]: Specifies the overscan info(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            videoSignalTypePresentFlag;     /**< [in]: If set to 1, it specifies  that the videoFormat, videoFullRangeFlag and colourDescriptionPresentFlag are present. */
+    NV_ENC_VUI_VIDEO_FORMAT             videoFormat;                    /**< [in]: Specifies the source video format(as defined in Annex E of the ITU-T Specification).*/
+    uint32_t                            videoFullRangeFlag;             /**< [in]: Specifies the output range of the luma and chroma samples(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            colourDescriptionPresentFlag;   /**< [in]: If set to 1, it specifies that the colourPrimaries, transferCharacteristics and colourMatrix are present. */
+    NV_ENC_VUI_COLOR_PRIMARIES          colourPrimaries;                /**< [in]: Specifies color primaries for converting to RGB(as defined in Annex E of the ITU-T Specification) */
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC  transferCharacteristics;        /**< [in]: Specifies the opto-electronic transfer characteristics to use (as defined in Annex E of the ITU-T Specification) */
+    NV_ENC_VUI_MATRIX_COEFFS            colourMatrix;                   /**< [in]: Specifies the matrix coefficients used in deriving the luma and chroma from the RGB primaries (as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            chromaSampleLocationFlag;       /**< [in]: If set to 1 , it specifies that the chromaSampleLocationTop and chromaSampleLocationBot are present.*/
+    uint32_t                            chromaSampleLocationTop;        /**< [in]: Specifies the chroma sample location for top field(as defined in Annex E of the ITU-T Specification) */
+    uint32_t                            chromaSampleLocationBot;        /**< [in]: Specifies the chroma sample location for bottom field(as defined in Annex E of the ITU-T Specification) */
+    uint32_t                            bitstreamRestrictionFlag;       /**< [in]: If set to 1, it specifies the bitstream restriction parameters are present in the bitstream.*/
+    uint32_t                            timingInfoPresentFlag;          /**< [in]: If set to 1, it specifies that the timingInfo is present and the 'numUnitInTicks' and 'timeScale' fields are specified by the application. */
+                                                                        /**< [in]: If not set, the timingInfo may still be present with timing related fields calculated internally basedon the frame rate specified by the application. */
+    uint32_t                            numUnitInTicks;                 /**< [in]: Specifies the number of time units of the clock(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            timeScale;                      /**< [in]: Specifies the frquency of the clock(as defined in Annex E of the ITU-T Specification). */
+    uint32_t                            reserved[12];                   /**< [in]: Reserved and must be set to 0 */
 }NV_ENC_CONFIG_H264_VUI_PARAMETERS;
 
 typedef NV_ENC_CONFIG_H264_VUI_PARAMETERS NV_ENC_CONFIG_HEVC_VUI_PARAMETERS;
@@ -1357,7 +1534,7 @@ typedef NV_ENC_CONFIG_H264_VUI_PARAMETERS NV_ENC_CONFIG_HEVC_VUI_PARAMETERS;
 /**
  * \struct _NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
  * External motion vector hint counts per block type.
- * H264 supports multiple hint while HEVC supports one hint for each valid candidate.
+ * H264 and AV1 support multiple hint while HEVC supports one hint for each valid candidate.
  */
 typedef struct _NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
 {
@@ -1365,14 +1542,15 @@ typedef struct _NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
     uint32_t   numCandsPerBlk16x8                    : 4;   /**< [in]: Supported for H264 only. Specifies the number of candidates per 16x8 block. */
     uint32_t   numCandsPerBlk8x16                    : 4;   /**< [in]: Supported for H264 only. Specifies the number of candidates per 8x16 block. */
     uint32_t   numCandsPerBlk8x8                     : 4;   /**< [in]: Supported for H264, HEVC. Specifies the number of candidates per 8x8 block. */
-    uint32_t   reserved                              : 16;  /**< [in]: Reserved for padding. */
+    uint32_t   numCandsPerSb                         : 8;   /**< [in]: Supported for AV1 only. Specifies the number of candidates per SB. */
+    uint32_t   reserved                              : 8;   /**< [in]: Reserved for padding. */
     uint32_t   reserved1[3];                                /**< [in]: Reserved for future use. */
 } NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE;
 
 
 /**
  * \struct _NVENC_EXTERNAL_ME_HINT
- * External Motion Vector hint structure.
+ * External Motion Vector hint structure for H264 and HEVC.
  */
 typedef struct _NVENC_EXTERNAL_ME_HINT
 {
@@ -1385,6 +1563,26 @@ typedef struct _NVENC_EXTERNAL_ME_HINT
     int32_t    lastOfMB    : 1;                         /**< [in]: Set to 1 for the last MV of macroblock. */
 } NVENC_EXTERNAL_ME_HINT;
 
+/**
+ * \struct _NVENC_EXTERNAL_ME_SB_HINT
+ * External Motion Vector SB hint structure for AV1
+ */
+typedef struct _NVENC_EXTERNAL_ME_SB_HINT
+{
+    int16_t    refidx         : 5;                      /**< [in]: Specifies the reference index (31=invalid) */
+    int16_t    direction      : 1;                      /**< [in]: Specifies the direction of motion estimation . 0=L0 1=L1.*/
+    int16_t    bi             : 1;                      /**< [in]: Specifies reference mode 0=single mv, 1=compound mv */
+    int16_t    partition_type : 3;                      /**< [in]: Specifies the partition type: 0: 2NX2N, 1:2NxN, 2:Nx2N. reserved 3bits for future modes */
+    int16_t    x8             : 3;                      /**< [in]: Specifies the current partition's top left x position in 8 pixel unit */
+    int16_t    last_of_cu     : 1;                      /**< [in]: Set to 1 for the last MV current CU */
+    int16_t    last_of_sb     : 1;                      /**< [in]: Set to 1 for the last MV of current SB */
+    int16_t    reserved0      : 1;                      /**< [in]: Reserved and must be set to 0 */
+    int16_t    mvx            : 14;                     /**< [in]: Specifies the x component of integer pixel MV (relative to current MB) S12.2. */
+    int16_t    cu_size        : 2;                      /**< [in]: Specifies the CU size: 0: 8x8, 1: 16x16, 2:32x32, 3:64x64 */
+    int16_t    mvy            : 12;                     /**< [in]: Specifies the y component of integer pixel MV (relative to current MB) S10.2 .*/
+    int16_t    y8             : 3;                      /**< [in]: Specifies the current partition's top left y position in 8 pixel unit */
+    int16_t    reserved1      : 1;                      /**< [in]: Reserved and must be set to 0 */
+} NVENC_EXTERNAL_ME_SB_HINT;
 
 /**
  * \struct _NV_ENC_CONFIG_H264
@@ -1397,8 +1595,7 @@ typedef struct _NV_ENC_CONFIG_H264
     uint32_t hierarchicalPFrames       :1;                          /**< [in]: Set to 1 to enable hierarchical P Frames */
     uint32_t hierarchicalBFrames       :1;                          /**< [in]: Set to 1 to enable hierarchical B Frames */
     uint32_t outputBufferingPeriodSEI  :1;                          /**< [in]: Set to 1 to write SEI buffering period syntax in the bitstream */
-    uint32_t outputPictureTimingSEI    :1;                          /**< [in]: Set to 1 to write SEI picture timing syntax in the bitstream.  When set for following rateControlMode : NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ,
-                                                                               NV_ENC_PARAMS_RC_CBR_HQ, filler data is inserted if needed to achieve HRD bitrate */ 
+    uint32_t outputPictureTimingSEI    :1;                          /**< [in]: Set to 1 to write SEI picture timing syntax in the bitstream. */
     uint32_t outputAUD                 :1;                          /**< [in]: Set to 1 to write access unit delimiter syntax in bitstream */
     uint32_t disableSPSPPS             :1;                          /**< [in]: Set to 1 to disable writing of Sequence and Picture parameter info in bitstream */
     uint32_t outputFramePackingSEI     :1;                          /**< [in]: Set to 1 to enable writing of frame packing arrangement SEI messages to bitstream */
@@ -1408,7 +1605,7 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                Constrained encoding works only with rectangular slices.
                                                                                Check support for constrained encoding using ::NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING caps. */
     uint32_t repeatSPSPPS              :1;                          /**< [in]: Set to 1 to enable writing of Sequence and Picture parameter for every IDR frame */
-    uint32_t enableVFR                 :1;                          /**< [in]: Setting enableVFR=1 currently only sets the fixed_frame_rate_flag=0 in the VUI but otherwise 
+    uint32_t enableVFR                 :1;                          /**< [in]: Setting enableVFR=1 currently only sets the fixed_frame_rate_flag=0 in the VUI but otherwise
                                                                                has no impact on the encoder behavior. For more details please refer to E.1 VUI syntax of H.264 standard. Note, however, that NVENC does not support VFR encoding and rate control. */
     uint32_t enableLTR                 :1;                          /**< [in]: Set to 1 to enable LTR (Long Term Reference) frame support. LTR can be used in two modes: "LTR Trust" mode and "LTR Per Picture" mode.
                                                                                LTR Trust mode: In this mode, ltrNumFrames pictures after IDR are automatically marked as LTR. This mode is enabled by setting ltrTrustMode = 1.
@@ -1432,15 +1629,19 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                return an error. */
     uint32_t disableSVCPrefixNalu      :1;                          /**< [in]: Set to 1 to disable writing of SVC Prefix NALU preceding each slice in bitstream.
                                                                                Applicable only when temporal SVC is enabled (NV_ENC_CONFIG_H264::enableTemporalSVC = 1). */
-    uint32_t enableScalabilityInfoSEI  :1;                          /**< [in]: Set to 1 to enable writing of Scalability Information SEI message preceding each IDR picture in bitstream 
+    uint32_t enableScalabilityInfoSEI  :1;                          /**< [in]: Set to 1 to enable writing of Scalability Information SEI message preceding each IDR picture in bitstream
                                                                                Applicable only when temporal SVC is enabled (NV_ENC_CONFIG_H264::enableTemporalSVC = 1). */
-    uint32_t reservedBitFields         :12;                         /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t singleSliceIntraRefresh   :1;                          /**< [in]: Set to 1 to maintain single slice in frames during intra refresh.
+                                                                               Check support for single slice intra refresh using ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps.
+                                                                               This flag will be ignored if the value returned for ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps is false. */
+    uint32_t enableTimeCode            :1;                          /**< [in]: Set to 1 to enable writing of clock timestamp sets in picture timing SEI.  Note that this flag will be ignored for D3D12 interface. */
+    uint32_t reservedBitFields         :10;                         /**< [in]: Reserved bitfields and must be set to 0 */
     uint32_t level;                                                 /**< [in]: Specifies the encoding level. Client is recommended to set this to NV_ENC_LEVEL_AUTOSELECT in order to enable the NvEncodeAPI interface to select the correct level. */
     uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
     uint32_t separateColourPlaneFlag;                               /**< [in]: Set to 1 to enable 4:4:4 separate colour planes */
-    uint32_t disableDeblockingFilterIDC;                            /**< [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]. This flag corresponds 
-                                                                               to the flag disable_deblocking_filter_idc specified in section 7.4.3 of H.264 specification, 
-                                                                               which specifies whether the operation of the deblocking filter shall be disabled across some 
+    uint32_t disableDeblockingFilterIDC;                            /**< [in]: Specifies the deblocking filter mode. Permissible value range: [0,2]. This flag corresponds
+                                                                               to the flag disable_deblocking_filter_idc specified in section 7.4.3 of H.264 specification,
+                                                                               which specifies whether the operation of the deblocking filter shall be disabled across some
                                                                                block edges of the slice and specifies for which edges the filtering is disabled. See section
                                                                                7.4.3 of H.264 specification for more details.*/
     uint32_t numTemporalLayers;                                     /**< [in]: Specifies number of temporal layers to be used for hierarchical coding / temporal SVC. Valid value range is [1,::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS] */
@@ -1454,7 +1655,7 @@ typedef struct _NV_ENC_CONFIG_H264
     uint32_t                            intraRefreshPeriod;         /**< [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
                                                                                Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH. */
     uint32_t                            intraRefreshCnt;            /**< [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod */
-    uint32_t                            maxNumRefFrames;            /**< [in]: Specifies the DPB size used for encoding. Setting it to 0 will let driver use the default DPB size. 
+    uint32_t                            maxNumRefFrames;            /**< [in]: Specifies the DPB size used for encoding. Setting it to 0 will let driver use the default DPB size.
                                                                                The low latency application which wants to invalidate reference frame as an error resilience tool
                                                                                is recommended to use a large DPB size so that the encoder can keep old reference frames which can be used if recent
                                                                                frames are invalidated. */
@@ -1472,19 +1673,20 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                In "LTR Trust" mode (ltrTrustMode = 1), encoder will mark the first ltrNumFrames base layer reference frames within each IDR interval as LTR.
                                                                                In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB. */
     uint32_t                            ltrTrustMode;               /**< [in]: Specifies the LTR operating mode. See comments near NV_ENC_CONFIG_H264::enableLTR for description of the two modes.
-                                                                               Set to 1 to use "LTR Trust" mode of LTR operation. Clients are discouraged to use "LTR Trust" mode as this mode may 
+                                                                               Set to 1 to use "LTR Trust" mode of LTR operation. Clients are discouraged to use "LTR Trust" mode as this mode may
                                                                                be deprecated in future releases.
                                                                                Set to 0 when using "LTR Per Picture" mode of LTR operation. */
     uint32_t                            chromaFormatIDC;            /**< [in]: Specifies the chroma format. Should be set to 1 for yuv420 input, 3 for yuv444 input.
                                                                                Check support for YUV444 encoding using ::NV_ENC_CAPS_SUPPORT_YUV444_ENCODE caps.*/
-    uint32_t                            maxTemporalLayers;          /**< [in]: Specifies the maximum temporal layer used for temporal SVC / hierarchical coding.
+    uint32_t                            maxTemporalLayers;          /**< [in]: Specifies the max temporal layer used for temporal SVC / hierarchical coding.
                                                                                Defaut value of this field is NV_ENC_CAPS::NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS. Note that the value NV_ENC_CONFIG_H264::maxNumRefFrames should
                                                                                be greater than or equal to (NV_ENC_CONFIG_H264::maxTemporalLayers - 2) * 2, for NV_ENC_CONFIG_H264::maxTemporalLayers >= 2.*/
     NV_ENC_BFRAME_REF_MODE              useBFramesAsRef;            /**< [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.*/
-    NV_ENC_NUM_REF_FRAMES               numRefL0;                   /**< [in]: Specifies max number of reference frames in reference picture list L0, that can be used by hardware for prediction of a frame. 
+    NV_ENC_NUM_REF_FRAMES               numRefL0;                   /**< [in]: Specifies max number of reference frames in reference picture list L0, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL0 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
-    NV_ENC_NUM_REF_FRAMES               numRefL1;                   /**< [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame. 
+    NV_ENC_NUM_REF_FRAMES               numRefL1;                   /**< [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL1 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
+
     uint32_t                            reserved1[267];             /**< [in]: Reserved and must be set to 0 */
     void*                               reserved2[64];              /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_CONFIG_H264;
@@ -1530,7 +1732,12 @@ typedef struct _NV_ENC_CONFIG_HEVC
                                                                                Constrained encoding works only with rectangular slices.
                                                                                Check support for constrained encoding using ::NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING caps. */
     uint32_t enableAlphaLayerEncoding              :1;              /**< [in]: Set this to 1 to enable HEVC encode with alpha layer. */
-    uint32_t reserved                              :15;             /**< [in]: Reserved bitfields.*/
+    uint32_t singleSliceIntraRefresh               :1;              /**< [in]: Set this to 1 to maintain single slice frames during intra refresh.
+                                                                               Check support for single slice intra refresh using ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps.
+                                                                               This flag will be ignored if the value returned for ::NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH caps is false. */
+    uint32_t outputRecoveryPointSEI                :1;              /**< [in]: Set to 1 to enable writing of recovery point SEI message */
+    uint32_t outputTimeCodeSEI                     :1;              /**< [in]: Set 1 to write SEI time code syntax in the bitstream. Note that this flag will be ignored for D3D12 interface.*/
+    uint32_t reserved                              :12;             /**< [in]: Reserved bitfields.*/
     uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG. Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
     uint32_t intraRefreshPeriod;                                    /**< [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
                                                                     Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH. */
@@ -1538,7 +1745,10 @@ typedef struct _NV_ENC_CONFIG_HEVC
     uint32_t maxNumRefFramesInDPB;                                  /**< [in]: Specifies the maximum number of references frames in the DPB.*/
     uint32_t ltrNumFrames;                                          /**< [in]: This parameter has different meaning in two LTR modes.
                                                                                In "LTR Trust" mode (ltrTrustMode = 1), encoder will mark the first ltrNumFrames base layer reference frames within each IDR interval as LTR.
-                                                                               In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB. */
+                                                                               In "LTR Per Picture" mode (ltrTrustMode = 0 and ltrMarkFrame = 1), ltrNumFrames specifies maximum number of LTR frames in DPB.
+                                                                               These ltrNumFrames acts as a guidance to the encoder and are not necessarily honored. To achieve a right balance between the encoding
+                                                                               quality and keeping LTR frames in the DPB queue, the encoder can internally limit the number of LTR frames.
+                                                                               The number of LTR frames actually used depends upon the encoding preset being used; Faster encoding presets will use fewer LTR frames.*/
     uint32_t vpsId;                                                 /**< [in]: Specifies the VPS id of the video parameter set */
     uint32_t spsId;                                                 /**< [in]: Specifies the SPS id of the sequence header */
     uint32_t ppsId;                                                 /**< [in]: Specifies the PPS id of the picture header */
@@ -1553,22 +1763,121 @@ typedef struct _NV_ENC_CONFIG_HEVC
     uint32_t maxTemporalLayersMinus1;                               /**< [in]: Specifies the max temporal layer used for hierarchical coding. */
     NV_ENC_CONFIG_HEVC_VUI_PARAMETERS   hevcVUIParameters;          /**< [in]: Specifies the HEVC video usability info parameters */
     uint32_t ltrTrustMode;                                          /**< [in]: Specifies the LTR operating mode. See comments near NV_ENC_CONFIG_HEVC::enableLTR for description of the two modes.
-                                                                               Set to 1 to use "LTR Trust" mode of LTR operation. Clients are discouraged to use "LTR Trust" mode as this mode may 
+                                                                               Set to 1 to use "LTR Trust" mode of LTR operation. Clients are discouraged to use "LTR Trust" mode as this mode may
                                                                                be deprecated in future releases.
                                                                                Set to 0 when using "LTR Per Picture" mode of LTR operation. */
     NV_ENC_BFRAME_REF_MODE              useBFramesAsRef;            /**< [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using  ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.*/
-    NV_ENC_NUM_REF_FRAMES               numRefL0;                   /**< [in]: Specifies max number of reference frames in reference picture list L0, that can be used by hardware for prediction of a frame. 
+    NV_ENC_NUM_REF_FRAMES               numRefL0;                   /**< [in]: Specifies max number of reference frames in reference picture list L0, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL0 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
-    NV_ENC_NUM_REF_FRAMES               numRefL1;                   /**< [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame. 
+    NV_ENC_NUM_REF_FRAMES               numRefL1;                   /**< [in]: Specifies max number of reference frames in reference picture list L1, that can be used by hardware for prediction of a frame.
                                                                                Check support for numRefL1 using ::NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES caps. */
     uint32_t                            reserved1[214];             /**< [in]: Reserved and must be set to 0.*/
     void*                               reserved2[64];              /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_CONFIG_HEVC;
 
+#define NV_MAX_TILE_COLS_AV1               64
+#define NV_MAX_TILE_ROWS_AV1               64
+
+/**
+ * \struct _NV_ENC_FILM_GRAIN_PARAMS_AV1
+ * AV1 Film Grain Parameters structure
+ */
+
+typedef struct _NV_ENC_FILM_GRAIN_PARAMS_AV1
+{
+    uint32_t applyGrain                 :1;                         /**< [in]: Set to 1 to specify film grain should be added to frame */
+    uint32_t chromaScalingFromLuma      :1;                         /**< [in]: Set to 1 to specify the chroma scaling is inferred from luma scaling */
+    uint32_t overlapFlag                :1;                         /**< [in]: Set to 1 to indicate that overlap between film grain blocks should be applied*/
+    uint32_t clipToRestrictedRange      :1;                         /**< [in]: Set to 1 to clip values to restricted (studio) range after adding film grain  */
+    uint32_t grainScalingMinus8         :2;                         /**< [in]: Represents the shift - 8 applied to the values of the chroma component */
+    uint32_t arCoeffLag                 :2;                         /**< [in]: Specifies the number of auto-regressive coefficients for luma and chroma */
+    uint32_t numYPoints                 :4;                         /**< [in]: Specifies the number of points for the piecewise linear scaling function of the luma component */
+    uint32_t numCbPoints                :4;                         /**< [in]: Specifies the number of points for the piecewise linear scaling function of the cb component */
+    uint32_t numCrPoints                :4;                         /**< [in]: Specifies the number of points for the piecewise linear scaling function of the cr component */
+    uint32_t arCoeffShiftMinus6         :2;                         /**< [in]: specifies the range of the auto-regressive coefficients */
+    uint32_t grainScaleShift            :2;                         /**< [in]: Specifies how much the Gaussian random numbers should be scaled down during the grain synthesi process  */
+    uint32_t reserved1                  :8;                         /**< [in]: Reserved bits field - should be set to 0 */
+    uint8_t  pointYValue[14];                                       /**< [in]: pointYValue[i]: x coordinate for i-th point of luma piecewise linear scaling function. Values on a scale of 0...255 */
+    uint8_t  pointYScaling[14];                                     /**< [in]: pointYScaling[i]: i-th point output value of luma piecewise linear scaling function */
+    uint8_t  pointCbValue[10];                                      /**< [in]: pointCbValue[i]: x coordinate for i-th point of cb piecewise linear scaling function. Values on a scale of 0...255 */
+    uint8_t  pointCbScaling[10];                                    /**< [in]: pointCbScaling[i]: i-th point output value of cb piecewise linear scaling function */
+    uint8_t  pointCrValue[10];                                      /**< [in]: pointCrValue[i]: x coordinate for i-th point of cr piecewise linear scaling function. Values on a scale of 0...255 */
+    uint8_t  pointCrScaling[10];                                    /**< [in]: pointCrScaling[i]: i-th point output value of cr piecewise linear scaling function */
+    uint8_t  arCoeffsYPlus128[24];                                  /**< [in]: Specifies auto-regressive coefficients used for the Y plane */
+    uint8_t  arCoeffsCbPlus128[25];                                 /**< [in]: Specifies auto-regressive coefficients used for the U plane */
+    uint8_t  arCoeffsCrPlus128[25];                                 /**< [in]: Specifies auto-regressive coefficients used for the V plane */
+    uint8_t  reserved2[2];                                          /**< [in]: Reserved bytes -  should be set to 0 */
+    uint8_t  cbMult;                                                /**< [in]: Represents a multiplier for the cb component used in derivation of the input index to the cb component scaling function */
+    uint8_t  cbLumaMult;                                            /**< [in]: represents a multiplier for the average luma component used in derivation of the input index to the cb component scaling function. */
+    uint16_t cbOffset;                                              /**< [in]: Represents an offset used in derivation of the input index to the cb component scaling function */
+    uint8_t  crMult;                                                /**< [in]: Represents a multiplier for the cr component used in derivation of the input index to the cr component scaling function */
+    uint8_t  crLumaMult;                                            /**< [in]: represents a multiplier for the average luma component used in derivation of the input index to the cr component scaling function. */
+    uint16_t crOffset;                                              /**< [in]: Represents an offset used in derivation of the input index to the cr component scaling function */
+} NV_ENC_FILM_GRAIN_PARAMS_AV1;
+
+/**
+* \struct _NV_ENC_CONFIG_AV1
+* AV1 encoder configuration parameters to be set during initialization.
+*/
+typedef struct _NV_ENC_CONFIG_AV1
+{
+    uint32_t level;                                                 /**< [in]: Specifies the level of the encoded bitstream.*/
+    uint32_t tier;                                                  /**< [in]: Specifies the level tier of the encoded bitstream.*/
+    NV_ENC_AV1_PART_SIZE minPartSize;                               /**< [in]: Specifies the minimum size of luma coding block partition.*/
+    NV_ENC_AV1_PART_SIZE maxPartSize;                               /**< [in]: Specifies the maximum size of luma coding block partition.*/
+    uint32_t outputAnnexBFormat             : 1;                    /**< [in]: Set 1 to use Annex B format for bitstream output.*/
+    uint32_t enableTimingInfo               : 1;                    /**< [in]: Set 1 to write Timing Info into sequence/frame headers */
+    uint32_t enableDecoderModelInfo         : 1;                    /**< [in]: Set 1 to write Decoder Model Info into sequence/frame headers */
+    uint32_t enableFrameIdNumbers           : 1;                    /**< [in]: Set 1 to write Frame id numbers in  bitstream */
+    uint32_t disableSeqHdr                  : 1;                    /**< [in]: Set 1 to disable Sequence Header signaling in the bitstream. */
+    uint32_t repeatSeqHdr                   : 1;                    /**< [in]: Set 1 to output Sequence Header for every Key frame.*/
+    uint32_t enableIntraRefresh             : 1;                    /**< [in]: Set 1 to enable gradual decoder refresh or intra refresh. If the GOP structure uses B frames this will be ignored */
+    uint32_t chromaFormatIDC                : 2;                    /**< [in]: Specifies the chroma format. Should be set to 1 for yuv420 input (yuv444 input currently not supported).*/
+    uint32_t enableBitstreamPadding         : 1;                    /**< [in]: Set 1 to enable bitstream padding. */
+    uint32_t enableCustomTileConfig         : 1;                    /**< [in]: Set 1 to enable custom tile configuration: numTileColumns and numTileRows must have non zero values and tileWidths and tileHeights must point to a valid address  */
+    uint32_t enableFilmGrainParams          : 1;                    /**< [in]: Set 1 to enable custom film grain parameters: filmGrainParams must point to a valid address  */
+    uint32_t inputPixelBitDepthMinus8       : 3;                    /**< [in]: Specifies pixel bit depth minus 8 of video input. Should be set to 0 for 8 bit input, 2 for 10 bit input.*/
+    uint32_t pixelBitDepthMinus8            : 3;                    /**< [in]: Specifies pixel bit depth minus 8 of encoded video. Should be set to 0 for 8 bit, 2 for 10 bit.
+                                                                               HW will do the bitdepth conversion internally from inputPixelBitDepthMinus8 -> pixelBitDepthMinus8 if bit dpeths differ
+                                                                               Support for 8 bit input to 10 bit encode conversion only */
+    uint32_t reserved                       : 14;                   /**< [in]: Reserved bitfields.*/
+    uint32_t idrPeriod;                                             /**< [in]: Specifies the IDR/Key frame interval. If not set, this is made equal to gopLength in NV_ENC_CONFIG.Low latency application client can set IDR interval to NVENC_INFINITE_GOPLENGTH so that IDR frames are not inserted automatically. */
+    uint32_t intraRefreshPeriod;                                    /**< [in]: Specifies the interval between successive intra refresh if enableIntrarefresh is set. Requires enableIntraRefresh to be set.
+                                                                               Will be disabled if NV_ENC_CONFIG::gopLength is not set to NVENC_INFINITE_GOPLENGTH. */
+    uint32_t intraRefreshCnt;                                       /**< [in]: Specifies the length of intra refresh in number of frames for periodic intra refresh. This value should be smaller than intraRefreshPeriod */
+    uint32_t maxNumRefFramesInDPB;                                  /**< [in]: Specifies the maximum number of references frames in the DPB.*/
+    uint32_t numTileColumns;                                        /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileWidths[] specifies the way in which the picture is divided into tile columns.
+                                                                               When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileColumns tile columns. If numTileColumns is not a power of 2,
+                                                                               it will be rounded down to the next power of 2 value. If numTileColumns == 0, the picture will be coded with the smallest number of vertical tiles as allowed by standard.
+                                                                               When enableCustomTileConfig == 1, numTileColumns must be > 0 and <= NV_MAX_TILE_COLS_AV1 and tileWidths must point to a valid array of numTileColumns entries.
+                                                                               Entry i specifies the width in 64x64 CTU unit of tile colum i. The sum of all the entries should be equal to the picture width in 64x64 CTU units. */
+    uint32_t numTileRows;                                           /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileHeights[] specifies the way in which the picture is divided into tiles rows
+                                                                               When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileRows tile rows. If numTileRows is not a power of 2,
+                                                                               it will be rounded down to the next power of 2 value. If numTileRows == 0, the picture will be coded with the smallest number of horizontal tiles as allowed by standard.
+                                                                               When enableCustomTileConfig == 1, numTileRows must be > 0 and <= NV_MAX_TILE_ROWS_AV1 and tileHeights must point to a valid array of numTileRows entries.
+                                                                               Entry i specifies the height in 64x64 CTU unit of tile row i. The sum of all the entries should be equal to the picture hieght in 64x64 CTU units. */
+    uint32_t *tileWidths;                                           /**< [in]: If enableCustomTileConfig == 1, tileWidths[i] specifies the width of tile column i in 64x64 CTU unit, with 0 <= i <= numTileColumns -1. */
+    uint32_t *tileHeights;                                          /**< [in]: If enableCustomTileConfig == 1, tileHeights[i] specifies the height of tile row i in 64x64 CTU unit, with 0 <= i <= numTileRows -1. */
+    uint32_t maxTemporalLayersMinus1;                               /**< [in]: Specifies the max temporal layer used for hierarchical coding. */
+    NV_ENC_VUI_COLOR_PRIMARIES colorPrimaries;                      /**< [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273 */
+    NV_ENC_VUI_TRANSFER_CHARACTERISTIC transferCharacteristics;     /**< [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273 */
+    NV_ENC_VUI_MATRIX_COEFFS matrixCoefficients;                    /**< [in]: as defined in section of ISO/IEC 23091-4/ITU-T H.273 */
+    uint32_t colorRange;                                            /**< [in]: 0: studio swing representation - 1: full swing representation */
+    uint32_t chromaSamplePosition;                                  /**< [in]: 0: unknown
+                                                                               1: Horizontally collocated with luma (0,0) sample, between two vertical samples
+                                                                               2: Co-located with luma (0,0) sample */
+    NV_ENC_BFRAME_REF_MODE useBFramesAsRef;                         /**< [in]: Specifies the B-Frame as reference mode. Check support for useBFramesAsRef mode using  ::NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE caps.*/
+    NV_ENC_FILM_GRAIN_PARAMS_AV1 *filmGrainParams;                  /**< [in]: If enableFilmGrainParams == 1, filmGrainParams must point to a valid NV_ENC_FILM_GRAIN_PARAMS_AV1 structure */
+    NV_ENC_NUM_REF_FRAMES  numFwdRefs;                              /**< [in]: Specifies max number of forward reference frame used for prediction of a frame. It must be in range 1-4 (Last, Last2, last3 and Golden). It's a suggestive value not necessarily be honored always. */
+    NV_ENC_NUM_REF_FRAMES  numBwdRefs;                              /**< [in]: Specifies max number of L1 list reference frame used for prediction of a frame. It must be in range 1-3 (Backward, Altref2, Altref). It's a suggestive value not necessarily be honored always. */
+    uint32_t reserved1[235];                                        /**< [in]: Reserved and must be set to 0.*/
+    void*    reserved2[62];                                         /**< [in]: Reserved and must be set to NULL */
+} NV_ENC_CONFIG_AV1;
+
 /**
  * \struct _NV_ENC_CONFIG_H264_MEONLY
  * H264 encoder configuration parameters for ME only Mode
- * 
+ *
  */
 typedef struct _NV_ENC_CONFIG_H264_MEONLY
 {
@@ -1587,7 +1896,7 @@ typedef struct _NV_ENC_CONFIG_H264_MEONLY
 /**
  * \struct _NV_ENC_CONFIG_HEVC_MEONLY
  * HEVC encoder configuration parameters for ME only Mode
- * 
+ *
  */
 typedef struct _NV_ENC_CONFIG_HEVC_MEONLY
 {
@@ -1603,6 +1912,7 @@ typedef union _NV_ENC_CODEC_CONFIG
 {
     NV_ENC_CONFIG_H264        h264Config;                /**< [in]: Specifies the H.264-specific encoder configuration. */
     NV_ENC_CONFIG_HEVC        hevcConfig;                /**< [in]: Specifies the HEVC-specific encoder configuration. */
+    NV_ENC_CONFIG_AV1         av1Config;                 /**< [in]: Specifies the AV1-specific encoder configuration. */
     NV_ENC_CONFIG_H264_MEONLY h264MeOnlyConfig;          /**< [in]: Specifies the H.264-specific ME only encoder configuration. */
     NV_ENC_CONFIG_HEVC_MEONLY hevcMeOnlyConfig;          /**< [in]: Specifies the HEVC-specific ME only encoder configuration. */
     uint32_t                reserved[320];               /**< [in]: Reserved and must be set to 0 */
@@ -1631,7 +1941,7 @@ typedef struct _NV_ENC_CONFIG
 } NV_ENC_CONFIG;
 
 /** macro for constructing the version field of ::_NV_ENC_CONFIG */
-#define NV_ENC_CONFIG_VER (NVENCAPI_STRUCT_VERSION(7) | ( 1<<31 ))
+#define NV_ENC_CONFIG_VER (NVENCAPI_STRUCT_VERSION(8) | ( 1<<31 ))
 
 /**
  *  Tuning information of NVENC encoding (TuningInfo is not applicable to H264 and HEVC MEOnly mode).
@@ -1657,21 +1967,21 @@ typedef struct _NV_ENC_INITIALIZE_PARAMS
     GUID                                       presetGUID;                      /**< [in]: Specifies the preset for encoding. If the preset GUID is set then , the preset configuration will be applied before any other parameter. */
     uint32_t                                   encodeWidth;                     /**< [in]: Specifies the encode width. If not set ::NvEncInitializeEncoder() API will fail. */
     uint32_t                                   encodeHeight;                    /**< [in]: Specifies the encode height. If not set ::NvEncInitializeEncoder() API will fail. */
-    uint32_t                                   darWidth;                        /**< [in]: Specifies the display aspect ratio Width. */
-    uint32_t                                   darHeight;                       /**< [in]: Specifies the display aspect ratio height. */
+    uint32_t                                   darWidth;                        /**< [in]: Specifies the display aspect ratio width (H264/HEVC) or the render width (AV1). */
+    uint32_t                                   darHeight;                       /**< [in]: Specifies the display aspect ratio height (H264/HEVC) or the render height (AV1). */
     uint32_t                                   frameRateNum;                    /**< [in]: Specifies the numerator for frame rate used for encoding in frames per second ( Frame rate = frameRateNum / frameRateDen ). */
     uint32_t                                   frameRateDen;                    /**< [in]: Specifies the denominator for frame rate used for encoding in frames per second ( Frame rate = frameRateNum / frameRateDen ). */
     uint32_t                                   enableEncodeAsync;               /**< [in]: Set this to 1 to enable asynchronous mode and is expected to use events to get picture completion notification. */
     uint32_t                                   enablePTD;                       /**< [in]: Set this to 1 to enable the Picture Type Decision is be taken by the NvEncodeAPI interface. */
     uint32_t                                   reportSliceOffsets        :1;    /**< [in]: Set this to 1 to enable reporting slice offsets in ::_NV_ENC_LOCK_BITSTREAM. NV_ENC_INITIALIZE_PARAMS::enableEncodeAsync must be set to 0 to use this feature. Client must set this to 0 if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs */
     uint32_t                                   enableSubFrameWrite       :1;    /**< [in]: Set this to 1 to write out available bitstream to memory at subframe intervals.
-                                                                                           If enableSubFrameWrite = 1, then the hardware encoder returns data as soon as a slice has completed encoding.
-                                                                                           This results in better encoding latency, but the downside is that the application has to keep polling via a call to nvEncLockBitstream API continuously to see if any encoded slice data is available. 
+                                                                                           If enableSubFrameWrite = 1, then the hardware encoder returns data as soon as a slice (H264/HEVC) or tile (AV1) has completed encoding.
+                                                                                           This results in better encoding latency, but the downside is that the application has to keep polling via a call to nvEncLockBitstream API continuously to see if any encoded slice/tile data is available.
                                                                                            Use this mode if you feel that the marginal reduction in latency from sub-frame encoding is worth the increase in complexity due to CPU-based polling. */
-    uint32_t                                   enableExternalMEHints     :1;    /**< [in]: Set to 1 to enable external ME hints for the current frame. For NV_ENC_INITIALIZE_PARAMS::enablePTD=1 with B frames, programming L1 hints is optional for B frames since Client doesn't know internal GOP structure. 
+    uint32_t                                   enableExternalMEHints     :1;    /**< [in]: Set to 1 to enable external ME hints for the current frame. For NV_ENC_INITIALIZE_PARAMS::enablePTD=1 with B frames, programming L1 hints is optional for B frames since Client doesn't know internal GOP structure.
                                                                                            NV_ENC_PIC_PARAMS::meHintRefPicDist should preferably be set with enablePTD=1. */
     uint32_t                                   enableMEOnlyMode          :1;    /**< [in]: Set to 1 to enable ME Only Mode .*/
-    uint32_t                                   enableWeightedPrediction  :1;    /**< [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames (i.e. NV_ENC_CONFIG::frameIntervalP > 1 or preset >=P3 when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or 
+    uint32_t                                   enableWeightedPrediction  :1;    /**< [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames (i.e. NV_ENC_CONFIG::frameIntervalP > 1 or preset >=P3 when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or
                                                                                            tuningInfo = ::NV_ENC_TUNING_INFO_LOSSLESS. This is because preset >=p3 internally enables B frames when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or ::NV_ENC_TUNING_INFO_LOSSLESS). */
     uint32_t                                   enableOutputInVidmem      :1;    /**< [in]: Set this to 1 to enable output of NVENC in video memory buffer created by application. This feature is not supported for HEVC ME only mode. */
     uint32_t                                   reservedBitFields         :26;   /**< [in]: Reserved bitfields and must be set to 0 */
@@ -1684,11 +1994,12 @@ typedef struct _NV_ENC_INITIALIZE_PARAMS
                                                                                            Client should allocate output buffers according to this dimension for dynamic resolution change. If set to 0, Encoder will not allow dynamic resolution change. */
     uint32_t                                   maxEncodeHeight;                 /**< [in]: Maximum encode height to be allowed for current Encode session.
                                                                                            Client should allocate output buffers according to this dimension for dynamic resolution change. If set to 0, Encode will not allow dynamic resolution change. */
-    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE maxMEHintCountsPerBlock[2];      /**< [in]: If Client wants to pass external motion vectors in NV_ENC_PIC_PARAMS::meExternalHints buffer it must specify the maximum number of hint candidates per block per direction for the encode session.
+    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE maxMEHintCountsPerBlock[2];     /**< [in]: If Client wants to pass external motion vectors in NV_ENC_PIC_PARAMS::meExternalHints buffer it must specify the maximum number of hint candidates per block per direction for the encode session.
                                                                                            The NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[0] is for L0 predictors and NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[1] is for L1 predictors.
                                                                                            This client must also set NV_ENC_INITIALIZE_PARAMS::enableExternalMEHints to 1. */
     NV_ENC_TUNING_INFO                         tuningInfo;                      /**< [in]: Tuning Info of NVENC encoding(TuningInfo is not applicable to H264 and HEVC meonly mode). */
-    uint32_t                                   reserved [288];                  /**< [in]: Reserved and must be set to 0 */
+    NV_ENC_BUFFER_FORMAT                       bufferFormat;                    /**< [in]: Input buffer format. Used only when DX12 interface type is used */
+    uint32_t                                   reserved [287];                  /**< [in]: Reserved and must be set to 0 */
     void*                                      reserved2[64];                   /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_INITIALIZE_PARAMS;
 
@@ -1732,7 +2043,7 @@ typedef struct _NV_ENC_RECONFIGURE_PARAMS
 /**
  * \struct _NV_ENC_PRESET_CONFIG
  * Encoder preset config
- */ 
+ */
 typedef struct _NV_ENC_PRESET_CONFIG
 {
     uint32_t      version;                               /**< [in]:  Struct version. Must be set to ::NV_ENC_PRESET_CONFIG_VER. */
@@ -1748,7 +2059,7 @@ typedef struct _NV_ENC_PRESET_CONFIG
 /**
  * \struct _NV_ENC_PIC_PARAMS_MVC
  * MVC-specific parameters to be sent on a per-frame basis.
- */ 
+ */
 typedef struct _NV_ENC_PIC_PARAMS_MVC
 {
     uint32_t version;                                    /**< [in]: Struct version. Must be set to ::NV_ENC_PIC_PARAMS_MVC_VER. */
@@ -1766,7 +2077,7 @@ typedef struct _NV_ENC_PIC_PARAMS_MVC
 /**
  * \union _NV_ENC_PIC_PARAMS_H264_EXT
  * H264 extension  picture parameters
- */ 
+ */
 typedef union _NV_ENC_PIC_PARAMS_H264_EXT
 {
     NV_ENC_PIC_PARAMS_MVC mvcPicParams;                  /**< [in]: Specifies the MVC picture parameters. */
@@ -1789,17 +2100,17 @@ typedef struct _NV_ENC_SEI_PAYLOAD
 /**
  * \struct _NV_ENC_PIC_PARAMS_H264
  * H264 specific enc pic params. sent on a per frame basis.
- */ 
+ */
 typedef struct _NV_ENC_PIC_PARAMS_H264
 {
     uint32_t displayPOCSyntax;                           /**< [in]: Specifies the display POC syntax This is required to be set if client is handling the picture type decision. */
     uint32_t reserved3;                                  /**< [in]: Reserved and must be set to 0 */
     uint32_t refPicFlag;                                 /**< [in]: Set to 1 for a reference picture. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
     uint32_t colourPlaneId;                              /**< [in]: Specifies the colour plane ID associated with the current input. */
-    uint32_t forceIntraRefreshWithFrameCnt;              /**< [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt. 
-                                                                    When outputRecoveryPointSEI is set this is value is used for recovery_frame_cnt in recovery point SEI message 
+    uint32_t forceIntraRefreshWithFrameCnt;              /**< [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt.
+                                                                    When outputRecoveryPointSEI is set this is value is used for recovery_frame_cnt in recovery point SEI message
                                                                     forceIntraRefreshWithFrameCnt cannot be used if B frames are used in the GOP structure specified */
-    uint32_t constrainedFrame           :1;              /**< [in]: Set to 1 if client wants to encode this frame with each slice completely independent of other slices in the frame. 
+    uint32_t constrainedFrame           :1;              /**< [in]: Set to 1 if client wants to encode this frame with each slice completely independent of other slices in the frame.
                                                                     NV_ENC_INITIALIZE_PARAMS::enableConstrainedEncoding should be set to 1 */
     uint32_t sliceModeDataUpdate        :1;              /**< [in]: Set to 1 if client wants to change the sliceModeData field to specify new sliceSize Parameter
                                                                     When forceIntraRefreshWithFrameCnt is set it will have priority over sliceMode setting */
@@ -1825,9 +2136,10 @@ typedef struct _NV_ENC_PIC_PARAMS_H264
     uint32_t forceIntraSliceCount;                       /**< [in]: Specifies the number of slices to be forced to Intra in the current picture.
                                                                     This option along with forceIntraSliceIdx[] array needs to be used with sliceMode = 3 only */
     uint32_t *forceIntraSliceIdx;                        /**< [in]: Slice indices to be forced to intra in the current picture. Each slice index should be <= num_slices_in_picture -1. Index starts from 0 for first slice.
-                                                                    The number of entries in this array should be equal to forceIntraSliceCount */															
+                                                                    The number of entries in this array should be equal to forceIntraSliceCount */
     NV_ENC_PIC_PARAMS_H264_EXT h264ExtPicParams;         /**< [in]: Specifies the H264 extension config parameters using this config. */
-    uint32_t reserved [210];                             /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_TIME_CODE timeCode;                           /**< [in]: Specifies the clock timestamp sets used in picture timing SEI. Applicable only when NV_ENC_CONFIG_H264::enableTimeCode is set to 1. */
+    uint32_t reserved [203];                             /**< [in]: Reserved and must be set to 0. */
     void*    reserved2[61];                              /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_PIC_PARAMS_H264;
 
@@ -1840,18 +2152,18 @@ typedef struct _NV_ENC_PIC_PARAMS_HEVC
     uint32_t displayPOCSyntax;                           /**< [in]: Specifies the display POC syntax This is required to be set if client is handling the picture type decision. */
     uint32_t refPicFlag;                                 /**< [in]: Set to 1 for a reference picture. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
     uint32_t temporalId;                                 /**< [in]: Specifies the temporal id of the picture */
-    uint32_t forceIntraRefreshWithFrameCnt;              /**< [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt. 
-                                                                    When outputRecoveryPointSEI is set this is value is used for recovery_frame_cnt in recovery point SEI message 
+    uint32_t forceIntraRefreshWithFrameCnt;              /**< [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt.
+                                                                    When outputRecoveryPointSEI is set this is value is used for recovery_frame_cnt in recovery point SEI message
                                                                     forceIntraRefreshWithFrameCnt cannot be used if B frames are used in the GOP structure specified */
-    uint32_t constrainedFrame           :1;              /**< [in]: Set to 1 if client wants to encode this frame with each slice completely independent of other slices in the frame. 
+    uint32_t constrainedFrame           :1;              /**< [in]: Set to 1 if client wants to encode this frame with each slice completely independent of other slices in the frame.
                                                                     NV_ENC_INITIALIZE_PARAMS::enableConstrainedEncoding should be set to 1 */
     uint32_t sliceModeDataUpdate        :1;              /**< [in]: Set to 1 if client wants to change the sliceModeData field to specify new sliceSize Parameter
                                                                     When forceIntraRefreshWithFrameCnt is set it will have priority over sliceMode setting */
     uint32_t ltrMarkFrame               :1;              /**< [in]: Set to 1 if client wants to mark this frame as LTR */
     uint32_t ltrUseFrames               :1;              /**< [in]: Set to 1 if client allows encoding this frame using the LTR frames specified in ltrFrameBitmap */
     uint32_t reservedBitFields          :28;             /**< [in]: Reserved bit fields and must be set to 0 */
-    uint8_t* sliceTypeData;                              /**< [in]: Array which specifies the slice type used to force intra slice for a particular slice. Currently supported only for NV_ENC_CONFIG_H264::sliceMode == 3. 
-                                                                    Client should allocate array of size sliceModeData where sliceModeData is specified in field of ::_NV_ENC_CONFIG_H264 
+    uint8_t* sliceTypeData;                              /**< [in]: Array which specifies the slice type used to force intra slice for a particular slice. Currently supported only for NV_ENC_CONFIG_H264::sliceMode == 3.
+                                                                    Client should allocate array of size sliceModeData where sliceModeData is specified in field of ::_NV_ENC_CONFIG_H264
                                                                     Array element with index n corresponds to nth slice. To force a particular slice to intra client should set corresponding array element to NV_ENC_SLICE_TYPE_I
                                                                     all other array elements should be set to NV_ENC_SLICE_TYPE_DEFAULT */
     uint32_t sliceTypeArrayCnt;                          /**< [in]: Client should set this to the number of elements allocated in sliceTypeData array. If sliceTypeData is NULL then this should be set to 0 */
@@ -1870,9 +2182,59 @@ typedef struct _NV_ENC_PIC_PARAMS_HEVC
     uint32_t seiPayloadArrayCnt;                         /**< [in]: Specifies the number of elements allocated in  seiPayloadArray array. */
     uint32_t reserved;                                   /**< [in]: Reserved and must be set to 0. */
     NV_ENC_SEI_PAYLOAD* seiPayloadArray;                 /**< [in]: Array of SEI payloads which will be inserted for this frame. */
-    uint32_t reserved2 [244];                             /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_TIME_CODE timeCode;                           /**< [in]: Specifies the clock timestamp sets used in time code SEI. Applicable only when NV_ENC_CONFIG_HEVC::enableTimeCodeSEI is set to 1. */
+    uint32_t reserved2 [237];                            /**< [in]: Reserved and must be set to 0. */
     void*    reserved3[61];                              /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_PIC_PARAMS_HEVC;
+
+#define NV_ENC_AV1_OBU_PAYLOAD NV_ENC_SEI_PAYLOAD
+
+/**
+* \struct _NV_ENC_PIC_PARAMS_AV1
+* AV1 specific enc pic params. sent on a per frame basis.
+*/
+typedef struct _NV_ENC_PIC_PARAMS_AV1
+{
+    uint32_t displayPOCSyntax;                           /**< [in]: Specifies the display POC syntax This is required to be set if client is handling the picture type decision. */
+    uint32_t refPicFlag;                                 /**< [in]: Set to 1 for a reference picture. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t temporalId;                                 /**< [in]: Specifies the temporal id of the picture */
+    uint32_t forceIntraRefreshWithFrameCnt;              /**< [in]: Forces an intra refresh with duration equal to intraRefreshFrameCnt.
+                                                                    forceIntraRefreshWithFrameCnt cannot be used if B frames are used in the GOP structure specified */
+    uint32_t goldenFrameFlag            : 1;             /**< [in]: Encode frame as Golden Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t arfFrameFlag               : 1;             /**< [in]: Encode frame as Alternate Reference Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t arf2FrameFlag              : 1;             /**< [in]: Encode frame as Alternate Reference 2 Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t bwdFrameFlag               : 1;             /**< [in]: Encode frame as Backward Reference Frame. This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t overlayFrameFlag           : 1;             /**< [in]: Encode frame as overlay frame. A previously encoded frame with the same displayPOCSyntax value should be present in reference frame buffer.
+                                                                    This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t showExistingFrameFlag      : 1;             /**< [in]: When ovelayFrameFlag is set to 1, this flag controls the value of the show_existing_frame syntax element associated with the overlay frame.
+                                                                    This flag is added to the interface as a placeholder. Its value is ignored for now and always assumed to be set to 1.
+                                                                    This is ignored if NV_ENC_INITIALIZE_PARAMS::enablePTD is set to 1. */
+    uint32_t errorResilientModeFlag     : 1;             /**< [in]: encode frame independently from previously encoded frames */
+
+    uint32_t tileConfigUpdate           : 1;             /**< [in]: Set to 1 if client wants to overwrite the default tile configuration with the tile parameters specified below
+                                                                    When forceIntraRefreshWithFrameCnt is set it will have priority over tileConfigUpdate setting */
+    uint32_t enableCustomTileConfig     : 1;             /**< [in]: Set 1 to enable custom tile configuration: numTileColumns and numTileRows must have non zero values and tileWidths and tileHeights must point to a valid address  */
+    uint32_t filmGrainParamsUpdate      : 1;             /**< [in]: Set to 1 if client wants to update previous film grain parameters: filmGrainParams must point to a valid address and encoder must have been configured with film grain enabled  */
+    uint32_t reservedBitFields          : 22;            /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t numTileColumns;                             /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileWidths[] specifies the way in which the picture is divided into tile columns.
+                                                                    When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileColumns tile columns. If numTileColumns is not a power of 2,
+                                                                    it will be rounded down to the next power of 2 value. If numTileColumns == 0, the picture will be coded with the smallest number of vertical tiles as allowed by standard.
+                                                                    When enableCustomTileConfig == 1, numTileColumns must be > 0 and <= NV_MAX_TILE_COLS_AV1 and tileWidths must point to a valid array of numTileColumns entries.
+                                                                    Entry i specifies the width in 64x64 CTU unit of tile colum i. The sum of all the entries should be equal to the picture width in 64x64 CTU units. */
+    uint32_t numTileRows;                                /**< [in]: This parameter in conjunction with the flag enableCustomTileConfig and the array tileHeights[] specifies the way in which the picture is divided into tiles rows
+                                                                    When enableCustomTileConfig == 0, the picture will be uniformly divided into numTileRows tile rows. If numTileRows is not a power of 2,
+                                                                    it will be rounded down to the next power of 2 value. If numTileRows == 0, the picture will be coded with the smallest number of horizontal tiles as allowed by standard.
+                                                                    When enableCustomTileConfig == 1, numTileRows must be > 0 and <= NV_MAX_TILE_ROWS_AV1 and tileHeights must point to a valid array of numTileRows entries.
+                                                                    Entry i specifies the height in 64x64 CTU unit of tile row i. The sum of all the entries should be equal to the picture hieght in 64x64 CTU units. */
+    uint32_t *tileWidths;                                /**< [in]: If enableCustomTileConfig == 1, tileWidths[i] specifies the width of tile column i in 64x64 CTU unit, with 0 <= i <= numTileColumns -1. */
+    uint32_t *tileHeights;                               /**< [in]: If enableCustomTileConfig == 1, tileHeights[i] specifies the height of tile row i in 64x64 CTU unit, with 0 <= i <= numTileRows -1. */
+    uint32_t obuPayloadArrayCnt;                         /**< [in]: Specifies the number of elements allocated in  obuPayloadArray array. */
+    uint32_t reserved;                                   /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_AV1_OBU_PAYLOAD* obuPayloadArray;             /**< [in]: Array of OBU payloads which will be inserted for this frame. */
+    NV_ENC_FILM_GRAIN_PARAMS_AV1 *filmGrainParams;       /**< [in]: If filmGrainParamsUpdate == 1, filmGrainParams must point to a valid NV_ENC_FILM_GRAIN_PARAMS_AV1 structure */
+    uint32_t reserved2[247];                             /**< [in]: Reserved and must be set to 0. */
+    void*    reserved3[61];                              /**< [in]: Reserved and must be set to NULL. */
+} NV_ENC_PIC_PARAMS_AV1;
 
 /**
  * Codec specific per-picture encoding parameters.
@@ -1881,8 +2243,10 @@ typedef union _NV_ENC_CODEC_PIC_PARAMS
 {
     NV_ENC_PIC_PARAMS_H264 h264PicParams;                /**< [in]: H264 encode picture params. */
     NV_ENC_PIC_PARAMS_HEVC hevcPicParams;                /**< [in]: HEVC encode picture params. */
+    NV_ENC_PIC_PARAMS_AV1  av1PicParams;                 /**< [in]: AV1 encode picture params. */
     uint32_t               reserved[256];                /**< [in]: Reserved and must be set to 0. */
 } NV_ENC_CODEC_PIC_PARAMS;
+
 
 /**
  * \struct _NV_ENC_PIC_PARAMS
@@ -1896,48 +2260,53 @@ typedef struct _NV_ENC_PIC_PARAMS
     uint32_t                                    inputPitch;                     /**< [in]: Specifies the input buffer pitch. If pitch value is not known, set this to inputWidth. */
     uint32_t                                    encodePicFlags;                 /**< [in]: Specifies bit-wise OR of encode picture flags. See ::NV_ENC_PIC_FLAGS enum. */
     uint32_t                                    frameIdx;                       /**< [in]: Specifies the frame index associated with the input frame [optional]. */
-    uint64_t                                    inputTimeStamp;                 /**< [in]: Specifies opaque data which is associated with the encoded frame, but not actually encoded in the output bitstream. 
-                                                                                           This opaque data can be used later to uniquely refer to the corresponding encoded frame. For example, it can be used 
+    uint64_t                                    inputTimeStamp;                 /**< [in]: Specifies opaque data which is associated with the encoded frame, but not actually encoded in the output bitstream.
+                                                                                           This opaque data can be used later to uniquely refer to the corresponding encoded frame. For example, it can be used
                                                                                            for identifying the frame to be invalidated in the reference picture buffer, if lost at the client. */
     uint64_t                                    inputDuration;                  /**< [in]: Specifies duration of the input picture */
     NV_ENC_INPUT_PTR                            inputBuffer;                    /**< [in]: Specifies the input buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.*/
-    NV_ENC_OUTPUT_PTR                           outputBitstream;                /**< [in]: Specifies the output buffer pointer. 
-                                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 0, specifies the pointer to output buffer. Client should use a pointer obtained from ::NvEncCreateBitstreamBuffer() API. 
-                                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 1, client should allocate buffer in video memory for NV_ENC_ENCODE_OUT_PARAMS struct and encoded bitstream data. Client 
-                                                                                           should use a pointer obtained from ::NvEncMapInputResource() API, when mapping this output buffer and assign it to NV_ENC_PIC_PARAMS::outputBitstream. 
-                                                                                           First 256 bytes of this buffer should be interpreted as NV_ENC_ENCODE_OUT_PARAMS struct followed by encoded bitstream data. Recommended size for output buffer is sum of size of 
-                                                                                           NV_ENC_ENCODE_OUT_PARAMS struct and twice the input frame size for lower resolution eg. CIF and 1.5 times the input frame size for higher resolutions. If encoded bitstream size is 
-                                                                                           greater than the allocated buffer size for encoded bitstream, then the output buffer will have encoded bitstream data equal to buffer size. All CUDA operations on this buffer must use 
+    NV_ENC_OUTPUT_PTR                           outputBitstream;                /**< [in]: Specifies the output buffer pointer.
+                                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 0, specifies the pointer to output buffer. Client should use a pointer obtained from ::NvEncCreateBitstreamBuffer() API.
+                                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 1, client should allocate buffer in video memory for NV_ENC_ENCODE_OUT_PARAMS struct and encoded bitstream data. Client
+                                                                                           should use a pointer obtained from ::NvEncMapInputResource() API, when mapping this output buffer and assign it to NV_ENC_PIC_PARAMS::outputBitstream.
+                                                                                           First 256 bytes of this buffer should be interpreted as NV_ENC_ENCODE_OUT_PARAMS struct followed by encoded bitstream data. Recommended size for output buffer is sum of size of
+                                                                                           NV_ENC_ENCODE_OUT_PARAMS struct and twice the input frame size for lower resolution eg. CIF and 1.5 times the input frame size for higher resolutions. If encoded bitstream size is
+                                                                                           greater than the allocated buffer size for encoded bitstream, then the output buffer will have encoded bitstream data equal to buffer size. All CUDA operations on this buffer must use
                                                                                            the default stream. */
     void*                                       completionEvent;                /**< [in]: Specifies an event to be signaled on completion of encoding of this Frame [only if operating in Asynchronous mode]. Each output buffer should be associated with a distinct event pointer. */
     NV_ENC_BUFFER_FORMAT                        bufferFmt;                      /**< [in]: Specifies the input buffer format. */
     NV_ENC_PIC_STRUCT                           pictureStruct;                  /**< [in]: Specifies structure of the input picture. */
     NV_ENC_PIC_TYPE                             pictureType;                    /**< [in]: Specifies input picture type. Client required to be set explicitly by the client if the client has not set NV_ENC_INITALIZE_PARAMS::enablePTD to 1 while calling NvInitializeEncoder. */
     NV_ENC_CODEC_PIC_PARAMS                     codecPicParams;                 /**< [in]: Specifies the codec specific per-picture encoding parameters. */
-    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE meHintCountsPerBlock[2];        /**< [in]: Specifies the number of hint candidates per block per direction for the current frame. meHintCountsPerBlock[0] is for L0 predictors and meHintCountsPerBlock[1] is for L1 predictors.
+    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE meHintCountsPerBlock[2];        /**< [in]: For H264 and Hevc, specifies the number of hint candidates per block per direction for the current frame. meHintCountsPerBlock[0] is for L0 predictors and meHintCountsPerBlock[1] is for L1 predictors.
                                                                                            The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder initialization. */
-    NVENC_EXTERNAL_ME_HINT                     *meExternalHints;                /**< [in]: Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
-                                                                                           The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8  
+    NVENC_EXTERNAL_ME_HINT                     *meExternalHints;                /**< [in]: For H264 and Hevc, Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
+                                                                                           The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8
                                                                                            + 4*meHintCountsPerBlock[Lx].numCandsPerBlk8x8. For frames using bidirectional ME , the total number of candidates for single macroblock is sum of total number of candidates per MB for each direction (L0 and L1) */
     uint32_t                                    reserved1[6];                    /**< [in]: Reserved and must be set to 0 */
     void*                                       reserved2[2];                    /**< [in]: Reserved and must be set to NULL */
-    int8_t                                     *qpDeltaMap;                      /**< [in]: Specifies the pointer to signed byte array containing value per MB for H264 and per CTB for HEVC in raster scan order for the current picture, which will be interpreted depending on NV_ENC_RC_PARAMS::qpMapMode. 
-                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DELTA, qpDeltaMap specifies QP modifier per MB for H264 and per CTB for HEVC. This QP modifier will be applied on top of the QP chosen by rate control.
-                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_EMPHASIS, qpDeltaMap specifies Emphasis Level Map per MB for H264. This level value along with QP chosen by rate control is used to 
+    int8_t                                     *qpDeltaMap;                      /**< [in]: Specifies the pointer to signed byte array containing value per MB for H264, per CTB for HEVC and per SB for AV1 in raster scan order for the current picture, which will be interpreted depending on NV_ENC_RC_PARAMS::qpMapMode.
+                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DELTA, qpDeltaMap specifies QP modifier per MB for H264, per CTB for HEVC and per SB for AV1. This QP modifier will be applied on top of the QP chosen by rate control.
+                                                                                            If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_EMPHASIS, qpDeltaMap specifies Emphasis Level Map per MB for H264. This level value along with QP chosen by rate control is used to
                                                                                             compute the QP modifier, which in turn is applied on top of QP chosen by rate control.
                                                                                             If NV_ENC_RC_PARAMS::qpMapMode is NV_ENC_QP_MAP_DISABLED, value in qpDeltaMap will be ignored.*/
-    uint32_t                                    qpDeltaMapSize;                  /**< [in]: Specifies the size in bytes of qpDeltaMap surface allocated by client and pointed to by NV_ENC_PIC_PARAMS::qpDeltaMap. Surface (array) should be picWidthInMbs * picHeightInMbs for H264 and picWidthInCtbs * picHeightInCtbs for HEVC */
+    uint32_t                                    qpDeltaMapSize;                  /**< [in]: Specifies the size in bytes of qpDeltaMap surface allocated by client and pointed to by NV_ENC_PIC_PARAMS::qpDeltaMap. Surface (array) should be picWidthInMbs * picHeightInMbs for H264, picWidthInCtbs * picHeightInCtbs for HEVC and
+                                                                                            picWidthInSbs * picHeightInSbs for AV1 */
     uint32_t                                    reservedBitFields;               /**< [in]: Reserved bitfields and must be set to 0 */
-    uint16_t                                    meHintRefPicDist[2];             /**< [in]: Specifies temporal distance for reference picture (NVENC_EXTERNAL_ME_HINT::refidx = 0) used during external ME with NV_ENC_INITALIZE_PARAMS::enablePTD = 1 . meHintRefPicDist[0] is for L0 hints and meHintRefPicDist[1] is for L1 hints. 
+    uint16_t                                    meHintRefPicDist[2];             /**< [in]: Specifies temporal distance for reference picture (NVENC_EXTERNAL_ME_HINT::refidx = 0) used during external ME with NV_ENC_INITALIZE_PARAMS::enablePTD = 1 . meHintRefPicDist[0] is for L0 hints and meHintRefPicDist[1] is for L1 hints.
                                                                                             If not set, will internally infer distance of 1. Ignored for NV_ENC_INITALIZE_PARAMS::enablePTD = 0 */
     NV_ENC_INPUT_PTR                            alphaBuffer;                     /**< [in]: Specifies the input alpha buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.
                                                                                             Applicable only when encoding hevc with alpha layer is enabled. */
-    uint32_t                                    reserved3[286];                  /**< [in]: Reserved and must be set to 0 */
-    void*                                       reserved4[59];                   /**< [in]: Reserved and must be set to NULL */
+    NVENC_EXTERNAL_ME_SB_HINT                  *meExternalSbHints;               /**< [in]: For AV1,Specifies the pointer to ME external SB hints for the current frame. The size of ME hint buffer should be equal to meSbHintsCount. */
+    uint32_t                                    meSbHintsCount;                  /**< [in]: For AV1, specifies the total number of external ME SB hint candidates for the frame
+                                                                                            NV_ENC_PIC_PARAMS::meSbHintsCount must never exceed the total number of SBs in frame * the max number of candidates per SB provided during encoder initialization.
+                                                                                            The max number of candidates per SB is maxMeHintCountsPerBlock[0].numCandsPerSb + maxMeHintCountsPerBlock[1].numCandsPerSb */
+    uint32_t                                    reserved3[285];                  /**< [in]: Reserved and must be set to 0 */
+    void*                                       reserved4[58];                   /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_PIC_PARAMS;
 
 /** Macro for constructing the version field of ::_NV_ENC_PIC_PARAMS */
-#define NV_ENC_PIC_PARAMS_VER (NVENCAPI_STRUCT_VERSION(4) | ( 1<<31 ))
+#define NV_ENC_PIC_PARAMS_VER (NVENCAPI_STRUCT_VERSION(6) | ( 1<<31 ))
 
 
 /**
@@ -1953,22 +2322,22 @@ typedef struct _NV_ENC_MEONLY_PARAMS
     NV_ENC_INPUT_PTR        inputBuffer;                        /**< [in]: Specifies the input buffer pointer. Client must use a pointer obtained from NvEncCreateInputBuffer() or NvEncMapInputResource() APIs. */
     NV_ENC_INPUT_PTR        referenceFrame;                     /**< [in]: Specifies the reference frame pointer */
     NV_ENC_OUTPUT_PTR       mvBuffer;                           /**< [in]: Specifies the output buffer pointer.
-                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 0, specifies the pointer to motion vector data buffer allocated by NvEncCreateMVBuffer. 
-                                                                           Client must lock mvBuffer using ::NvEncLockBitstream() API to get the motion vector data. 
-                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 1, client should allocate buffer in video memory for storing the motion vector data. The size of this buffer must 
-                                                                           be equal to total number of macroblocks multiplied by size of NV_ENC_H264_MV_DATA struct. Client should use a pointer obtained from ::NvEncMapInputResource() API, when mapping this 
+                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 0, specifies the pointer to motion vector data buffer allocated by NvEncCreateMVBuffer.
+                                                                           Client must lock mvBuffer using ::NvEncLockBitstream() API to get the motion vector data.
+                                                                           If NV_ENC_INITIALIZE_PARAMS::enableOutputInVidmem is set to 1, client should allocate buffer in video memory for storing the motion vector data. The size of this buffer must
+                                                                           be equal to total number of macroblocks multiplied by size of NV_ENC_H264_MV_DATA struct. Client should use a pointer obtained from ::NvEncMapInputResource() API, when mapping this
                                                                            output buffer and assign it to NV_ENC_MEONLY_PARAMS::mvBuffer. All CUDA operations on this buffer must use the default stream. */
     NV_ENC_BUFFER_FORMAT    bufferFmt;                          /**< [in]: Specifies the input buffer format. */
-    void*                   completionEvent;                    /**< [in]: Specifies an event to be signaled on completion of motion estimation 
-                                                                           of this Frame [only if operating in Asynchronous mode]. 
+    void*                   completionEvent;                    /**< [in]: Specifies an event to be signaled on completion of motion estimation
+                                                                           of this Frame [only if operating in Asynchronous mode].
                                                                            Each output buffer should be associated with a distinct event pointer. */
     uint32_t                viewID;                             /**< [in]: Specifies left or right viewID if NV_ENC_CONFIG_H264_MEONLY::bStereoEnable is set.
                                                                             viewID can be 0,1 if bStereoEnable is set, 0 otherwise. */
-    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE 
+    NVENC_EXTERNAL_ME_HINT_COUNTS_PER_BLOCKTYPE
                             meHintCountsPerBlock[2];            /**< [in]: Specifies the number of hint candidates per block for the current frame. meHintCountsPerBlock[0] is for L0 predictors.
                                                                             The candidate count in NV_ENC_PIC_PARAMS::meHintCountsPerBlock[lx] must never exceed NV_ENC_INITIALIZE_PARAMS::maxMEHintCountsPerBlock[lx] provided during encoder initialization. */
     NVENC_EXTERNAL_ME_HINT  *meExternalHints;                   /**< [in]: Specifies the pointer to ME external hints for the current frame. The size of ME hint buffer should be equal to number of macroblocks * the total number of candidates per macroblock.
-                                                                            The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8  
+                                                                            The total number of candidates per MB per direction = 1*meHintCountsPerBlock[Lx].numCandsPerBlk16x16 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk16x8 + 2*meHintCountsPerBlock[Lx].numCandsPerBlk8x8
                                                                             + 4*meHintCountsPerBlock[Lx].numCandsPerBlk8x8. For frames using bidirectional ME , the total number of candidates for single macroblock is sum of total number of candidates per MB for each direction (L0 and L1) */
     uint32_t                reserved1[243];                     /**< [in]: Reserved and must be set to 0 */
     void*                   reserved2[59];                      /**< [in]: Reserved and must be set to NULL */
@@ -1983,22 +2352,23 @@ typedef struct _NV_ENC_MEONLY_PARAMS
  * Bitstream buffer lock parameters.
  */
 typedef struct _NV_ENC_LOCK_BITSTREAM
-{ 
+{
     uint32_t                version;                     /**< [in]: Struct version. Must be set to ::NV_ENC_LOCK_BITSTREAM_VER. */
     uint32_t                doNotWait         :1;        /**< [in]: If this flag is set, the NvEncodeAPI interface will return buffer pointer even if operation is not completed. If not set, the call will block until operation completes. */
     uint32_t                ltrFrame          :1;        /**< [out]: Flag indicating this frame is marked as LTR frame */
     uint32_t                getRCStats        :1;        /**< [in]: If this flag is set then lockBitstream call will add additional intra-inter MB count and average MVX, MVY */
     uint32_t                reservedBitFields :29;       /**< [in]: Reserved bit fields and must be set to 0 */
     void*                   outputBitstream;             /**< [in]: Pointer to the bitstream buffer being locked. */
-    uint32_t*               sliceOffsets;                /**< [in, out]: Array which receives the slice offsets. This is not supported if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs. Array size must be equal to size of frame in MBs. */
-    uint32_t                frameIdx;                    /**< [out]: Frame no. for which the bitstream is being retrieved. */ 
+    uint32_t*               sliceOffsets;                /**< [in, out]: Array which receives the slice (H264/HEVC) or tile (AV1) offsets. This is not supported if NV_ENC_CONFIG_H264::sliceMode is 1 on Kepler GPUs. Array size must be equal to size of frame in MBs. */
+    uint32_t                frameIdx;                    /**< [out]: Frame no. for which the bitstream is being retrieved. */
     uint32_t                hwEncodeStatus;              /**< [out]: The NvEncodeAPI interface status for the locked picture. */
-    uint32_t                numSlices;                   /**< [out]: Number of slices in the encoded picture. Will be reported only if NV_ENC_INITIALIZE_PARAMS::reportSliceOffsets set to 1. */
-    uint32_t                bitstreamSizeInBytes;        /**< [out]: Actual number of bytes generated and copied to the memory pointed by bitstreamBufferPtr. 
-                                                                     When HEVC alpha layer encoding is enabled, this field reports the total encoded size in bytes i.e it is the encoded size of the base plus the alpha layer. */
+    uint32_t                numSlices;                   /**< [out]: Number of slices (H264/HEVC) or tiles (AV1) in the encoded picture. Will be reported only if NV_ENC_INITIALIZE_PARAMS::reportSliceOffsets set to 1. */
+    uint32_t                bitstreamSizeInBytes;        /**< [out]: Actual number of bytes generated and copied to the memory pointed by bitstreamBufferPtr.
+                                                                     When HEVC alpha layer encoding is enabled, this field reports the total encoded size in bytes i.e it is the encoded size of the base plus the alpha layer.
+                                                                     For AV1 when enablePTD is set, this field reports the total encoded size in bytes of all the encoded frames packed into the current output surface i.e. show frame plus all preceding no-show frames */
     uint64_t                outputTimeStamp;             /**< [out]: Presentation timestamp associated with the encoded output. */
     uint64_t                outputDuration;              /**< [out]: Presentation duration associates with the encoded output. */
-    void*                   bitstreamBufferPtr;          /**< [out]: Pointer to the generated output bitstream. 
+    void*                   bitstreamBufferPtr;          /**< [out]: Pointer to the generated output bitstream.
                                                                      For MEOnly mode _NV_ENC_LOCK_BITSTREAM::bitstreamBufferPtr should be typecast to
                                                                      NV_ENC_H264_MV_DATA/NV_ENC_HEVC_MV_DATA pointer respectively for H264/HEVC  */
     NV_ENC_PIC_TYPE         pictureType;                 /**< [out]: Picture type of the encoded picture. */
@@ -2007,19 +2377,20 @@ typedef struct _NV_ENC_LOCK_BITSTREAM
     uint32_t                frameSatd;                   /**< [out]: Total SATD cost for whole frame. */
     uint32_t                ltrFrameIdx;                 /**< [out]: Frame index associated with this LTR frame. */
     uint32_t                ltrFrameBitmap;              /**< [out]: Bitmap of LTR frames indices which were used for encoding this frame. Value of 0 if no LTR frames were used. */
-    uint32_t                reserved[13];                /**< [in]: Reserved and must be set to 0 */
-    uint32_t                intraMBCount;                /**< [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
-    uint32_t                interMBCount;                /**< [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
+    uint32_t                temporalId;                  /**< [out]: TemporalId value of the frame when using temporalSVC encoding */
+    uint32_t                reserved[12];                /**< [in]: Reserved and must be set to 0 */
+    uint32_t                intraMBCount;                /**< [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. For AV1, Number of Intra SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
+    uint32_t                interMBCount;                /**< [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. For AV1, Number of Inter SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     int32_t                 averageMVX;                  /**< [out]: Average Motion Vector in X direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     int32_t                 averageMVY;                  /**< [out]: Average Motion Vector in y direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
-    uint32_t                alphaLayerSizeInBytes;       /**< [out]: Number of bytes generated for the alpha layer in the encoded output. Applicable only when HEVC with alpha encoding is enabled. */ 
+    uint32_t                alphaLayerSizeInBytes;       /**< [out]: Number of bytes generated for the alpha layer in the encoded output. Applicable only when HEVC with alpha encoding is enabled. */
 
     uint32_t                reserved1[218];              /**< [in]: Reserved and must be set to 0 */
     void*                   reserved2[64];               /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_LOCK_BITSTREAM;
 
 /** Macro for constructing the version field of ::_NV_ENC_LOCK_BITSTREAM */
-#define NV_ENC_LOCK_BITSTREAM_VER NVENCAPI_STRUCT_VERSION(1)
+#define NV_ENC_LOCK_BITSTREAM_VER NVENCAPI_STRUCT_VERSION(2)
 
 
 /**
@@ -2072,6 +2443,60 @@ typedef struct _NV_ENC_INPUT_RESOURCE_OPENGL_TEX
     uint32_t target;                                      /**< [in]: Accepted values are GL_TEXTURE_RECTANGLE and GL_TEXTURE_2D. */
 } NV_ENC_INPUT_RESOURCE_OPENGL_TEX;
 
+/** \struct NV_ENC_FENCE_POINT_D3D12
+* Fence and fence value for synchronization.
+*/
+typedef struct _NV_ENC_FENCE_POINT_D3D12
+{
+    uint32_t                version;                   /**< [in]: Struct version. Must be set to ::NV_ENC_FENCE_POINT_D3D12_VER. */
+    uint32_t                reserved;                  /**< [in]: Reserved and must be set to 0. */
+    void*                   pFence;                    /**< [in]: Pointer to ID3D12Fence. This fence object is used for synchronization. */
+    uint64_t                waitValue;                 /**< [in]: Fence value to reach or exceed before the GPU operation. */
+    uint64_t                signalValue;               /**< [in]: Fence value to set the fence to, after the GPU operation. */
+    uint32_t                bWait:1;                   /**< [in]: Wait on 'waitValue' if bWait is set to 1, before starting GPU operation. */
+    uint32_t                bSignal:1;                 /**< [in]: Signal on 'signalValue' if bSignal is set to 1, after GPU operation is complete. */
+    uint32_t                reservedBitField:30;       /**< [in]: Reserved and must be set to 0. */
+    uint32_t                reserved1[7];              /**< [in]: Reserved and must be set to 0. */
+} NV_ENC_FENCE_POINT_D3D12;
+
+#define NV_ENC_FENCE_POINT_D3D12_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * \struct _NV_ENC_INPUT_RESOURCE_D3D12
+ * NV_ENC_PIC_PARAMS::inputBuffer and NV_ENC_PIC_PARAMS::alphaBuffer must be a pointer to a struct of this type,
+ * when D3D12 interface is used
+ */
+typedef struct _NV_ENC_INPUT_RESOURCE_D3D12
+{
+    uint32_t                    version;                /**< [in]: Struct version. Must be set to ::NV_ENC_INPUT_RESOURCE_D3D12_VER. */
+    uint32_t                    reserved;               /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_INPUT_PTR            pInputBuffer;           /**< [in]: Specifies the input surface pointer. Client must use a pointer obtained from NvEncMapInputResource() in NV_ENC_MAP_INPUT_RESOURCE::mappedResource
+                                                                   when mapping the input surface. */
+    NV_ENC_FENCE_POINT_D3D12    inputFencePoint;        /**< [in]: Specifies the fence and corresponding fence values to do GPU wait and signal. */
+    uint32_t                    reserved1[16];          /**< [in]: Reserved and must be set to 0. */
+    void*                       reserved2[16];          /**< [in]: Reserved and must be set to NULL. */
+} NV_ENC_INPUT_RESOURCE_D3D12;
+
+#define NV_ENC_INPUT_RESOURCE_D3D12_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * \struct _NV_ENC_OUTPUT_RESOURCE_D3D12
+ * NV_ENC_PIC_PARAMS::outputBitstream and NV_ENC_LOCK_BITSTREAM::outputBitstream must be a pointer to a struct of this type,
+ * when D3D12 interface is used
+ */
+typedef struct _NV_ENC_OUTPUT_RESOURCE_D3D12
+{
+    uint32_t                    version;                /**< [in]: Struct version. Must be set to ::NV_ENC_OUTPUT_RESOURCE_D3D12_VER. */
+    uint32_t                    reserved;               /**< [in]: Reserved and must be set to 0. */
+    NV_ENC_INPUT_PTR            pOutputBuffer;          /**< [in]: Specifies the output buffer pointer. Client must use a pointer obtained from NvEncMapInputResource() in NV_ENC_MAP_INPUT_RESOURCE::mappedResource
+                                                                   when mapping output bitstream buffer */
+    NV_ENC_FENCE_POINT_D3D12    outputFencePoint;       /**< [in]: Specifies the fence and corresponding fence values to do GPU wait and signal.*/
+    uint32_t                    reserved1[16];          /**< [in]: Reserved and must be set to 0. */
+    void*                       reserved2[16];          /**< [in]: Reserved and must be set to NULL. */
+} NV_ENC_OUTPUT_RESOURCE_D3D12;
+
+#define NV_ENC_OUTPUT_RESOURCE_D3D12_VER NVENCAPI_STRUCT_VERSION(1)
+
 /**
  * \struct _NV_ENC_REGISTER_RESOURCE
  * Register a resource for future use with the Nvidia Video Encoder Interface.
@@ -2103,12 +2528,19 @@ typedef struct _NV_ENC_REGISTER_RESOURCE
     NV_ENC_REGISTERED_PTR       registeredResource;             /**< [out]: Registered resource handle. This should be used in future interactions with the Nvidia Video Encoder Interface. */
     NV_ENC_BUFFER_FORMAT        bufferFormat;                   /**< [in]: Buffer format of resource to be registered. */
     NV_ENC_BUFFER_USAGE         bufferUsage;                    /**< [in]: Usage of resource to be registered. */
+    NV_ENC_FENCE_POINT_D3D12*   pInputFencePoint;               /**< [in]: Specifies the input fence and corresponding fence values to do GPU wait and signal.
+                                                                           To be used only when NV_ENC_REGISTER_RESOURCE::resourceToRegister represents D3D12 surface and
+                                                                           NV_ENC_BUFFER_USAGE::bufferUsage is NV_ENC_INPUT_IMAGE.
+                                                                           The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::waitValue will be used to do GPU wait
+                                                                           before starting GPU operation, if NV_ENC_FENCE_POINT_D3D12::bWait is set.
+                                                                           The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::signalValue will be used to do GPU signal
+                                                                           when GPU operation finishes, if NV_ENC_FENCE_POINT_D3D12::bSignal is set. */
     uint32_t                    reserved1[247];                 /**< [in]: Reserved and must be set to 0. */
-    void*                       reserved2[62];                  /**< [in]: Reserved and must be set to NULL. */
+    void*                       reserved2[61];                  /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_REGISTER_RESOURCE;
 
 /** Macro for constructing the version field of ::_NV_ENC_REGISTER_RESOURCE */
-#define NV_ENC_REGISTER_RESOURCE_VER NVENCAPI_STRUCT_VERSION(3)
+#define NV_ENC_REGISTER_RESOURCE_VER NVENCAPI_STRUCT_VERSION(4)
 
 /**
  * \struct _NV_ENC_STAT
@@ -2150,7 +2582,7 @@ typedef struct _NV_ENC_SEQUENCE_PARAM_PAYLOAD
     uint32_t            inBufferSize;                    /**< [in]:  Specifies the size of the spsppsBuffer provided by the client */
     uint32_t            spsId;                           /**< [in]:  Specifies the SPS id to be used in sequence header. Default value is 0.  */
     uint32_t            ppsId;                           /**< [in]:  Specifies the PPS id to be used in picture header. Default value is 0.  */
-    void*               spsppsBuffer;                    /**< [in]:  Specifies bitstream header pointer of size NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize. 
+    void*               spsppsBuffer;                    /**< [in]:  Specifies bitstream header pointer of size NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize.
                                                                      It is the client's responsibility to manage this memory. */
     uint32_t*           outSPSPPSPayloadSize;            /**< [out]: Size of the sequence and picture header in bytes. */
     uint32_t            reserved [250];                  /**< [in]:  Reserved and must be set to 0 */
@@ -2203,7 +2635,7 @@ typedef struct _NV_ENC_OPEN_ENCODE_SESSIONEX_PARAMS
 // NvEncOpenEncodeSession
 /**
  * \brief Opens an encoding session.
- * 
+ *
  * Deprecated.
  *
  * \return
@@ -2218,10 +2650,10 @@ NVENCSTATUS NVENCAPI NvEncOpenEncodeSession                     (void* device, u
  *
  * The function returns the number of codec GUIDs supported by the NvEncodeAPI
  * interface.
- *  
- * \param [in] encoder  
+ *
+ * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
- * \param [out] encodeGUIDCount 
+ * \param [out] encodeGUIDCount
  *   Number of supported encode GUIDs.
  *
  * \return
@@ -2277,15 +2709,15 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeGUIDs                        (void* encoder, 
 /**
  * \brief Retrieves the number of supported profile GUIDs.
  *
- * The function returns the number of profile GUIDs supported for a given codec. 
- * The client must first enumerate the codec GUIDs supported by the NvEncodeAPI 
+ * The function returns the number of profile GUIDs supported for a given codec.
+ * The client must first enumerate the codec GUIDs supported by the NvEncodeAPI
  * interface. After determining the codec GUID, it can query the NvEncodeAPI
  * interface to determine the number of profile GUIDs supported for a particular
  * codec GUID.
  *
- * \param [in] encoder  
+ * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
- * \param [in] encodeGUID 
+ * \param [in] encodeGUID
  *   The codec GUID for which the profile GUIDs are being enumerated.
  * \param [out] encodeProfileGUIDCount
  *   Number of encode profiles supported for the given encodeGUID.
@@ -2310,7 +2742,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDCount                    (void* en
  *
  * The function returns an array of supported profile GUIDs for a particular
  * codec GUID. The client must allocate an array where the NvEncodeAPI interface
- * can populate the profile GUIDs. The client can determine the array size using 
+ * can populate the profile GUIDs. The client can determine the array size using
  * ::NvEncGetEncodeProfileGUIDCount() API. The client must also validiate that the
  * NvEncodeAPI interface supports the GUID the client wants to pass as \p encodeGUID
  * parameter.
@@ -2320,7 +2752,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDCount                    (void* en
  * \param [in] encodeGUID
  *   The encode GUID whose profile GUIDs are being enumerated.
  * \param [in] guidArraySize
- *   Number of GUIDs to be retrieved. Should be set to the number retrieved using 
+ *   Number of GUIDs to be retrieved. Should be set to the number retrieved using
  *   ::NvEncGetEncodeProfileGUIDCount.
  * \param [out] profileGUIDs
  *   Array of supported Encode Profile GUIDs
@@ -2351,7 +2783,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeProfileGUIDs                               (v
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
- *   Encode GUID, corresponding to which the number of supported input formats 
+ *   Encode GUID, corresponding to which the number of supported input formats
  *   is to be retrieved.
  * \param [out] inputFmtCount
  *   Number of input formats supported for specified Encode GUID.
@@ -2373,13 +2805,13 @@ NVENCSTATUS NVENCAPI NvEncGetInputFormatCount                   (void* encoder, 
 /**
  * \brief Retrieves an array of supported Input formats
  *
- * Returns an array of supported input formats  The client must use the input 
+ * Returns an array of supported input formats  The client must use the input
  * format to create input surface using ::NvEncCreateInputBuffer() API.
- * 
- * \param [in] encoder 
+ *
+ * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
- *   Encode GUID, corresponding to which the number of supported input formats 
+ *   Encode GUID, corresponding to which the number of supported input formats
  *   is to be retrieved.
  *\param [in] inputFmtArraySize
  *   Size input format count array passed in \p inputFmts.
@@ -2407,9 +2839,9 @@ NVENCSTATUS NVENCAPI NvEncGetInputFormats                       (void* encoder, 
 /**
  * \brief Retrieves the capability value for a specified encoder attribute.
  *
- * The function returns the capability value for a given encoder attribute. The 
- * client must validate the encodeGUID using ::NvEncGetEncodeGUIDs() API before 
- * calling this function. The encoder attribute being queried are enumerated in 
+ * The function returns the capability value for a given encoder attribute. The
+ * client must validate the encodeGUID using ::NvEncGetEncodeGUIDs() API before
+ * calling this function. The encoder attribute being queried are enumerated in
  * ::NV_ENC_CAPS_PARAM enum.
  *
  * \param [in] encoder
@@ -2417,7 +2849,7 @@ NVENCSTATUS NVENCAPI NvEncGetInputFormats                       (void* encoder, 
  * \param [in] encodeGUID
  *   Encode GUID, corresponding to which the capability attribute is to be retrieved.
  * \param [in] capsParam
- *   Used to specify attribute being queried. Refer ::NV_ENC_CAPS_PARAM for  more 
+ *   Used to specify attribute being queried. Refer ::NV_ENC_CAPS_PARAM for  more
  * details.
  * \param [out] capsVal
  *   The value corresponding to the capability attribute being queried.
@@ -2439,14 +2871,14 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeCaps                     (void* encoder, GUID
 /**
  * \brief Retrieves the number of supported preset GUIDs.
  *
- * The function returns the number of preset GUIDs available for a given codec. 
- * The client must validate the codec GUID using ::NvEncGetEncodeGUIDs() API 
+ * The function returns the number of preset GUIDs available for a given codec.
+ * The client must validate the codec GUID using ::NvEncGetEncodeGUIDs() API
  * before calling this function.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
- *   Encode GUID, corresponding to which the number of supported presets is to 
+ *   Encode GUID, corresponding to which the number of supported presets is to
  *   be retrieved.
  * \param [out] encodePresetGUIDCount
  *   Receives the number of supported preset GUIDs.
@@ -2469,19 +2901,19 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetCount              (void* encoder, GUID
 /**
  * \brief Receives an array of supported encoder preset GUIDs.
  *
- * The function returns an array of encode preset GUIDs available for a given codec. 
+ * The function returns an array of encode preset GUIDs available for a given codec.
  * The client can directly use one of the preset GUIDs based upon the use case
- * or target device. The preset GUID chosen can be directly used in 
- * NV_ENC_INITIALIZE_PARAMS::presetGUID parameter to ::NvEncEncodePicture() API. 
- * Alternately client can  also use the preset GUID to retrieve the encoding config 
+ * or target device. The preset GUID chosen can be directly used in
+ * NV_ENC_INITIALIZE_PARAMS::presetGUID parameter to ::NvEncEncodePicture() API.
+ * Alternately client can  also use the preset GUID to retrieve the encoding config
  * parameters being used by NvEncodeAPI interface for that given preset, using
  * ::NvEncGetEncodePresetConfig() API. It can then modify preset config parameters
- * as per its use case and send it to NvEncodeAPI interface as part of 
+ * as per its use case and send it to NvEncodeAPI interface as part of
  * NV_ENC_INITIALIZE_PARAMS::encodeConfig parameter for NvEncInitializeEncoder()
  * API.
  *
  *
- * \param [in] encoder 
+ * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
  *   Encode GUID, corresponding to which the list of supported presets is to be
@@ -2489,10 +2921,10 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetCount              (void* encoder, GUID
  * \param [in] guidArraySize
  *   Size of array of preset GUIDs passed in \p preset GUIDs
  * \param [out] presetGUIDs
- *   Array of supported Encode preset GUIDs from the NvEncodeAPI interface 
+ *   Array of supported Encode preset GUIDs from the NvEncodeAPI interface
  *   to client.
  * \param [out] encodePresetGUIDCount
- *   Receives the number of preset GUIDs returned by the NvEncodeAPI 
+ *   Receives the number of preset GUIDs returned by the NvEncodeAPI
  *   interface.
  *
  * \return
@@ -2513,21 +2945,22 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetGUIDs                  (void* encoder, 
 /**
  * \brief Returns a preset config structure supported for given preset GUID.
  *
- * The function returns a preset config structure for a given preset GUID. Before  
- * using this function the client must enumerate the preset GUIDs available for 
+ * The function returns a preset config structure for a given preset GUID.
+ * NvEncGetEncodePresetConfig() API is not applicable to AV1.
+ * Before using this function the client must enumerate the preset GUIDs available for
  * a given codec. The preset config structure can be modified by the client depending
- * upon its use case and can be then used to initialize the encoder using 
- * ::NvEncInitializeEncoder() API. The client can use this function only if it 
- * wants to modify the NvEncodeAPI preset configuration, otherwise it can 
+ * upon its use case and can be then used to initialize the encoder using
+ * ::NvEncInitializeEncoder() API. The client can use this function only if it
+ * wants to modify the NvEncodeAPI preset configuration, otherwise it can
  * directly use the preset GUID.
- * 
+ *
  * \param [in] encoder
- *   Pointer to the NvEncodeAPI interface. 
+ *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
  *   Encode GUID, corresponding to which the list of supported presets is to be
  *   retrieved.
  * \param [in] presetGUID
- *   Preset GUID, corresponding to which the Encoding configurations is to be 
+ *   Preset GUID, corresponding to which the Encoding configurations is to be
  *   retrieved.
  * \param [out] presetConfig
  *   The requested Preset Encoder Attribute set. Refer ::_NV_ENC_CONFIG for
@@ -2551,25 +2984,25 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfig               (void* encoder, GU
 /**
  * \brief Returns a preset config structure supported for given preset GUID.
  *
- * The function returns a preset config structure for a given preset GUID and tuning info. 
+ * The function returns a preset config structure for a given preset GUID and tuning info.
  * NvEncGetEncodePresetConfigEx() API is not applicable to H264 and HEVC meonly mode.
- * Before using this function the client must enumerate the preset GUIDs available for 
+ * Before using this function the client must enumerate the preset GUIDs available for
  * a given codec. The preset config structure can be modified by the client depending
- * upon its use case and can be then used to initialize the encoder using 
- * ::NvEncInitializeEncoder() API. The client can use this function only if it 
- * wants to modify the NvEncodeAPI preset configuration, otherwise it can 
+ * upon its use case and can be then used to initialize the encoder using
+ * ::NvEncInitializeEncoder() API. The client can use this function only if it
+ * wants to modify the NvEncodeAPI preset configuration, otherwise it can
  * directly use the preset GUID.
- * 
+ *
  * \param [in] encoder
- *   Pointer to the NvEncodeAPI interface. 
+ *   Pointer to the NvEncodeAPI interface.
  * \param [in] encodeGUID
  *   Encode GUID, corresponding to which the list of supported presets is to be
  *   retrieved.
  * \param [in] presetGUID
- *   Preset GUID, corresponding to which the Encoding configurations is to be 
+ *   Preset GUID, corresponding to which the Encoding configurations is to be
  *   retrieved.
  * \param [in] tuningInfo
- *   tuning info, corresponding to which the Encoding configurations is to be 
+ *   tuning info, corresponding to which the Encoding configurations is to be
  *   retrieved.
  * \param [out] presetConfig
  *   The requested Preset Encoder Attribute set. Refer ::_NV_ENC_CONFIG for
@@ -2599,11 +3032,11 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfigEx               (void* encoder, 
  * - NV_ENC_INITIALIZE_PARAMS::encodeGUID
  * - NV_ENC_INITIALIZE_PARAMS::encodeWidth
  * - NV_ENC_INITIALIZE_PARAMS::encodeHeight
- * 
+ *
  * The client can pass a preset GUID directly to the NvEncodeAPI interface using
- * NV_ENC_INITIALIZE_PARAMS::presetGUID field. If the client doesn't pass 
+ * NV_ENC_INITIALIZE_PARAMS::presetGUID field. If the client doesn't pass
  * NV_ENC_INITIALIZE_PARAMS::encodeConfig structure, the codec specific parameters
- * will be selected based on the preset GUID. The preset GUID must have been 
+ * will be selected based on the preset GUID. The preset GUID must have been
  * validated by the client using ::NvEncGetEncodePresetGUIDs() API.
  * If the client passes a custom ::_NV_ENC_CONFIG structure through
  * NV_ENC_INITIALIZE_PARAMS::encodeConfig , it will override the codec specific parameters
@@ -2637,7 +3070,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfigEx               (void* encoder, 
  * The client working in synchronous mode can work in a single threaded or multi
  * threaded mode. The client need not allocate any event objects. The client can
  * only lock the bitstream data after NvEncodeAPI interface has returned
- * ::NV_ENC_SUCCESS from encode picture. The NvEncodeAPI interface can return 
+ * ::NV_ENC_SUCCESS from encode picture. The NvEncodeAPI interface can return
  * ::NV_ENC_ERR_NEED_MORE_INPUT error code from ::NvEncEncodePicture() API. The
  * client must not lock the output buffer in such case but should send the next
  * frame for encoding. The client must keep on calling ::NvEncEncodePicture() API
@@ -2648,16 +3081,16 @@ NVENCSTATUS NVENCAPI NvEncGetEncodePresetConfigEx               (void* encoder, 
  *\par Picture type decision:
  * If the client is taking the picture type decision and it must disable the picture
  * type decision module in NvEncodeAPI by setting NV_ENC_INITIALIZE_PARAMS::enablePTD
- * to 0. In this case the client is  required to send the picture in encoding 
+ * to 0. In this case the client is  required to send the picture in encoding
  * order to NvEncodeAPI by doing the re-ordering for B frames. \n
- * If the client doesn't want to take the picture type decision it can enable 
- * picture type decision module in the NvEncodeAPI interface by setting 
- * NV_ENC_INITIALIZE_PARAMS::enablePTD to 1 and send the input pictures in display 
+ * If the client doesn't want to take the picture type decision it can enable
+ * picture type decision module in the NvEncodeAPI interface by setting
+ * NV_ENC_INITIALIZE_PARAMS::enablePTD to 1 and send the input pictures in display
  * order.
- * 
+ *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
- * \param [in] createEncodeParams 
+ * \param [in] createEncodeParams
  *   Refer ::_NV_ENC_INITIALIZE_PARAMS for details.
  *
  * \return
@@ -2680,10 +3113,10 @@ NVENCSTATUS NVENCAPI NvEncInitializeEncoder                     (void* encoder, 
  * \brief Allocates Input buffer.
  *
  * This function is used to allocate an input buffer. The client must enumerate
- * the input buffer format before allocating the input buffer resources. The 
- * NV_ENC_INPUT_PTR returned by the NvEncodeAPI interface in the 
+ * the input buffer format before allocating the input buffer resources. The
+ * NV_ENC_INPUT_PTR returned by the NvEncodeAPI interface in the
  * NV_ENC_CREATE_INPUT_BUFFER::inputBuffer field can be directly used in
- * ::NvEncEncodePicture() API. The number of input buffers to be allocated by the 
+ * ::NvEncEncodePicture() API. The number of input buffers to be allocated by the
  * client must be at least 4 more than the number of B frames being used for encoding.
  *
  * \param [in] encoder
@@ -2701,7 +3134,7 @@ NVENCSTATUS NVENCAPI NvEncInitializeEncoder                     (void* encoder, 
  * ::NV_ENC_ERR_INVALID_PARAM \n
  * ::NV_ENC_ERR_INVALID_VERSION \n
  * ::NV_ENC_ERR_GENERIC \n
- * 
+ *
  */
 NVENCSTATUS NVENCAPI NvEncCreateInputBuffer                     (void* encoder, NV_ENC_CREATE_INPUT_BUFFER* createInputBufferParams);
 
@@ -2717,7 +3150,7 @@ NVENCSTATUS NVENCAPI NvEncCreateInputBuffer                     (void* encoder, 
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
- * \param [in] inputBuffer 
+ * \param [in] inputBuffer
  *   Pointer to the input buffer to be released.
  *
  * \return
@@ -2739,18 +3172,18 @@ NVENCSTATUS NVENCAPI NvEncDestroyInputBuffer                    (void* encoder, 
  * \brief Set input and output CUDA stream for specified encoder attribute.
  *
  * Encoding may involve CUDA pre-processing on the input and post-processing on encoded output.
- * This function is used to set input and output CUDA streams to pipeline the CUDA pre-processing 
- * and post-processing tasks. Clients should call this function before the call to 
- * NvEncUnlockInputBuffer(). If this function is not called, the default CUDA stream is used for 
- * input and output processing. After a successful call to this function, the streams specified 
- * in that call will replace the previously-used streams. 
+ * This function is used to set input and output CUDA streams to pipeline the CUDA pre-processing
+ * and post-processing tasks. Clients should call this function before the call to
+ * NvEncUnlockInputBuffer(). If this function is not called, the default CUDA stream is used for
+ * input and output processing. After a successful call to this function, the streams specified
+ * in that call will replace the previously-used streams.
  * This API is supported for NVCUVID interface only.
  *
- * \param [in] encoder 
+ * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
  * \param [in] inputStream
  *   Pointer to CUstream which is used to process ::NV_ENC_PIC_PARAMS::inputFrame for encode.
- *   In case of ME-only mode, inputStream is used to process ::NV_ENC_MEONLY_PARAMS::inputBuffer and 
+ *   In case of ME-only mode, inputStream is used to process ::NV_ENC_MEONLY_PARAMS::inputBuffer and
  *   ::NV_ENC_MEONLY_PARAMS::referenceFrame
  * \param [in] outputStream
  *  Pointer to CUstream which is used to process ::NV_ENC_PIC_PARAMS::outputBuffer for encode.
@@ -2772,15 +3205,15 @@ NVENCSTATUS NVENCAPI NvEncSetIOCudaStreams                     (void* encoder, N
 
 // NvEncCreateBitstreamBuffer
 /**
- * \brief Allocates an output bitstream buffer 
+ * \brief Allocates an output bitstream buffer
  *
- * This function is used to allocate an output bitstream buffer and returns a 
- * NV_ENC_OUTPUT_PTR to bitstream  buffer to the client in the 
+ * This function is used to allocate an output bitstream buffer and returns a
+ * NV_ENC_OUTPUT_PTR to bitstream  buffer to the client in the
  * NV_ENC_CREATE_BITSTREAM_BUFFER::bitstreamBuffer field.
- * The client can only call this function after the encoder session has been 
- * initialized using ::NvEncInitializeEncoder() API. The minimum number of output 
+ * The client can only call this function after the encoder session has been
+ * initialized using ::NvEncInitializeEncoder() API. The minimum number of output
  * buffers allocated by the client must be at least 4 more than the number of B
- * B frames being used for encoding. The client can only access the output 
+ * B frames being used for encoding. The client can only access the output
  * bitstream data by locking the \p bitstreamBuffer using the ::NvEncLockBitstream()
  * function.
  *
@@ -2807,7 +3240,7 @@ NVENCSTATUS NVENCAPI NvEncCreateBitstreamBuffer                 (void* encoder, 
 
 // NvEncDestroyBitstreamBuffer
 /**
- * \brief Release a bitstream buffer. 
+ * \brief Release a bitstream buffer.
  *
  * This function is used to release the output bitstream buffer allocated using
  * the ::NvEncCreateBitstreamBuffer() function. The client must release the output
@@ -2837,7 +3270,7 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
 /**
  * \brief Submit an input picture for encoding.
  *
- * This function is used to submit an input picture buffer for encoding. The 
+ * This function is used to submit an input picture buffer for encoding. The
  * encoding parameters are passed using \p *encodePicParams which is a pointer
  * to the ::_NV_ENC_PIC_PARAMS structure.
  *
@@ -2855,62 +3288,62 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
  * view and view ID as 1 for dependent view.
  *
  *\par Asynchronous Encoding
- * If the client has enabled asynchronous mode of encoding by setting 
+ * If the client has enabled asynchronous mode of encoding by setting
  * NV_ENC_INITIALIZE_PARAMS::enableEncodeAsync to 1 in the ::NvEncInitializeEncoder()
  * API ,then the client must send a valid NV_ENC_PIC_PARAMS::completionEvent.
  * Incase of asynchronous mode of operation, client can queue the ::NvEncEncodePicture()
- * API commands from the main thread and then queue output buffers to be processed 
- * to a secondary worker thread. Before the locking the output buffers in the 
+ * API commands from the main thread and then queue output buffers to be processed
+ * to a secondary worker thread. Before the locking the output buffers in the
  * secondary thread , the client must wait on NV_ENC_PIC_PARAMS::completionEvent
  * it has queued in ::NvEncEncodePicture() API call. The client must always process
  * completion event and the output buffer in the same order in which they have been
- * submitted for encoding. The NvEncodeAPI interface is responsible for any 
+ * submitted for encoding. The NvEncodeAPI interface is responsible for any
  * re-ordering required for B frames and will always ensure that encoded bitstream
  * data is written in the same order in which output buffer is submitted.
  * The NvEncodeAPI interface may return ::NV_ENC_ERR_NEED_MORE_INPUT error code for
  * some ::NvEncEncodePicture() API calls but the client must not treat it as a fatal error.
- * The NvEncodeAPI interface might not be able to submit an input picture buffer for encoding 
+ * The NvEncodeAPI interface might not be able to submit an input picture buffer for encoding
  * immediately due to re-ordering for B frames.
  *\code
   The below example shows how  asynchronous encoding in case of 1 B frames
   ------------------------------------------------------------------------
-  Suppose the client allocated 4 input buffers(I1,I2..), 4 output buffers(O1,O2..) 
-  and 4 completion events(E1, E2, ...). The NvEncodeAPI interface will need to 
-  keep a copy of the input buffers for re-ordering and it allocates following 
+  Suppose the client allocated 4 input buffers(I1,I2..), 4 output buffers(O1,O2..)
+  and 4 completion events(E1, E2, ...). The NvEncodeAPI interface will need to
+  keep a copy of the input buffers for re-ordering and it allocates following
   internal buffers (NvI1, NvI2...). These internal buffers are managed by NvEncodeAPI
-  and the client is not responsible for the allocating or freeing the memory of 
+  and the client is not responsible for the allocating or freeing the memory of
   the internal buffers.
 
-  a) The client main thread will queue the following encode frame calls. 
-  Note the picture type is unknown to the client, the decision is being taken by 
-  NvEncodeAPI interface. The client should pass ::_NV_ENC_PIC_PARAMS parameter  
-  consisting of allocated input buffer, output buffer and output events in successive 
+  a) The client main thread will queue the following encode frame calls.
+  Note the picture type is unknown to the client, the decision is being taken by
+  NvEncodeAPI interface. The client should pass ::_NV_ENC_PIC_PARAMS parameter
+  consisting of allocated input buffer, output buffer and output events in successive
   ::NvEncEncodePicture() API calls along with other required encode picture params.
   For example:
   1st EncodePicture parameters - (I1, O1, E1)
   2nd EncodePicture parameters - (I2, O2, E2)
   3rd EncodePicture parameters - (I3, O3, E3)
 
-  b) NvEncodeAPI SW will receive the following encode Commands from the client. 
-  The left side shows input from client in the form (Input buffer, Output Buffer, 
+  b) NvEncodeAPI SW will receive the following encode Commands from the client.
+  The left side shows input from client in the form (Input buffer, Output Buffer,
   Output Event). The right hand side shows a possible picture type decision take by
   the NvEncodeAPI interface.
   (I1, O1, E1)    ---P1 Frame
   (I2, O2, E2)    ---B2 Frame
   (I3, O3, E3)    ---P3 Frame
 
-  c) NvEncodeAPI interface will make a copy of the input buffers to its internal  
-   buffers for re-ordering. These copies are done as part of nvEncEncodePicture  
-   function call from the client and NvEncodeAPI interface is responsible for  
+  c) NvEncodeAPI interface will make a copy of the input buffers to its internal
+   buffers for re-ordering. These copies are done as part of nvEncEncodePicture
+   function call from the client and NvEncodeAPI interface is responsible for
    synchronization of copy operation with the actual encoding operation.
-   I1 --> NvI1  
-   I2 --> NvI2 
+   I1 --> NvI1
+   I2 --> NvI2
    I3 --> NvI3
 
    d) The NvEncodeAPI encodes I1 as P frame and submits I1 to encoder HW and returns ::NV_ENC_SUCCESS.
    The NvEncodeAPI tries to encode I2 as B frame and fails with ::NV_ENC_ERR_NEED_MORE_INPUT error code.
    The error is not fatal and it notifies client that I2 is not submitted to encoder immediately.
-   The NvEncodeAPI encodes I3 as P frame and submits I3 for encoding which will be used as  backward 
+   The NvEncodeAPI encodes I3 as P frame and submits I3 for encoding which will be used as  backward
    reference frame for I2. The NvEncodeAPI then submits I2 for encoding and returns ::NV_ENC_SUCESS.
    Both the submission are part of the same ::NvEncEncodePicture() function call.
 
@@ -2922,22 +3355,22 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
    (I1, O1, E1)
    (I2, O2, E2)
    (I3, O3, E3)
-   Note they are in the same order in which client calls ::NvEncEncodePicture() API 
+   Note they are in the same order in which client calls ::NvEncEncodePicture() API
    in \p step a).
 
-  f) NvEncodeAPI interface  will do the re-ordering such that Encoder HW will receive 
+  f) NvEncodeAPI interface  will do the re-ordering such that Encoder HW will receive
   the following encode commands:
   (NvI1, O1, E1)   ---P1 Frame
   (NvI3, O2, E2)   ---P3 Frame
   (NvI2, O3, E3)   ---B2 frame
 
-  g) After the encoding operations are completed, the events will be signaled 
+  g) After the encoding operations are completed, the events will be signaled
   by NvEncodeAPI interface in the following order :
   (O1, E1) ---P1 Frame ,output bitstream copied to O1 and event E1 signaled.
   (O2, E2) ---P3 Frame ,output bitstream copied to O2 and event E2 signaled.
   (O3, E3) ---B2 Frame ,output bitstream copied to O3 and event E3 signaled.
 
-  h) The client must lock the bitstream data using ::NvEncLockBitstream() API in 
+  h) The client must lock the bitstream data using ::NvEncLockBitstream() API in
    the order O1,O2,O3  to read the encoded data, after waiting for the events
    to be signaled in the same order i.e E1, E2 and E3.The output processing is
    done in the secondary thread in the following order:
@@ -2945,57 +3378,57 @@ NVENCSTATUS NVENCAPI NvEncDestroyBitstreamBuffer                (void* encoder, 
    Waits on E2, copies encoded bitstream from O2
    Waits on E3, copies encoded bitstream from O3
 
-  -Note the client will receive the events signaling and output buffer in the 
+  -Note the client will receive the events signaling and output buffer in the
    same order in which they have submitted for encoding.
-  -Note the LockBitstream will have picture type field which will notify the 
+  -Note the LockBitstream will have picture type field which will notify the
    output picture type to the clients.
-  -Note the input, output buffer and the output completion event are free to be 
+  -Note the input, output buffer and the output completion event are free to be
    reused once NvEncodeAPI interfaced has signaled the event and the client has
    copied the data from the output buffer.
 
  * \endcode
  *
  *\par Synchronous Encoding
- * The client can enable synchronous mode of encoding by setting 
+ * The client can enable synchronous mode of encoding by setting
  * NV_ENC_INITIALIZE_PARAMS::enableEncodeAsync to 0 in ::NvEncInitializeEncoder() API.
  * The NvEncodeAPI interface may return ::NV_ENC_ERR_NEED_MORE_INPUT error code for
- * some ::NvEncEncodePicture() API calls when NV_ENC_INITIALIZE_PARAMS::enablePTD 
- * is set to 1, but the client must not treat it as a fatal error. The NvEncodeAPI 
- * interface might not be able to submit an input picture buffer for encoding 
- * immediately due to re-ordering for B frames. The NvEncodeAPI interface cannot 
- * submit the input picture which is decided to be encoded as B frame as it waits 
+ * some ::NvEncEncodePicture() API calls when NV_ENC_INITIALIZE_PARAMS::enablePTD
+ * is set to 1, but the client must not treat it as a fatal error. The NvEncodeAPI
+ * interface might not be able to submit an input picture buffer for encoding
+ * immediately due to re-ordering for B frames. The NvEncodeAPI interface cannot
+ * submit the input picture which is decided to be encoded as B frame as it waits
  * for backward reference from  temporally subsequent frames. This input picture
  * is buffered internally and waits for more input picture to arrive. The client
- * must not call ::NvEncLockBitstream() API on the output buffers whose 
- * ::NvEncEncodePicture() API returns ::NV_ENC_ERR_NEED_MORE_INPUT. The client must 
- * wait for the NvEncodeAPI interface to return ::NV_ENC_SUCCESS before locking the 
+ * must not call ::NvEncLockBitstream() API on the output buffers whose
+ * ::NvEncEncodePicture() API returns ::NV_ENC_ERR_NEED_MORE_INPUT. The client must
+ * wait for the NvEncodeAPI interface to return ::NV_ENC_SUCCESS before locking the
  * output bitstreams to read the encoded bitstream data. The following example
  * explains the scenario with synchronous encoding with 2 B frames.
  *\code
  The below example shows how  synchronous encoding works in case of 1 B frames
  -----------------------------------------------------------------------------
- Suppose the client allocated 4 input buffers(I1,I2..), 4 output buffers(O1,O2..) 
- and 4 completion events(E1, E2, ...). The NvEncodeAPI interface will need to 
- keep a copy of the input buffers for re-ordering and it allocates following 
+ Suppose the client allocated 4 input buffers(I1,I2..), 4 output buffers(O1,O2..)
+ and 4 completion events(E1, E2, ...). The NvEncodeAPI interface will need to
+ keep a copy of the input buffers for re-ordering and it allocates following
  internal buffers (NvI1, NvI2...). These internal buffers are managed by NvEncodeAPI
- and the client is not responsible for the allocating or freeing the memory of 
+ and the client is not responsible for the allocating or freeing the memory of
  the internal buffers.
 
  The client calls ::NvEncEncodePicture() API with input buffer I1 and output buffer O1.
  The NvEncodeAPI decides to encode I1 as P frame and submits it to encoder
- HW and returns ::NV_ENC_SUCCESS. 
+ HW and returns ::NV_ENC_SUCCESS.
  The client can now read the encoded data by locking the output O1 by calling
  NvEncLockBitstream API.
 
  The client calls ::NvEncEncodePicture() API with input buffer I2 and output buffer O2.
  The NvEncodeAPI decides to encode I2 as B frame and buffers I2 by copying it
  to internal buffer and returns ::NV_ENC_ERR_NEED_MORE_INPUT.
- The error is not fatal and it notifies client that it cannot read the encoded 
+ The error is not fatal and it notifies client that it cannot read the encoded
  data by locking the output O2 by calling ::NvEncLockBitstream() API without submitting
  more work to the NvEncodeAPI interface.
-  
+
  The client calls ::NvEncEncodePicture() with input buffer I3 and output buffer O3.
- The NvEncodeAPI decides to encode I3 as P frame and it first submits I3 for 
+ The NvEncodeAPI decides to encode I3 as P frame and it first submits I3 for
  encoding which will be used as backward reference frame for I2.
  The NvEncodeAPI then submits I2 for encoding and returns ::NV_ENC_SUCESS. Both
  the submission are part of the same ::NvEncEncodePicture() function call.
@@ -3035,16 +3468,16 @@ NVENCSTATUS NVENCAPI NvEncEncodePicture                         (void* encoder, 
  * \brief Lock output bitstream buffer
  *
  * This function is used to lock the bitstream buffer to read the encoded data.
- * The client can only access the encoded data by calling this function. 
- * The pointer to client accessible encoded data is returned in the 
+ * The client can only access the encoded data by calling this function.
+ * The pointer to client accessible encoded data is returned in the
  * NV_ENC_LOCK_BITSTREAM::bitstreamBufferPtr field. The size of the encoded data
  * in the output buffer is returned in the NV_ENC_LOCK_BITSTREAM::bitstreamSizeInBytes
- * The NvEncodeAPI interface also returns the output picture type and picture structure 
+ * The NvEncodeAPI interface also returns the output picture type and picture structure
  * of the encoded frame in NV_ENC_LOCK_BITSTREAM::pictureType and
  * NV_ENC_LOCK_BITSTREAM::pictureStruct fields respectively. If the client has
  * set NV_ENC_LOCK_BITSTREAM::doNotWait to 1, the function might return
- * ::NV_ENC_ERR_LOCK_BUSY if client is operating in synchronous mode. This is not 
- * a fatal failure if NV_ENC_LOCK_BITSTREAM::doNotWait is set to 1. In the above case the client can 
+ * ::NV_ENC_ERR_LOCK_BUSY if client is operating in synchronous mode. This is not
+ * a fatal failure if NV_ENC_LOCK_BITSTREAM::doNotWait is set to 1. In the above case the client can
  * retry the function after few milliseconds.
  *
  * \param [in] encoder
@@ -3106,9 +3539,9 @@ NVENCSTATUS NVENCAPI NvEncUnlockBitstream                       (void* encoder, 
  * This function is used to lock the input buffer to load the uncompressed YUV
  * pixel data into input buffer memory. The client must pass the NV_ENC_INPUT_PTR
  * it had previously allocated using ::NvEncCreateInputBuffer()in the
- * NV_ENC_LOCK_INPUT_BUFFER::inputBuffer field. 
- * The NvEncodeAPI interface returns pointer to client accessible input buffer 
- * memory in NV_ENC_LOCK_INPUT_BUFFER::bufferDataPtr field. 
+ * NV_ENC_LOCK_INPUT_BUFFER::inputBuffer field.
+ * The NvEncodeAPI interface returns pointer to client accessible input buffer
+ * memory in NV_ENC_LOCK_INPUT_BUFFER::bufferDataPtr field.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3169,6 +3602,8 @@ NVENCSTATUS NVENCAPI NvEncUnlockInputBuffer                     (void* encoder, 
  *
  * This function is used to retrieve the encoding statistics.
  * This API is not supported when encode device type is CUDA.
+ * Note that this API will be removed in future Video Codec SDK release.
+ * Clients should use NvEncLockBitstream() API to retrieve the encoding statistics.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3194,16 +3629,16 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeStats                        (void* encoder, 
 /**
  * \brief Get encoded sequence and picture header.
  *
- * This function can be used to retrieve the sequence and picture header out of 
- * band. The client must call this function only after the encoder has been 
- * initialized using ::NvEncInitializeEncoder() function. The client must 
+ * This function can be used to retrieve the sequence and picture header out of
+ * band. The client must call this function only after the encoder has been
+ * initialized using ::NvEncInitializeEncoder() function. The client must
  * allocate the memory where the NvEncodeAPI interface can copy the bitstream
- * header and pass the pointer to the memory in NV_ENC_SEQUENCE_PARAM_PAYLOAD::spsppsBuffer. 
+ * header and pass the pointer to the memory in NV_ENC_SEQUENCE_PARAM_PAYLOAD::spsppsBuffer.
  * The size of buffer is passed in the field  NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize.
- * The NvEncodeAPI interface will copy the bitstream header payload and returns 
+ * The NvEncodeAPI interface will copy the bitstream header payload and returns
  * the actual size of the bitstream header in the field
  * NV_ENC_SEQUENCE_PARAM_PAYLOAD::outSPSPPSPayloadSize.
- * The client must call  ::NvEncGetSequenceParams() function from the same thread which is 
+ * The client must call  ::NvEncGetSequenceParams() function from the same thread which is
  * being used to call ::NvEncEncodePicture() function.
  *
  * \param [in] encoder
@@ -3221,7 +3656,7 @@ NVENCSTATUS NVENCAPI NvEncGetEncodeStats                        (void* encoder, 
  * ::NV_ENC_ERR_INVALID_VERSION \n
  * ::NV_ENC_ERR_INVALID_PARAM \n
  * ::NV_ENC_ERR_ENCODER_NOT_INITIALIZED \n
- * ::NV_ENC_ERR_GENERIC \n 
+ * ::NV_ENC_ERR_GENERIC \n
  *
  */
 NVENCSTATUS NVENCAPI NvEncGetSequenceParams                     (void* encoder, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload);
@@ -3231,15 +3666,15 @@ NVENCSTATUS NVENCAPI NvEncGetSequenceParams                     (void* encoder, 
  * \brief Get sequence and picture header.
  *
  * This function can be used to retrieve the sequence and picture header out of band, even when
- * encoder has not been initialized using ::NvEncInitializeEncoder() function. 
+ * encoder has not been initialized using ::NvEncInitializeEncoder() function.
  * The client must allocate the memory where the NvEncodeAPI interface can copy the bitstream
- * header and pass the pointer to the memory in NV_ENC_SEQUENCE_PARAM_PAYLOAD::spsppsBuffer. 
- * The size of buffer is passed in the field  NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize. 
- * If encoder has not been initialized using ::NvEncInitializeEncoder() function, client must 
- * send NV_ENC_INITIALIZE_PARAMS as input. The NV_ENC_INITIALIZE_PARAMS passed must be same as the 
+ * header and pass the pointer to the memory in NV_ENC_SEQUENCE_PARAM_PAYLOAD::spsppsBuffer.
+ * The size of buffer is passed in the field  NV_ENC_SEQUENCE_PARAM_PAYLOAD::inBufferSize.
+ * If encoder has not been initialized using ::NvEncInitializeEncoder() function, client must
+ * send NV_ENC_INITIALIZE_PARAMS as input. The NV_ENC_INITIALIZE_PARAMS passed must be same as the
  * one which will be used for initializing encoder using ::NvEncInitializeEncoder() function later.
- * If encoder is already initialized using ::NvEncInitializeEncoder() function, the provided 
- * NV_ENC_INITIALIZE_PARAMS structure is ignored. The NvEncodeAPI interface will copy the bitstream 
+ * If encoder is already initialized using ::NvEncInitializeEncoder() function, the provided
+ * NV_ENC_INITIALIZE_PARAMS structure is ignored. The NvEncodeAPI interface will copy the bitstream
  * header payload and returns the actual size of the bitstream header in the field
  * NV_ENC_SEQUENCE_PARAM_PAYLOAD::outSPSPPSPayloadSize. The client must call  ::NvEncGetSequenceParamsEx()
  * function from the same thread which is being used to call ::NvEncEncodePicture() function.
@@ -3260,7 +3695,7 @@ NVENCSTATUS NVENCAPI NvEncGetSequenceParams                     (void* encoder, 
  * ::NV_ENC_ERR_OUT_OF_MEMORY \n
  * ::NV_ENC_ERR_INVALID_VERSION \n
  * ::NV_ENC_ERR_INVALID_PARAM \n
- * ::NV_ENC_ERR_GENERIC \n 
+ * ::NV_ENC_ERR_GENERIC \n
  *
  */
 NVENCSTATUS NVENCAPI NvEncGetSequenceParamEx                     (void* encoder, NV_ENC_INITIALIZE_PARAMS* encInitParams, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload);
@@ -3269,11 +3704,11 @@ NVENCSTATUS NVENCAPI NvEncGetSequenceParamEx                     (void* encoder,
 /**
  * \brief Register event for notification to encoding completion.
  *
- * This function is used to register the completion event with NvEncodeAPI 
- * interface. The event is required when the client has configured the encoder to 
+ * This function is used to register the completion event with NvEncodeAPI
+ * interface. The event is required when the client has configured the encoder to
  * work in asynchronous mode. In this mode the client needs to send a completion
- * event with every output buffer. The NvEncodeAPI interface will signal the 
- * completion of the encoding process using this event. Only after the event is 
+ * event with every output buffer. The NvEncodeAPI interface will signal the
+ * completion of the encoding process using this event. Only after the event is
  * signaled the client can get the encoded data using ::NvEncLockBitstream() function.
  *
  * \param [in] encoder
@@ -3326,7 +3761,7 @@ NVENCSTATUS NVENCAPI NvEncRegisterAsyncEvent                    (void* encoder, 
 NVENCSTATUS NVENCAPI NvEncUnregisterAsyncEvent                  (void* encoder, NV_ENC_EVENT_PARAMS* eventParams);
 
 
-// NvEncMapInputResource 
+// NvEncMapInputResource
 /**
  * \brief Map an externally created input resource pointer for encoding.
  *
@@ -3340,6 +3775,7 @@ NVENCSTATUS NVENCAPI NvEncUnregisterAsyncEvent                  (void* encoder, 
  * also true for compute (i.e. CUDA) work, provided that the previous workload using
  * the input resource was submitted to the default stream.
  * The client should not access any input buffer while they are mapped by the encoder.
+ * For D3D12 interface type, this function does not provide synchronization guarantee.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3364,7 +3800,7 @@ NVENCSTATUS NVENCAPI NvEncUnregisterAsyncEvent                  (void* encoder, 
 NVENCSTATUS NVENCAPI NvEncMapInputResource                         (void* encoder, NV_ENC_MAP_INPUT_RESOURCE* mapInputResParams);
 
 
-// NvEncUnmapInputResource 
+// NvEncUnmapInputResource
 /**
  * \brief  UnMaps a NV_ENC_INPUT_PTR  which was mapped for encoding
  *
@@ -3403,14 +3839,14 @@ NVENCSTATUS NVENCAPI NvEncUnmapInputResource                         (void* enco
  * \brief Destroy Encoding Session
  *
  * Destroys the encoder session previously created using ::NvEncOpenEncodeSession()
- * function. The client must flush the encoder before freeing any resources. In order 
- * to flush the encoder the client must pass a NULL encode picture packet and either 
- * wait for the ::NvEncEncodePicture() function to return in synchronous mode or wait 
+ * function. The client must flush the encoder before freeing any resources. In order
+ * to flush the encoder the client must pass a NULL encode picture packet and either
+ * wait for the ::NvEncEncodePicture() function to return in synchronous mode or wait
  * for the flush event to be signaled by the encoder in asynchronous mode.
  * The client must free all the input and output resources created using the
  * NvEncodeAPI interface before destroying the encoder. If the client is operating
  * in asynchronous mode, it must also unregister the completion events previously
- * registered. 
+ * registered.
  *
  * \param [in] encoder
  *   Pointer to the NvEncodeAPI interface.
@@ -3430,15 +3866,15 @@ NVENCSTATUS NVENCAPI NvEncDestroyEncoder                        (void* encoder);
 
 // NvEncInvalidateRefFrames
 /**
- * \brief Invalidate reference frames 
+ * \brief Invalidate reference frames
  *
- * Invalidates reference frame based on the time stamp provided by the client. 
+ * Invalidates reference frame based on the time stamp provided by the client.
  * The encoder marks any reference frames or any frames which have been reconstructed
  * using the corrupt frame as invalid for motion estimation and uses older reference
- * frames for motion estimation. The encoded forces the current frame to be encoded
+ * frames for motion estimation. The encoder forces the current frame to be encoded
  * as an intra frame if no reference frames are left after invalidation process.
- * This is useful for low latency application for error resiliency. The client 
- * is recommended to set NV_ENC_CONFIG_H264::maxNumRefFrames to a large value so 
+ * This is useful for low latency application for error resiliency. The client
+ * is recommended to set NV_ENC_CONFIG_H264::maxNumRefFrames to a large value so
  * that encoder can keep a backup of older reference frames in the DPB and can use them
  * for motion estimation when the newer reference frames have been invalidated.
  * This API can be called multiple times.
@@ -3464,14 +3900,14 @@ NVENCSTATUS NVENCAPI NvEncInvalidateRefFrames(void* encoder, uint64_t invalidRef
 // NvEncOpenEncodeSessionEx
 /**
  * \brief Opens an encoding session.
- * 
+ *
  * Opens an encoding session and returns a pointer to the encoder interface in
  * the \p **encoder parameter. The client should start encoding process by calling
- * this API first. 
+ * this API first.
  * The client must pass a pointer to IDirect3DDevice9 device or CUDA context in the \p *device parameter.
  * For the OpenGL interface, \p device must be NULL. An OpenGL context must be current when
  * calling all NvEncodeAPI functions.
- * If the creation of encoder session fails, the client must call ::NvEncDestroyEncoder API 
+ * If the creation of encoder session fails, the client must call ::NvEncDestroyEncoder API
  * before exiting.
  *
  * \param [in] openSessionExParams
@@ -3494,7 +3930,7 @@ NVENCSTATUS NVENCAPI NvEncOpenEncodeSessionEx                   (NV_ENC_OPEN_ENC
 // NvEncRegisterResource
 /**
  * \brief Registers a resource with the Nvidia Video Encoder Interface.
- * 
+ *
  * Registers a resource with the Nvidia Video Encoder Interface for book keeping.
  * The client is expected to pass the registered resource handle as well, while calling ::NvEncMapInputResource API.
  *
@@ -3503,7 +3939,7 @@ NVENCSTATUS NVENCAPI NvEncOpenEncodeSessionEx                   (NV_ENC_OPEN_ENC
  *
  * \param [in] registerResParams
  *   Pointer to a ::_NV_ENC_REGISTER_RESOURCE structure
- * 
+ *
  * \return
  * ::NV_ENC_SUCCESS \n
  * ::NV_ENC_ERR_INVALID_PTR \n
@@ -3524,9 +3960,9 @@ NVENCSTATUS NVENCAPI NvEncRegisterResource                      (void* encoder, 
 // NvEncUnregisterResource
 /**
  * \brief Unregisters a resource previously registered with the Nvidia Video Encoder Interface.
- * 
+ *
  * Unregisters a resource previously registered with the Nvidia Video Encoder Interface.
- * The client is expected to unregister any resource that it has registered with the 
+ * The client is expected to unregister any resource that it has registered with the
  * Nvidia Video Encoder Interface before destroying the resource.
  *
  * \param [in] encoder
@@ -3555,16 +3991,16 @@ NVENCSTATUS NVENCAPI NvEncUnregisterResource                    (void* encoder, 
 // NvEncReconfigureEncoder
 /**
  * \brief Reconfigure an existing encoding session.
- * 
+ *
  * Reconfigure an existing encoding session.
- * The client should call this API to change/reconfigure the parameter passed during 
+ * The client should call this API to change/reconfigure the parameter passed during
  * NvEncInitializeEncoder API call.
  * Currently Reconfiguration of following are not supported.
  * Change in GOP structure.
  * Change in sync-Async mode.
  * Change in MaxWidth & MaxHeight.
  * Change in PTD mode.
- * 
+ *
  * Resolution change is possible only if maxEncodeWidth & maxEncodeHeight of NV_ENC_INITIALIZE_PARAMS
  * is set while creating encoder session.
  *
@@ -3713,7 +4149,7 @@ const char * NVENCAPI NvEncGetLastErrorString          (void* encoder);
 
 /// \cond API PFN
 /*
- *  Defines API function pointers 
+ *  Defines API function pointers
  */
 typedef NVENCSTATUS (NVENCAPI* PNVENCOPENENCODESESSION)         (void* device, uint32_t deviceType, void** encoder);
 typedef NVENCSTATUS (NVENCAPI* PNVENCGETENCODEGUIDCOUNT)        (void* encoder, uint32_t* encodeGUIDCount);
@@ -3822,7 +4258,7 @@ typedef struct _NV_ENCODE_API_FUNCTION_LIST
 /**
  * \ingroup ENCODE_FUNC
  * Entry Point to the NvEncodeAPI interface.
- * 
+ *
  * Creates an instance of the NvEncodeAPI interface, and populates the
  * pFunctionList with function pointers to the API routines implemented by the
  * NvEncodeAPI interface.

--- a/Plugin~/NvCodec/include/nvcuvid.h
+++ b/Plugin~/NvCodec/include/nvcuvid.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2020 NVIDIA Corporation
+ * Copyright (c) 2010-2022 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -28,7 +28,7 @@
 /********************************************************************************************************************/
 //! \file nvcuvid.h
 //!   NVDECODE API provides video decoding interface to NVIDIA GPU devices.
-//! \date 2015-2020
+//! \date 2015-2022
 //!  This file contains the interface constants, structure definitions and function prototypes.
 /********************************************************************************************************************/
 
@@ -41,6 +41,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#define MAX_CLOCK_TS 3
 
 /***********************************************/
 //!
@@ -77,6 +78,54 @@ typedef enum {
     cudaAudioCodec_LPCM,            /**< PCM Audio                  */
     cudaAudioCodec_AAC,             /**< AAC Audio                  */
 } cudaAudioCodec;
+
+/************************************************************************/
+//! \ingroup STRUCTS
+//! \struct HEVCTIMECODESET
+//! Used to store Time code extracted from Time code SEI in HEVC codec
+/************************************************************************/
+typedef struct _HEVCTIMECODESET
+{
+    unsigned int time_offset_value;
+    unsigned short n_frames;                 
+    unsigned char clock_timestamp_flag;
+    unsigned char units_field_based_flag;
+    unsigned char counting_type;
+    unsigned char full_timestamp_flag;
+    unsigned char discontinuity_flag;
+    unsigned char cnt_dropped_flag;
+    unsigned char seconds_value;
+    unsigned char minutes_value;
+    unsigned char hours_value;
+    unsigned char seconds_flag;
+    unsigned char minutes_flag;
+    unsigned char hours_flag;
+    unsigned char time_offset_length;
+    unsigned char reserved;
+} HEVCTIMECODESET;
+
+/************************************************************************/
+//! \ingroup STRUCTS
+//! \struct HEVCSEITIMECODE
+//! Used to extract Time code SEI in HEVC codec
+/************************************************************************/
+typedef struct _HEVCSEITIMECODE
+{
+    HEVCTIMECODESET time_code_set[MAX_CLOCK_TS];
+    unsigned char num_clock_ts;
+} HEVCSEITIMECODE;
+
+/**********************************************************************************/
+//! \ingroup STRUCTS
+//! \struct CUSEIMESSAGE;
+//! Used in CUVIDSEIMESSAGEINFO structure
+/**********************************************************************************/
+typedef struct _CUSEIMESSAGE
+{
+    unsigned char sei_message_type; /**< OUT: SEI Message Type      */
+    unsigned char reserved[3];
+    unsigned int sei_message_size;  /**< OUT: SEI Message Size      */
+} CUSEIMESSAGE;
 
 /************************************************************************************************/
 //! \ingroup STRUCTS
@@ -167,6 +216,19 @@ typedef struct
         unsigned char CodecReserved[1024];
     };
 } CUVIDOPERATINGPOINTINFO;
+
+/**********************************************************************************/
+//! \ingroup STRUCTS
+//! \struct CUVIDSEIMESSAGEINFO
+//! Used in cuvidParseVideoData API with PFNVIDSEIMSGCALLBACK pfnGetSEIMsg
+/**********************************************************************************/
+typedef struct _CUVIDSEIMESSAGEINFO
+{
+    void *pSEIData;                 /**< OUT: SEI Message Data      */
+    CUSEIMESSAGE *pSEIMessage;      /**< OUT: SEI Message Info      */
+    unsigned int sei_message_count; /**< OUT: SEI Message Count     */
+    unsigned int picIdx;            /**< OUT: SEI Message Pic Index */
+} CUVIDSEIMESSAGEINFO;
 
 /****************************************************************/
 //! \ingroup STRUCTS
@@ -366,11 +428,13 @@ typedef struct _CUVIDPARSERDISPINFO
 //! PFNVIDDECODECALLBACK   : 0: fail, >=1: succeeded
 //! PFNVIDDISPLAYCALLBACK  : 0: fail, >=1: succeeded
 //! PFNVIDOPPOINTCALLBACK  : <0: fail, >=0: succeeded (bit 0-9: OperatingPoint, bit 10-10: outputAllLayers, bit 11-30: reserved)
+//! PFNVIDSEIMSGCALLBACK   : 0: fail, >=1: succeeded
 /***********************************************************************************************************************/
 typedef int (CUDAAPI *PFNVIDSEQUENCECALLBACK)(void *, CUVIDEOFORMAT *);
 typedef int (CUDAAPI *PFNVIDDECODECALLBACK)(void *, CUVIDPICPARAMS *);
 typedef int (CUDAAPI *PFNVIDDISPLAYCALLBACK)(void *, CUVIDPARSERDISPINFO *);
 typedef int (CUDAAPI *PFNVIDOPPOINTCALLBACK)(void *, CUVIDOPERATINGPOINTINFO*);
+typedef int (CUDAAPI *PFNVIDSEIMSGCALLBACK) (void *, CUVIDSEIMESSAGEINFO *);
 
 /**************************************/
 //! \ingroup STRUCTS
@@ -395,7 +459,8 @@ typedef struct _CUVIDPARSERPARAMS
     PFNVIDDISPLAYCALLBACK pfnDisplayPicture;    /**< IN: Called whenever a picture is ready to be displayed (display order)  */
     PFNVIDOPPOINTCALLBACK pfnGetOperatingPoint; /**< IN: Called from AV1 sequence header to get operating point of a AV1 
                                                          scalable bitstream                                                  */
-    void *pvReserved2[6];                       /**< Reserved for future use - set to NULL                                   */
+    PFNVIDSEIMSGCALLBACK pfnGetSEIMsg;          /**< IN: Called when all SEI messages are parsed for particular frame        */
+    void *pvReserved2[5];                       /**< Reserved for future use - set to NULL                                   */
     CUVIDEOFORMATEX *pExtVideoInfo;             /**< IN: [Optional] sequence header data from system layer                   */
 } CUVIDPARSERPARAMS;
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1312,6 +1312,37 @@ extern "C"
 
     UNITY_INTERFACE_EXPORT int DataChannelGetID(DataChannelInterface* channel) { return channel->id(); }
 
+    struct RtpSource
+    {
+        Optional<uint8_t> audioLevel;
+        uint8_t sourceType;
+        uint32_t source;
+        uint32_t rtpTimestamp;
+        int64_t timestamp;
+
+        RtpSource(const webrtc::RtpSource& src)
+        {
+            audioLevel = src.audio_level();
+            rtpTimestamp = src.rtp_timestamp();
+            source = src.source_id();
+            sourceType = static_cast<uint8_t>(src.source_type());
+            timestamp = src.timestamp_ms();
+        }
+    };
+
+    UNITY_INTERFACE_EXPORT ::RtpSource* ReceiverGetSources(RtpReceiverInterface* receiver, size_t* length)
+    {
+        auto sources = receiver->GetSources();
+        if (sources.empty())
+            return nullptr;
+
+        std::vector<::RtpSource> result;
+        std::transform(sources.begin(), sources.end(), std::back_inserter(result), [](webrtc::RtpSource source) {
+            return source;
+        });
+        return ConvertArray(result, length);
+    }
+
     UNITY_INTERFACE_EXPORT char* DataChannelGetLabel(DataChannelInterface* channel)
     {
         return ConvertString(channel->label());

--- a/Runtime/Scripts/Internal/Marshalling.cs
+++ b/Runtime/Scripts/Internal/Marshalling.cs
@@ -151,6 +151,24 @@ namespace Unity.WebRTC
 
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    internal struct OptionalByte
+    {
+        [MarshalAs(UnmanagedType.U1)]
+        public bool hasValue;
+        public byte value;
+
+        public static implicit operator byte?(OptionalByte a)
+        {
+            return a.hasValue ? a.value : (byte?)null;
+        }
+        public static implicit operator OptionalByte(byte? a)
+        {
+            return new OptionalByte { hasValue = a.HasValue, value = a.GetValueOrDefault() };
+        }
+    }
+
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
     internal struct MarshallingArray<T> where T : struct
     {
         public int length;

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -15,93 +15,93 @@ namespace Unity.WebRTC
     public enum RTCErrorDetailType
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         DataChannelFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         DtlsFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         FingerprintFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpBadScriptFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpExecutionFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpLoadFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpNeedLogin,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpTimeout,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpTlsFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpTokenExpired,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IdpTokenInvalid,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         SctpFailure,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         SdpSyntaxError,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         HardwareEncoderNotAvailable,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         HardwareEncoderError
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public struct RTCError
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public RTCErrorType errorType;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public string message;
     }
@@ -113,32 +113,32 @@ namespace Unity.WebRTC
     public enum RTCPeerConnectionState : int
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         New = 0,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Connecting = 1,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Connected = 2,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Disconnected = 3,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Failed = 4,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Closed = 5
     }
@@ -150,42 +150,42 @@ namespace Unity.WebRTC
     public enum RTCIceConnectionState : int
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         New = 0,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Checking = 1,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Connected = 2,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Completed = 3,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Failed = 4,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Disconnected = 5,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Closed = 6,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Max = 7
     }
@@ -197,17 +197,17 @@ namespace Unity.WebRTC
     public enum RTCIceGatheringState : int
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         New = 0,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Gathering = 1,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Complete = 2
     }
@@ -219,32 +219,32 @@ namespace Unity.WebRTC
     public enum RTCSignalingState : int
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Stable = 0,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         HaveLocalOffer = 1,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         HaveLocalPrAnswer = 2,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         HaveRemoteOffer = 3,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         HaveRemotePrAnswer = 4,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Closed = 5,
     }
@@ -255,119 +255,119 @@ namespace Unity.WebRTC
     public enum RTCErrorType
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         None,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         UnsupportedOperation,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         UnsupportedParameter,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         InvalidParameter,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         InvalidRange,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         SyntaxError,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         InvalidState,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         InvalidModification,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         NetworkError,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         ResourceExhausted,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         InternalError,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         OperationErrorWithData
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public enum RTCPeerConnectionEventType
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         ConnectionStateChange,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         DataChannel,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IceCandidate,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         IceConnectionStateChange,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Track
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public enum RTCSdpType
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Offer,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Pranswer,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Answer,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Rollback
     }
@@ -379,17 +379,17 @@ namespace Unity.WebRTC
     public enum RTCBundlePolicy : int
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         BundlePolicyBalanced = 0,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         BundlePolicyMaxBundle = 1,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         BundlePolicyMaxCompat = 2
     }
@@ -401,22 +401,22 @@ namespace Unity.WebRTC
     public enum RTCDataChannelState
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Connecting,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Open,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Closing,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Closed
     }
@@ -427,12 +427,12 @@ namespace Unity.WebRTC
     public struct RTCSessionDescription
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public RTCSdpType type;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [MarshalAs(UnmanagedType.LPStr)]
         public string sdp;
@@ -444,7 +444,7 @@ namespace Unity.WebRTC
     public struct RTCOfferAnswerOptions
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public static RTCOfferAnswerOptions Default =
             new RTCOfferAnswerOptions { iceRestart = false, voiceActivityDetection = true };
@@ -472,12 +472,12 @@ namespace Unity.WebRTC
     public enum RTCIceCredentialType
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Password,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         OAuth
     }
@@ -490,25 +490,25 @@ namespace Unity.WebRTC
     public struct RTCIceServer
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Tooltip("Optional: specifies the password to use when authenticating with the ICE server")]
         public string credential;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Tooltip("What type of credential the `password` value")]
         public RTCIceCredentialType credentialType;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Tooltip("Array to set URLs of your STUN/TURN servers")]
         public string[] urls;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Tooltip("Optional: specifies the username to use when authenticating with the ICE server")]
         public string username;
@@ -602,32 +602,32 @@ namespace Unity.WebRTC
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public enum NativeLoggingSeverity
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Verbose,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Info,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Warning,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         Error,
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         None,
     };
@@ -646,7 +646,7 @@ namespace Unity.WebRTC
         private static SynchronizationContext s_syncContext;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="limitTextureSize"></param>
         /// <param name="enableNativeLog"></param>
@@ -732,7 +732,7 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public static bool enableLimitTextureSize
         {
@@ -1369,6 +1369,8 @@ namespace Unity.WebRTC
         public static extern IntPtr ReceiverGetTrack(IntPtr receiver);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr ReceiverGetStreams(IntPtr receiver, out ulong length);
+        [DllImport(WebRTC.Lib)]
+        public static extern IntPtr ReceiverGetSources(IntPtr receiver, out ulong length);
         [DllImport(WebRTC.Lib)]
         public static extern int DataChannelGetID(IntPtr ptr);
         [DllImport(WebRTC.Lib)]

--- a/Tests/Runtime/SignalingPeers.cs
+++ b/Tests/Runtime/SignalingPeers.cs
@@ -30,6 +30,11 @@ namespace Unity.WebRTC.RuntimeTest
             return peers[indexPeer].AddTransceiver(track);
         }
 
+        public RTCRtpTransceiver AddTransceiver(int indexPeer, TrackKind kind, RTCRtpTransceiverInit init = null)
+        {
+            return peers[indexPeer].AddTransceiver(kind, init);
+        }
+
         public RTCRtpSender AddTrack(int indexPeer, MediaStreamTrack track)
         {
             return peers[indexPeer].AddTrack(track);

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.TestTools;
+using Unity.Collections;
 using NUnit.Framework;
 using System.Collections;
 using System.Linq;
@@ -162,6 +163,51 @@ namespace Unity.WebRTC.RuntimeTest
             peer.Dispose();
         }
 
+        [UnityTest]
+        [Timeout(5000)]
+        public IEnumerator ReceiverGetContributingSource()
+        {
+            var track = new AudioStreamTrack();
+            var test = new MonoBehaviourTest<SignalingPeers>();
+            var transceiver1 = test.component.AddTransceiver(0, track);
+            RTCRtpReceiver receiver1 = transceiver1.Receiver;
+            var sources1 = receiver1.GetContributingSources();
+            Assert.That(sources1, Is.Empty);
+
+            yield return test;
+            test.component.CoroutineUpdate();
+
+            // wait for OnNegotiationNeeded callback in SignalingPeers class
+            yield return new WaitUntil(() => test.component.NegotiationCompleted());
+
+            var transceiver2 = test.component.GetPeerTransceivers(1).First();
+            RTCRtpReceiver receiver2 = transceiver2.Receiver;
+
+            // Send audio data manually.
+            var nativeArray = new NativeArray<float>(480, Allocator.Persistent);
+
+            yield return new WaitUntil(() =>
+			{
+	            track.SetData(ref nativeArray, 1, 48000);
+				return receiver2.GetContributingSources().Length > 0;
+			});
+            var sources2 = receiver2.GetContributingSources();
+            Assert.That(sources2, Is.Not.Empty);
+            Assert.That(sources2.Length, Is.EqualTo(1));
+            Assert.That(sources2[0], Is.Not.Null);
+            Assert.That(sources2[0].audioLevel, Is.Not.Null);
+            Assert.That(sources2[0].source, Is.Null);
+
+			// todo(kazuki): Returns zero on Linux platform.
+            // Assert.That(sources2[0].rtpTimestamp, Is.Not.Zero);
+            // Assert.That(sources2[0].timestamp, Is.Not.Zero);
+
+			nativeArray.Dispose();
+            test.component.Dispose();
+            track.Dispose();
+            Object.DestroyImmediate(test.gameObject);
+        }
+
 
         [UnityTest]
         [Timeout(5000)]
@@ -190,9 +236,9 @@ namespace Unity.WebRTC.RuntimeTest
 
             Assert.That(transceiver1.Stop(), Is.EqualTo(RTCErrorType.None));
 
-            // wait for OnNegotiationNeeded callback in SignalingPeers class
-            yield return 0;
-            yield return new WaitUntil(() => test.component.NegotiationCompleted());
+            yield return new WaitUntil(() =>
+            transceiver1.CurrentDirection == RTCRtpTransceiverDirection.Stopped &&
+            transceiver2.CurrentDirection == RTCRtpTransceiverDirection.Stopped);
 
             Assert.That(transceiver1.Direction, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));
             Assert.That(transceiver1.CurrentDirection, Is.EqualTo(RTCRtpTransceiverDirection.Stopped));


### PR DESCRIPTION
### What
Changing images used in CI jobs

### Why
The `katana-to-yamato/*` images previously used will likely be deprecated at some point, so let's just have you now move to images which will be maintained going forward.

### Dependencies
None

### Note to reviewers
Looks like relevant CI jobs has been started automatically, hope I have covered everything