### PR TITLE
Fix cuda resource leak

### DIFF
--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -38,7 +38,13 @@ namespace webrtc
 #endif
     }
 
-    GpuMemoryBufferFromUnity::~GpuMemoryBufferFromUnity() { }
+    GpuMemoryBufferFromUnity::~GpuMemoryBufferFromUnity()
+    {
+        // Make sure handle_ is released first
+        handle_ = nullptr;
+        texture_ = nullptr;
+        textureCpuRead_ = nullptr;
+    }
 
     bool GpuMemoryBufferFromUnity::ResetSync()
     {

--- a/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBufferPool.cpp
@@ -86,17 +86,17 @@ namespace webrtc
     void GpuMemoryBufferPool::ReleaseStaleBuffers(Timestamp now, TimeDelta timeLimit)
     {
         auto it = resourcesPool_.begin();
-        while (it != resourcesPool_.end())
+        for (; it != resourcesPool_.end();)
         {
             FrameResources* resources = (*it).get();
 
             if (!resources->IsUsed() && now - resources->lastUseTime() > timeLimit)
             {
-                resourcesPool_.erase(it++);
+                it = resourcesPool_.erase(it);
             }
             else
             {
-                it++;
+                ++it;
             }
         }
     }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.h
@@ -38,7 +38,7 @@ namespace webrtc
         // This method returns context for the thread which called the method.
         CUcontext GetContext() const;
 
-        static CUresult FindCudaDevice(const uint8_t* uuid, CUdevice* cuDevice);
+        static CUresult FindCudaDevice(const uint8_t* uuid, CUdevice* device);
 
     private:
         CUcontext m_context;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h
@@ -4,6 +4,40 @@
 
 #include "GpuMemoryBuffer.h"
 
+#define __GMB_CUDA_CALL(call, ret)                                                                                     \
+    CUresult err__ = call;                                                                                             \
+    if (err__ != CUDA_SUCCESS)                                                                                         \
+    {                                                                                                                  \
+        const char* szErrName = NULL;                                                                                  \
+        cuGetErrorName(err__, &szErrName);                                                                             \
+        RTC_LOG(LS_ERROR) << "GpuMemoryBufferCudaHandle error " << szErrName;                                          \
+        return ret;                                                                                                    \
+    }
+
+#define GMB_CUDA_CALL(call)                                                                                            \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        __GMB_CUDA_CALL(call, ;);                                                                                      \
+    } while (0)
+
+#define GMB_CUDA_CALL_ERROR(call)                                                                                      \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        __GMB_CUDA_CALL(call, err__);                                                                                  \
+    } while (0)
+
+#define GMB_CUDA_CALL_NULLPTR(call)                                                                                    \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        __GMB_CUDA_CALL(call, nullptr);                                                                                \
+    } while (0)
+
+#define GMB_CUDA_CALL_THROW(call)                                                                                      \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        __GMB_CUDA_CALL(call, throw);                                                                                  \
+    } while (0)
+
 namespace unity
 {
 namespace webrtc
@@ -16,7 +50,7 @@ namespace webrtc
         virtual ~GpuMemoryBufferCudaHandle() override;
 
         CUcontext context;
-        CUarray array;
+        CUmipmappedArray mipmappedArray;
         CUarray mappedArray;
         CUdeviceptr mappedPtr;
         CUgraphicsResource resource;


### PR DESCRIPTION
Mostly just code cleanups for CUDA handling, but should fix resource leaks for D3D12/Vulkan that use mipmappedArray. M92 era branch used to handle calling cuMipmappedArrayDestroy

Can't be sure if this alone fixes all the leaks I've seen, as I'm still using custom frame pooling, scheduling and vulkan changes on my branch, but have to start from somewhere.
