### PR TITLE
fix: Change UnityVulkanPluginEventConfig parameters for vulkan API

### DIFF
--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -14,7 +14,7 @@ namespace webrtc
     GpuMemoryBufferHandle::~GpuMemoryBufferHandle() { }
 
     GpuMemoryBufferFromUnity::GpuMemoryBufferFromUnity(
-        IGraphicsDevice* device, NativeTexPtr ptr, const Size& size, UnityRenderingExtTextureFormat format)
+        IGraphicsDevice* device, const Size& size, UnityRenderingExtTextureFormat format)
         : device_(device)
         , format_(format)
         , size_(size)
@@ -36,7 +36,6 @@ namespace webrtc
             handle_ = device_->Map(texture_.get());
         }
 #endif
-        CopyBuffer(ptr);
     }
 
     GpuMemoryBufferFromUnity::~GpuMemoryBufferFromUnity() { }
@@ -56,12 +55,15 @@ namespace webrtc
         return true;
     }
 
-    void GpuMemoryBufferFromUnity::CopyBuffer(NativeTexPtr ptr)
+    bool GpuMemoryBufferFromUnity::CopyBuffer(NativeTexPtr ptr)
     {
         // One texture cannot map CUDA memory and CPU memory simultaneously.
         // Believe there is still room for improvement.
-        device_->CopyResourceFromNativeV(texture_.get(), ptr);
-        device_->CopyResourceFromNativeV(textureCpuRead_.get(), ptr);
+        if (!device_->CopyResourceFromNativeV(texture_.get(), ptr))
+            return false;
+        if (!device_->CopyResourceFromNativeV(textureCpuRead_.get(), ptr))
+            return false;
+        return true;
     }
 
     UnityRenderingExtTextureFormat GpuMemoryBufferFromUnity::GetFormat() const { return format_; }

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.h
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.h
@@ -45,13 +45,12 @@ namespace webrtc
     class GpuMemoryBufferFromUnity : public GpuMemoryBufferInterface
     {
     public:
-        GpuMemoryBufferFromUnity(
-            IGraphicsDevice* device, NativeTexPtr ptr, const Size& size, UnityRenderingExtTextureFormat format);
+        GpuMemoryBufferFromUnity(IGraphicsDevice* device, const Size& size, UnityRenderingExtTextureFormat format);
         GpuMemoryBufferFromUnity(const GpuMemoryBufferFromUnity&) = delete;
         GpuMemoryBufferFromUnity& operator=(const GpuMemoryBufferFromUnity&) = delete;
 
         bool ResetSync();
-        void CopyBuffer(NativeTexPtr ptr);
+        bool CopyBuffer(NativeTexPtr ptr);
         UnityRenderingExtTextureFormat GetFormat() const override;
         Size GetSize() const override;
         rtc::scoped_refptr<I420BufferInterface> ToI420() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -19,7 +19,7 @@ namespace unity
 {
 namespace webrtc
 {
-    static std::unique_ptr<VulkanGraphicsDevice> s_GraphicsDevice = nullptr;
+    static VulkanGraphicsDevice* s_GraphicsDevice = nullptr;
 
     VulkanGraphicsDevice::VulkanGraphicsDevice(
         UnityGraphicsVulkan* unityVulkan,
@@ -46,8 +46,6 @@ namespace webrtc
         if (profiler)
             m_maker = profiler->CreateMarker(
                 "VulkanGraphicsDevice.CopyImage", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
-
-        s_GraphicsDevice.reset(this);
     }
 
     //---------------------------------------------------------------------------------------------------------------------
@@ -56,6 +54,8 @@ namespace webrtc
 #if CUDA_PLATFORM
         m_isCudaSupport = InitCudaContext();
 #endif
+        s_GraphicsDevice = this;
+
         return VK_SUCCESS == CreateCommandPool();
     }
 
@@ -82,7 +82,7 @@ namespace webrtc
 #endif
         VULKAN_SAFE_DESTROY_COMMAND_POOL(m_device, m_commandPool, m_allocator)
 
-        s_GraphicsDevice.reset();
+        s_GraphicsDevice = nullptr;
     }
 
     //---------------------------------------------------------------------------------------------------------------------
@@ -231,7 +231,14 @@ namespace webrtc
             return false;
         }
 
-        m_unityVulkan->AccessQueue(AccessQueueCallback, 0, dest, false);
+        if (m_unityVulkan != nullptr)
+        {
+            m_unityVulkan->AccessQueue(AccessQueueCallback, 0, dest, false);
+        }
+        else
+        {
+            AccessQueueCallback(0, dest);
+        }
 
         return true;
     }
@@ -308,7 +315,14 @@ namespace webrtc
             return false;
         }
 
-        m_unityVulkan->AccessQueue(AccessQueueCallback, 0, dest, false);
+        if (m_unityVulkan != nullptr)
+        {
+            m_unityVulkan->AccessQueue(AccessQueueCallback, 0, dest, false);
+        }
+        else
+        {
+            AccessQueueCallback(0, dest);
+        }
 
         return true;
     }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -318,7 +318,7 @@ namespace webrtc
         VkCommandPoolCreateInfo poolInfo = {};
         poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
         poolInfo.queueFamilyIndex = m_queueFamilyIndex;
-        poolInfo.flags = 0;
+        poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
         return vkCreateCommandPool(m_device, &poolInfo, m_allocator, &m_commandPool);
     }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -66,6 +66,7 @@ namespace webrtc
 #endif
     private:
         VkResult CreateCommandPool();
+        static void AccessQueueCallback(int eventID, void* data);
 
         UnityGraphicsVulkan* m_unityVulkan;
         VkPhysicalDevice m_physicalDevice;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -67,7 +67,7 @@ namespace webrtc
     private:
         VkResult CreateCommandPool();
         static void AccessQueueCallback(int eventID, void* data);
-
+        static VulkanGraphicsDevice* m_graphicsInstance;
         UnityGraphicsVulkan* m_unityVulkan;
         VkPhysicalDevice m_physicalDevice;
         VkDevice m_device;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -104,18 +104,16 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             /// Configure the event on the rendering thread called from CommandBuffer::IssuePluginEventAndData method in
             /// managed code.
             UnityVulkanPluginEventConfig encodeEventConfig;
-            encodeEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_Allow;
+            encodeEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
             encodeEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
             encodeEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
-                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState |
-                kUnityVulkanEventConfigFlag_FlushCommandBuffers;
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
 
             UnityVulkanPluginEventConfig releaseBufferEventConfig;
-            releaseBufferEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_Allow;
+            releaseBufferEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
             releaseBufferEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
             releaseBufferEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
-                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState |
-                kUnityVulkanEventConfigFlag_FlushCommandBuffers;
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
 
             vulkan->ConfigureEvent(s_renderEventID, &encodeEventConfig);
             vulkan->ConfigureEvent(s_releaseBuffersEventID, &releaseBufferEventConfig);

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -30,7 +30,7 @@ namespace webrtc
     static std::map<const uint32_t, std::shared_ptr<UnityVideoRenderer>> s_mapVideoRenderer;
     static std::unique_ptr<Clock> s_clock;
 
-    static const size_t kLimitBufferCount = 10;
+    static const size_t kLimitBufferCount = 20;
     static constexpr TimeDelta kStaleFrameLimit = TimeDelta::Seconds(10);
     static const UnityProfilerMarkerDesc* s_MarkerEncode = nullptr;
     static const UnityProfilerMarkerDesc* s_MarkerDecode = nullptr;

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -104,16 +104,18 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             /// Configure the event on the rendering thread called from CommandBuffer::IssuePluginEventAndData method in
             /// managed code.
             UnityVulkanPluginEventConfig encodeEventConfig;
-            encodeEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
+            encodeEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_Allow;
             encodeEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
             encodeEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
-                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState |
+                kUnityVulkanEventConfigFlag_FlushCommandBuffers;
 
             UnityVulkanPluginEventConfig releaseBufferEventConfig;
-            releaseBufferEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
-            releaseBufferEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_DontCare;
+            releaseBufferEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_Allow;
+            releaseBufferEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
             releaseBufferEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
-                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState |
+                kUnityVulkanEventConfigFlag_FlushCommandBuffers;
 
             vulkan->ConfigureEvent(s_renderEventID, &encodeEventConfig);
             vulkan->ConfigureEvent(s_releaseBuffersEventID, &releaseBufferEventConfig);

--- a/Plugin~/WebRTCPlugin/VideoFrameUtil.cpp
+++ b/Plugin~/WebRTCPlugin/VideoFrameUtil.cpp
@@ -18,13 +18,15 @@ namespace webrtc
         NativeTexPtr ptr = NativeTexPtr(texture->GetNativeTexturePtrV());
         Size size = Size(static_cast<int>(texture->GetWidth()), static_cast<int>(texture->GetHeight()));
 
-        rtc::scoped_refptr<GpuMemoryBufferInterface> gmb =
-            rtc::make_ref_counted<GpuMemoryBufferFromUnity>(device, ptr, size, format);
+        auto buffer = rtc::make_ref_counted<GpuMemoryBufferFromUnity>(device, size, format);
+
+        if (!buffer->CopyBuffer(ptr))
+            return nullptr;
 
         const int64_t timestamp_us = webrtc::Clock::GetRealTimeClock()->TimeInMicroseconds();
 
         return VideoFrame::WrapExternalGpuMemoryBuffer(
-            size, std::move(gmb), nullptr, webrtc::TimeDelta::Micros(timestamp_us));
+            size, std::move(buffer), nullptr, webrtc::TimeDelta::Micros(timestamp_us));
     }
 
 } // end namespace webrtc


### PR DESCRIPTION
This PR fixes the performance issue of video streaming when using vulkan graphics API on Linux with Unity 2022.2.

This issue is able to replicated by this condition below.

- Ubuntu 20.04
- Unity 2022.2 (Unity 2022.1 works fine)
- Use the samples of Unity Render Streaming
- Stream a video from Broadcast sample and receive a video streaming on Browser
- Any video codecs
- Build runtime (Not reproduced the issue on Unity Editor)
- Vulkan graphics API

The cause of this issue is handling errors occurred by vulkan synchronization between GPU and CPU. In addition, The timing of accessing rendering queue is another reason. We fixed the timing with callback of `UnityVulkanInterface::AccessQueue`.