### PR TITLE
Fix: Fix Crash on dedicated Linux Server

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -189,8 +189,13 @@ void PluginLoad(IUnityInterfaces* unityInterfaces)
     /// note::
     /// Intercept Vulkan initialization process to hook vulkan functions because vulkan extensions need adding when
     /// initializing vulkan device. This process have to be run before graphics device initialization.
-    auto vulkan = UnityGraphicsVulkan::Get(s_UnityInterfaces);
-    if (!vulkan->AddInterceptInitialization(InterceptVulkanInitialization, nullptr, 0))
+    std::unique_ptr<UnityGraphicsVulkan> vulkan;
+    vulkan = UnityGraphicsVulkan::Get(s_UnityInterfaces);
+    if (!vulkan)
+    {
+        RTC_LOG(LS_INFO) << "Failed to get Vulkan.";
+    }
+    else if (!vulkan->AddInterceptInitialization(InterceptVulkanInitialization, nullptr, 0))
     {
         RTC_LOG(LS_INFO) << "AddInterceptInitialization failed.";
     }


### PR DESCRIPTION
This simple check makes sure that vulkan is actually available and not a nullptr.

It enables dedicated servers to at least run the preload and not crash in the process of running webrtc without graphics initialized.
I didnt test yet to which degree webrtc feature works, but the Audio WebRtc Testscene works now without crash.

Fixes #791 in my case at least.

The reason this crashed is that vulkan is not available on dedicated server build and this function returns a nullptr which is not handled:
https://github.com/Unity-Technologies/com.unity.webrtc/blob/main/Plugin%7E/WebRTCPlugin/UnityVulkanInterfaceFunctions.cpp#L17