### PR TITLE
fix: Fix MSVC compiler support on CLion

### DIFF
--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(WebRTCLib STATIC)
 
+target_precompile_headers(WebRTCLib PRIVATE pch.h)
+
 target_sources(
   WebRTCLib
   PRIVATE Context.cpp
@@ -121,8 +123,6 @@ if(Windows)
 endif()
 
 if(Windows)
-  # Use precompiled header
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Yu /Yupch.h")
   set(PROJECT_BINARY_DIR "${CMAKE_SOURCE_DIR}/../Runtime/Plugins/x86_64")
 
   target_compile_definitions(WebRTCLib PUBLIC WEBRTC_WIN NOMINMAX
@@ -149,9 +149,6 @@ if(Windows)
   set_target_properties(
     WebRTCLib PROPERTIES MSVC_RUNTIME_LIBRARY
                          "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-
-  # Creare precompiled header
-  set_source_files_properties(pch.cpp PROPERTIES COMPILE_FLAGS "/Yc /Ycpch.h")
 elseif(macOS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -x objective-c")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lto -fno-rtti")

--- a/Plugin~/WebRTCPlugin/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_library(WebRTCLib STATIC)
 
-target_precompile_headers(WebRTCLib PRIVATE pch.h)
-
 target_sources(
   WebRTCLib
   PRIVATE Context.cpp
@@ -108,6 +106,7 @@ add_subdirectory(Codec)
 add_subdirectory(GraphicsDevice)
 
 if(Windows)
+  target_precompile_headers(WebRTCLib PRIVATE pch.h)
   # Force to always compile with W4
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(WebRTCLibTest)
 
+target_precompile_headers(WebRTCLibTest PRIVATE pch.h)
+
 target_sources(
   WebRTCLibTest
   PRIVATE pch.cpp
@@ -84,8 +86,6 @@ else()
 endif()
 
 if(Windows)
-  # Use precompiled header
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Yu /Yupch.h")
   target_link_libraries(
     WebRTCLibTest
     PRIVATE ${WEBRTC_LIBRARY}
@@ -109,8 +109,7 @@ if(Windows)
   target_include_directories(
     WebRTCLibTest PRIVATE ${CUDA_INCLUDE_DIRS} ${Vulkan_INCLUDE_DIR}
                           ${NVCODEC_INCLUDE_DIR})
-  # Creare precompiled header
-  set_source_files_properties(pch.cpp PROPERTIES COMPILE_FLAGS "/Yc /Ycpch.h")
+
   set_target_properties(
     WebRTCLibTest
     PROPERTIES

--- a/Plugin~/WebRTCPluginTest/CMakeLists.txt
+++ b/Plugin~/WebRTCPluginTest/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_executable(WebRTCLibTest)
 
-target_precompile_headers(WebRTCLibTest PRIVATE pch.h)
-
 target_sources(
   WebRTCLibTest
   PRIVATE pch.cpp
@@ -86,6 +84,7 @@ else()
 endif()
 
 if(Windows)
+  target_precompile_headers(WebRTCLibTest PRIVATE pch.h)
   target_link_libraries(
     WebRTCLibTest
     PRIVATE ${WEBRTC_LIBRARY}


### PR DESCRIPTION
This issue is reported from users below.
#892
#906

This PR use CMake command `target_precompile_headers` which is supported since CMake 3.16.