### PR TITLE
Add reserving eventID range and vulkan configuration for custom plugin events

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -292,20 +292,14 @@ extern "C" UnityRenderingEventAndData UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API
     return OnRenderEvent;
 }
 
-extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetRenderEventID()
-{
-    return s_renderEventID;
-}
+extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetRenderEventID() { return s_renderEventID; }
 
 extern "C" UnityRenderingEventAndData UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetReleaseBuffersFunc(Context* context)
 {
     return OnReleaseBuffers;
 }
 
-extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetReleaseBuffersEventID()
-{
-    return s_releaseBuffersEventID;
-}
+extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetReleaseBuffersEventID() { return s_releaseBuffersEventID; }
 
 static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)
 {

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -15,11 +15,6 @@
 #include "UnityVulkanInterfaceFunctions.h"
 #endif
 
-enum class VideoStreamRenderEventID
-{
-    Encode = 1,
-};
-
 using namespace unity::webrtc;
 using namespace ::webrtc;
 
@@ -41,6 +36,8 @@ namespace webrtc
     static const UnityProfilerMarkerDesc* s_MarkerDecode = nullptr;
     static std::unique_ptr<IGraphicsDevice> s_gfxDevice;
     static std::unique_ptr<GpuMemoryBufferPool> s_bufferPool;
+    static int s_renderEventID = 0;
+    static int s_releaseBuffersEventID = 0;
 
     IGraphicsDevice* Plugin::GraphicsDevice() { return s_gfxDevice.get(); }
 
@@ -86,6 +83,10 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
         if (renderer == kUnityGfxRendererNull)
             break;
 
+        // Reserve eventID range to use for custom plugin events.
+        s_renderEventID = s_UnityInterfaces->Get<IUnityGraphics>()->ReserveEventIDRange(2);
+        s_releaseBuffersEventID = s_renderEventID + 1;
+
 #if defined(SUPPORT_VULKAN)
         if (renderer == kUnityGfxRendererVulkan)
         {
@@ -98,15 +99,24 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
                 RTC_LOG(LS_INFO) << "LoadVulkanFunctions failed";
                 return;
             }
+
             /// note::
             /// Configure the event on the rendering thread called from CommandBuffer::IssuePluginEventAndData method in
             /// managed code.
             UnityVulkanPluginEventConfig encodeEventConfig;
             encodeEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
-            encodeEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_DontCare;
+            encodeEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
             encodeEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
                 kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
-            vulkan->ConfigureEvent(static_cast<int>(VideoStreamRenderEventID::Encode), &encodeEventConfig);
+
+            UnityVulkanPluginEventConfig releaseBufferEventConfig;
+            releaseBufferEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
+            releaseBufferEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_DontCare;
+            releaseBufferEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
+
+            vulkan->ConfigureEvent(s_renderEventID, &encodeEventConfig);
+            vulkan->ConfigureEvent(s_releaseBuffersEventID, &releaseBufferEventConfig);
         }
 #endif
         s_gfxDevice.reset(GraphicsDevice::GetInstance().Init(s_UnityInterfaces, s_ProfilerMarkerFactory.get()));
@@ -229,6 +239,8 @@ struct EncodeData
 // So, we comment out `DebugLog`.
 static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
 {
+    if (eventID != s_renderEventID)
+        return;
     if (!s_context)
         return;
     if (!ContextManager::GetInstance()->Exists(s_context))
@@ -267,6 +279,8 @@ static void UNITY_INTERFACE_API OnRenderEvent(int eventID, void* data)
 
 static void UNITY_INTERFACE_API OnReleaseBuffers(int eventID, void* data)
 {
+    if (eventID != s_releaseBuffersEventID)
+        return;
     // Release all buffers.
     if (s_bufferPool)
         s_bufferPool->ReleaseStaleBuffers(Timestamp::PlusInfinity(), kStaleFrameLimit);
@@ -278,9 +292,19 @@ extern "C" UnityRenderingEventAndData UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API
     return OnRenderEvent;
 }
 
+extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetRenderEventID()
+{
+    return s_renderEventID;
+}
+
 extern "C" UnityRenderingEventAndData UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetReleaseBuffersFunc(Context* context)
 {
     return OnReleaseBuffers;
+}
+
+extern "C" int UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API GetReleaseBuffersEventID()
+{
+    return s_releaseBuffersEventID;
 }
 
 static void UNITY_INTERFACE_API TextureUpdateCallback(int eventID, void* data)

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -63,7 +63,9 @@ namespace Unity.WebRTC
         private int id;
         private bool disposed;
         private IntPtr renderFunction;
+        private int renderEventID = -1;
         private IntPtr releaseBuffersFunction;
+        private int releaseBuffersEventID = -1;
         private IntPtr textureUpdateFunction;
 
         public static Context Create(int id = 0)
@@ -230,9 +232,19 @@ namespace Unity.WebRTC
             return NativeMethods.GetRenderEventFunc(self);
         }
 
+        public int GetRenderEventID()
+        {
+            return NativeMethods.GetRenderEventID();
+        }
+
         public IntPtr GetReleaseBufferFunc()
         {
             return NativeMethods.GetReleaseBuffersFunc(self);
+        }
+
+        public int GetReleaseBufferEventID()
+        {
+            return NativeMethods.GetReleaseBuffersEventID();
         }
 
         public IntPtr GetUpdateTextureFunc()
@@ -299,13 +311,15 @@ namespace Unity.WebRTC
         internal void Encode(IntPtr ptr)
         {
             renderFunction = renderFunction == IntPtr.Zero ? GetRenderEventFunc() : renderFunction;
-            VideoEncoderMethods.Encode(renderFunction, ptr);
+            renderEventID = renderEventID == -1 ? GetRenderEventID() : renderEventID;
+            VideoEncoderMethods.Encode(renderFunction, renderEventID, ptr);
         }
 
         internal void ReleaseBuffers()
         {
             releaseBuffersFunction = releaseBuffersFunction == IntPtr.Zero ? GetReleaseBufferFunc() : releaseBuffersFunction;
-            VideoEncoderMethods.ReleaseBuffers(releaseBuffersFunction);
+            releaseBuffersEventID = releaseBuffersEventID == -1 ? GetReleaseBufferEventID() : releaseBuffersEventID;
+            VideoEncoderMethods.ReleaseBuffers(releaseBuffersFunction, releaseBuffersEventID);
         }
 
         internal void UpdateRendererTexture(uint rendererId, UnityEngine.Texture texture)

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1465,7 +1465,11 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetRenderEventFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
+        public static extern int GetRenderEventID();
+        [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetReleaseBuffersFunc(IntPtr context);
+        [DllImport(WebRTC.Lib)]
+        public static extern int GetReleaseBuffersEventID();
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
@@ -1526,16 +1530,16 @@ namespace Unity.WebRTC
     {
         static CommandBuffer _command = new CommandBuffer();
 
-        public static void Encode(IntPtr callback, IntPtr data)
+        public static void Encode(IntPtr callback, int eventID, IntPtr data)
         {
-            _command.IssuePluginEventAndData(callback, 0, data);
+            _command.IssuePluginEventAndData(callback, eventID, data);
             Graphics.ExecuteCommandBuffer(_command);
             _command.Clear();
         }
 
-        public static void ReleaseBuffers(IntPtr callback)
+        public static void ReleaseBuffers(IntPtr callback, int eventID)
         {
-            _command.IssuePluginEventAndData(callback, 0, IntPtr.Zero);
+            _command.IssuePluginEventAndData(callback, eventID, IntPtr.Zero);
             Graphics.ExecuteCommandBuffer(_command);
             _command.Clear();
         }

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -339,12 +339,13 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(error, Is.EqualTo(RTCErrorType.None));
 
             var callback = NativeMethods.GetRenderEventFunc(context);
+            int encodeEventID = NativeMethods.GetRenderEventID();
             yield return new WaitForSeconds(1.0f);
 
             VideoTrackSource.EncodeData data = new VideoTrackSource.EncodeData(renderTexture, source);
             IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VideoTrackSource.EncodeData)));
             Marshal.StructureToPtr(data, ptr, true);
-            VideoEncoderMethods.Encode(callback, ptr);
+            VideoEncoderMethods.Encode(callback, encodeEventID, ptr);
             yield return new WaitForSeconds(1.0f);
 
             Marshal.FreeHGlobal(ptr);
@@ -383,6 +384,7 @@ namespace Unity.WebRTC.RuntimeTest
             NativeMethods.VideoTrackAddOrUpdateSink(track, renderer);
 
             var renderEvent = NativeMethods.GetRenderEventFunc(context);
+            int encodeEventID = NativeMethods.GetRenderEventID();
             var updateTextureEvent = NativeMethods.GetUpdateTextureFunc(context);
 
             yield return new WaitForSeconds(1.0f);
@@ -390,7 +392,7 @@ namespace Unity.WebRTC.RuntimeTest
             VideoTrackSource.EncodeData data = new VideoTrackSource.EncodeData(renderTexture, source);
             IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VideoTrackSource.EncodeData)));
             Marshal.StructureToPtr(data, ptr, true);
-            VideoEncoderMethods.Encode(renderEvent, ptr);
+            VideoEncoderMethods.Encode(renderEvent, encodeEventID, ptr);
             yield return new WaitForSeconds(1.0f);
 
             // this method is not supported on Direct3D12


### PR DESCRIPTION
Issue:

Graphics native plugins can reserve an event range to use when issuing their custom events.
Reserving a range allows the plugin to configure their own events and is useful to ensure there is no overlap with other plugins.
Currently, the WebRTC plugin isn't configuring it's own events, and is issuing an event with ID 0. 
This is an issue, as WebRTC should be configuring it's render event to ensure it's excuted outside the render pass, and since it's using a non-reserved ID, any other native graphics plugin could be using the same ID, and configuring it with the wrong settings.

Summary of changes:

This change adds reserving a range of events to use, configuring the events, pushing the eventID through the API, updating unit tests, and checking that events issued have the expected eventID for handling. 

Testing:
Ran unit tests to verify no new issues occur.