### PR TITLE
fix: Fix Workaround for a crash issue that EncodedTransform APIs on Android platform 

### DIFF
--- a/Plugin~/WebRTCPlugin/Logger.cpp
+++ b/Plugin~/WebRTCPlugin/Logger.cpp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
 #include "pch.h"
 
 #include "WebRTCPlugin.h"
@@ -45,3 +47,4 @@ namespace webrtc
 
 } // end namespace webrtc
 } // end namespace unity
+#pragma clang diagnostic pop

--- a/Runtime/Scripts/RTCRtpTransform.cs
+++ b/Runtime/Scripts/RTCRtpTransform.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
+using System.Runtime.CompilerServices;
 
 namespace Unity.WebRTC
 {
@@ -109,13 +110,19 @@ namespace Unity.WebRTC
         ///
         /// </summary>
         /// <returns></returns>
+#if UNITY_ANDROID
+        // todo: Optimizing for Android platform leads a crash issue.
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+#endif
         public NativeArray<byte>.ReadOnly GetData()
         {
             NativeMethods.FrameGetData(self, out var data, out var size);
+
             unsafe
             {
-                 var arr = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<byte>(
-                     data.ToPointer(), size, Allocator.None);
+                var arr = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<byte>(
+                    data.ToPointer(), size, Allocator.None);
+
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
                 NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref arr, AtomicSafetyHandle.Create());
 #endif
@@ -205,7 +212,7 @@ namespace Unity.WebRTC
             return new RTCEncodedVideoFrameMetadata(data);
         }
 
-        internal RTCEncodedVideoFrame(IntPtr ptr) : base(ptr) {}
+        internal RTCEncodedVideoFrame(IntPtr ptr) : base(ptr) { }
     };
 
     /// <summary>


### PR DESCRIPTION
This is workaround for Android platform. 

Add an attribute `MethodImpl(MethodImplOptions.NoOptimization)` to **RTCEncodedFrame.GetData** method to avoid a crash issue.