### PR TITLE
Command buffer batching

### DIFF
--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -270,6 +270,10 @@ static void UNITY_INTERFACE_API OnBatchUpdateEvent(int eventID, void* data)
         return;
     }
 
+    IGraphicsDevice* device = Plugin::GraphicsDevice();
+    UnityGfxRenderer gfxRenderer = device->GetGfxRenderer();
+    Timestamp timestamp = s_clock->CurrentTime();
+
     for (int i = 0; i < batchData->tracksCount; i++)
     {
         VideoStreamTrackData* trackData = batchData->tracks[i];
@@ -291,9 +295,7 @@ static void UNITY_INTERFACE_API OnBatchUpdateEvent(int eventID, void* data)
                 continue;
             }
 
-            Timestamp timestamp = s_clock->CurrentTime();
-            IGraphicsDevice* device = Plugin::GraphicsDevice();
-            UnityGfxRenderer gfxRenderer = device->GetGfxRenderer();
+            timestamp = s_clock->CurrentTime();
             void* ptr = GraphicsUtility::TextureHandleToNativeGraphicsPtr(trackData->texture, device, gfxRenderer);
             unity::webrtc::Size size(trackData->width, trackData->height);
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -90,6 +90,9 @@ namespace Unity.WebRTC
             const int roundedCapacity = 32;
             int totalCapacity = ((totalTracks + roundedCapacity) / roundedCapacity) * roundedCapacity;
 
+            if (ptr != IntPtr.Zero && data.tracks.Length >= totalCapacity)
+                return;
+
             data.tracksCount = 0;
             data.tracks = new IntPtr[totalCapacity];
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -57,9 +57,11 @@ namespace Unity.WebRTC
 
     internal class Batch
     {
+        [StructLayout(LayoutKind.Sequential)]
         public struct BatchData
         {
             public int tracksCount;
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=0)]
             public IntPtr[] tracks;
         }
 

--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -1,3 +1,6 @@
+// Update textures through built-in Unity plugin interface (CPU buffer upload in render thread)
+#define USE_UNITY_RENDERING_EXT_UPDATE_TEXTURE
+
 using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
@@ -21,8 +24,28 @@ namespace Unity.WebRTC
         internal static ConcurrentDictionary<IntPtr, WeakReference<VideoStreamTrack>> s_tracks =
             new ConcurrentDictionary<IntPtr, WeakReference<VideoStreamTrack>>();
 
+        public enum VideoStreamTrackAction
+        {
+            Ignore = 0,
+            Decode = 1,
+            Encode = 2
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct VideoStreamTrackData
+        {
+            public VideoStreamTrackAction action;
+            public IntPtr ptrTexture;
+            public IntPtr ptrSource;
+            public int width;
+            public int height;
+            public GraphicsFormat format;
+        }
+
         UnityVideoRenderer m_renderer;
         VideoTrackSource m_source;
+        VideoStreamTrackData m_data;
+        IntPtr m_dataptr = IntPtr.Zero;
 
         private static RenderTexture CreateRenderTexture(int width, int height)
         {
@@ -46,18 +69,62 @@ namespace Unity.WebRTC
         }
 
         /// <summary>
+        /// encoded / decoded texture ptr
+        /// </summary>
+        public IntPtr TexturePtr
+        {
+            get
+            {
+                if (m_renderer != null)
+                    return m_renderer.TexturePtr;
+                return m_source.destTexturePtr_;
+            }
+        }
+
+        public bool Decoding => m_renderer != null;
+        public bool Encoding => m_source != null;
+        public IntPtr DataPtr => m_dataptr;
+
+
+        /// <summary>
         ///
         /// </summary>
         public event OnVideoReceived OnVideoReceived;
 
-        internal void UpdateReceiveTexture()
+        internal void UpdateTexture()
         {
-            m_renderer?.Update();
-        }
+            var texture = Texture;
+            if (texture == null)
+                return;
 
-        internal void UpdateSendTexture()
-        {
             m_source?.Update();
+#if USE_UNITY_RENDERING_EXT_UPDATE_TEXTURE
+            m_renderer?.Update();
+#endif
+
+            var texturePtr = TexturePtr;
+            if (m_data.ptrTexture != texturePtr)
+            {
+                m_data.ptrTexture = texturePtr;
+                m_data.ptrSource = IntPtr.Zero;
+                m_data.action = VideoStreamTrackAction.Ignore;
+                if (Encoding == true)
+                {
+                    m_data.ptrSource = (IntPtr)m_source?.self;
+                    m_data.action = VideoStreamTrackAction.Encode;
+                }
+#if !USE_UNITY_RENDERING_EXT_UPDATE_TEXTURE
+                else if (Decoding == true)
+                {
+                    m_data.ptrSource = (IntPtr)m_renderer?.self;
+                    m_data.action = VideoStreamTrackAction.Decode;
+                }
+#endif
+                m_data.width = texture.width;
+                m_data.height = texture.height;
+                m_data.format = texture.graphicsFormat;
+                Marshal.StructureToPtr(m_data, m_dataptr, false);
+            }
         }
 
         /// <summary>
@@ -72,11 +139,15 @@ namespace Unity.WebRTC
             if (!s_tracks.TryAdd(self, new WeakReference<VideoStreamTrack>(this)))
                 throw new InvalidOperationException();
 
+            m_dataptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VideoStreamTrackData)));
+            Marshal.StructureToPtr(m_data, m_dataptr, false);
+
             var dest = CreateRenderTexture(texture.width, texture.height);
 
             m_source = source;
             m_source.sourceTexture_ = texture;
             m_source.destTexture_ = dest;
+            m_source.destTexturePtr_ = dest.GetNativeTexturePtr();
             m_source.needFlip_ = needFlip;
         }
 
@@ -89,6 +160,9 @@ namespace Unity.WebRTC
         {
             if (!s_tracks.TryAdd(self, new WeakReference<VideoStreamTrack>(this)))
                 throw new InvalidOperationException();
+
+            m_dataptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(VideoStreamTrackData)));
+            Marshal.StructureToPtr(m_data, m_dataptr, false);
 
             m_renderer = new UnityVideoRenderer(this, true);
         }
@@ -107,6 +181,17 @@ namespace Unity.WebRTC
             {
                 m_renderer?.Dispose();
                 m_source?.Dispose();
+
+                if (m_dataptr != IntPtr.Zero)
+                {
+                    // This buffer is referred from the rendering thread,
+                    // so set the delay 100ms to wait the task of another thread.
+                    WebRTC.DelayActionOnMainThread(() =>
+                    {
+                        Marshal.FreeHGlobal(m_dataptr);
+                        m_dataptr = IntPtr.Zero;
+                    }, 0.1f);
+                }
 
                 s_tracks.TryRemove(self, out var value);
             }
@@ -233,25 +318,6 @@ namespace Unity.WebRTC
 
     internal class VideoTrackSource : RefCountedObject
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct EncodeData
-        {
-            public IntPtr ptrTexture;
-            public IntPtr ptrTrackSource;
-            public int width;
-            public int height;
-            public GraphicsFormat format;
-
-            public EncodeData(Texture texture, IntPtr ptrSource)
-            {
-                ptrTexture = texture.GetNativeTexturePtr();
-                ptrTrackSource = ptrSource;
-                width = texture.width;
-                height = texture.height;
-                format = texture.graphicsFormat;
-            }
-        }
-
         // Blit parameter to flip vertically
         static Vector2 s_scale = new Vector2(1f, -1f);
         static Vector2 s_offset = new Vector2(0, 1f);
@@ -259,16 +325,12 @@ namespace Unity.WebRTC
         internal bool needFlip_ = false;
         internal Texture sourceTexture_;
         internal RenderTexture destTexture_;
-
-        IntPtr ptr_ = IntPtr.Zero;
-        EncodeData data_;
-        Texture prevTexture_;
+        internal IntPtr destTexturePtr_;
 
         public VideoTrackSource()
             : base(WebRTC.Context.CreateVideoTrackSource())
         {
             WebRTC.Table.Add(self, this);
-            ptr_ = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(EncodeData)));
         }
 
         ~VideoTrackSource()
@@ -291,16 +353,6 @@ namespace Unity.WebRTC
             {
                 Graphics.Blit(sourceTexture_, destTexture_);
             }
-
-            // todo:: This comparison is not sufficiency but it is for workaround of freeze bug.
-            // Texture.GetNativeTexturePtr method freezes Unity Editor on apple silicon.
-            if (prevTexture_ != destTexture_)
-            {
-                data_ = new EncodeData(destTexture_, self);
-                Marshal.StructureToPtr(data_, ptr_, true);
-                prevTexture_ = destTexture_;
-            }
-            WebRTC.Context.Encode(ptr_);
         }
 
         public override void Dispose()
@@ -316,16 +368,6 @@ namespace Unity.WebRTC
             // This texture is referred from the rendering thread,
             // so set the delay 100ms to wait the task of another thread.
             WebRTC.DestroyOnMainThread(destTexture_, 0.1f);
-
-            if (ptr_ != IntPtr.Zero)
-            {
-                // This buffer is referred from the rendering thread,
-                // so set the delay 100ms to wait the task of another thread.
-                WebRTC.DelayActionOnMainThread(() =>
-                {
-                    Marshal.FreeHGlobal(ptr_);
-                }, 0.1f);
-            }
 
             if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
             {
@@ -344,6 +386,7 @@ namespace Unity.WebRTC
         private bool disposed;
 
         public Texture Texture { get; private set; }
+        public IntPtr TexturePtr { get; private set; }
 
         public UnityVideoRenderer(VideoStreamTrack track, bool needFlip)
         {
@@ -353,12 +396,14 @@ namespace Unity.WebRTC
             WebRTC.Table.Add(self, this);
         }
 
+#if USE_UNITY_RENDERING_EXT_UPDATE_TEXTURE
         public void Update()
         {
             if (Texture == null)
                 return;
             WebRTC.Context.UpdateRendererTexture(id, Texture);
         }
+#endif
 
         ~UnityVideoRenderer()
         {
@@ -380,6 +425,7 @@ namespace Unity.WebRTC
                     NativeMethods.VideoTrackRemoveSink(trackPtr, self);
                 }
                 WebRTC.DestroyOnMainThread(Texture);
+                TexturePtr = IntPtr.Zero;
                 WebRTC.Context.DeleteVideoRenderer(self);
                 WebRTC.Table.Remove(self);
                 self = IntPtr.Zero;
@@ -402,10 +448,12 @@ namespace Unity.WebRTC
             {
                 WebRTC.DestroyOnMainThread(Texture);
                 Texture = null;
+                TexturePtr = IntPtr.Zero;
             }
 
             var format = WebRTC.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
             Texture = new Texture2D(width, height, format, TextureCreationFlags.None);
+            TexturePtr = Texture.GetNativeTexturePtr();
             track.OnVideoFrameResize(Texture);
         }
 

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1601,9 +1601,9 @@ namespace Unity.WebRTC
             _command.Clear();
         }
 
-        public static void BatchUpdate(IntPtr callback, int eventID, IntPtr tracks)
+        public static void BatchUpdate(IntPtr callback, int eventID, IntPtr batchData)
         {
-            _command.IssuePluginEventAndData(callback, eventID, tracks);
+            _command.IssuePluginEventAndData(callback, eventID, batchData);
         }
 
         public static void UpdateRendererTexture(IntPtr callback, Texture texture, uint rendererId)

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1044,7 +1044,7 @@ namespace Unity.WebRTC
         [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
         static void DebugLog(string str)
         {
-            Debug.Log(str);
+            UnityEngine.Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, "{0}", str);
         }
 
         [AOT.MonoPInvokeCallback(typeof(DelegateSetLocalDescription))]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -701,13 +701,10 @@ namespace Unity.WebRTC
                     var tempTextureActive = RenderTexture.active;
                     RenderTexture.active = null;
 
-                    int trackIndex = 0;
-                    int totalTracks = VideoStreamTrack.s_tracks.Count;
                     var batch = Context.batch;
+                    batch.ResizeCapacity(VideoStreamTrack.s_tracks.Count);
 
-                    if (batch.data.tracks.Length < totalTracks)
-                        batch.ResizeCapacity(totalTracks);
-
+                    int trackIndex = 0;
                     foreach (var reference in VideoStreamTrack.s_tracks.Values)
                     {
                         if (!reference.TryGetTarget(out var track))

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -700,13 +700,31 @@ namespace Unity.WebRTC
                 {
                     var tempTextureActive = RenderTexture.active;
                     RenderTexture.active = null;
+
+                    int trackIndex = 0;
+                    int totalTracks = VideoStreamTrack.s_tracks.Count;
+                    var batch = Context.batch;
+
+                    if (batch.data.tracks.Length < totalTracks)
+                        batch.ResizeCapacity(totalTracks);
+
                     foreach (var reference in VideoStreamTrack.s_tracks.Values)
                     {
                         if (!reference.TryGetTarget(out var track))
                             continue;
-                        track.UpdateSendTexture();
-                        track.UpdateReceiveTexture();
+
+                        track.UpdateTexture();
+                        if (track.DataPtr != IntPtr.Zero)
+                        {
+                            batch.data.tracks[trackIndex] = track.DataPtr;
+                            trackIndex++;
+                        }
                     }
+
+                    batch.data.tracksCount = trackIndex;
+                    if (trackIndex > 0)
+                        batch.Submit();
+
                     RenderTexture.active = tempTextureActive;
                 }
             }
@@ -1493,13 +1511,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern void SetCurrentContext(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern IntPtr GetRenderEventFunc(IntPtr context);
+        public static extern IntPtr GetBatchUpdateEventFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern int GetRenderEventID();
-        [DllImport(WebRTC.Lib)]
-        public static extern IntPtr GetReleaseBuffersFunc(IntPtr context);
-        [DllImport(WebRTC.Lib)]
-        public static extern int GetReleaseBuffersEventID();
+        public static extern int GetBatchUpdateEventID();
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
@@ -1572,28 +1586,25 @@ namespace Unity.WebRTC
 
     }
 
-    internal static class VideoEncoderMethods
+    internal static class VideoUpdateMethods
     {
         static CommandBuffer _command = new CommandBuffer();
 
-        public static void Encode(IntPtr callback, int eventID, IntPtr data)
+        static VideoUpdateMethods()
         {
-            _command.IssuePluginEventAndData(callback, eventID, data);
+            _command.name = "WebRTC";
+        }
+
+        public static void Flush()
+        {
             Graphics.ExecuteCommandBuffer(_command);
             _command.Clear();
         }
 
-        public static void ReleaseBuffers(IntPtr callback, int eventID)
+        public static void BatchUpdate(IntPtr callback, int eventID, IntPtr tracks)
         {
-            _command.IssuePluginEventAndData(callback, eventID, IntPtr.Zero);
-            Graphics.ExecuteCommandBuffer(_command);
-            _command.Clear();
+            _command.IssuePluginEventAndData(callback, eventID, tracks);
         }
-    }
-
-    internal static class VideoDecoderMethods
-    {
-        static UnityEngine.Rendering.CommandBuffer _command = new UnityEngine.Rendering.CommandBuffer();
 
         public static void UpdateRendererTexture(IntPtr callback, Texture texture, uint rendererId)
         {
@@ -1606,8 +1617,6 @@ namespace Unity.WebRTC
             }
 #endif
             _command.IssuePluginCustomTextureUpdateV2(callback, texture, rendererId);
-            Graphics.ExecuteCommandBuffer(_command);
-            _command.Clear();
         }
     }
 }

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -21,7 +21,7 @@ namespace Unity.WebRTC.RuntimeTest
     }
 
     [TestFixture]
-    [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxPlayer })]
+    [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.OSXEditor, RuntimePlatform.LinuxPlayer })]
     [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
     class VideoReceiveTestWithVP8Codec : VideoReceiveTestBase
     {
@@ -100,6 +100,7 @@ namespace Unity.WebRTC.RuntimeTest
 
                 yield return new WaitUntilWithTimeout(() => receiveVideoTrack.Texture != null, 15000);
                 Assert.That(receiveVideoTrack.Texture, Is.Not.Null);
+
                 test.component.Clear();
             }
 
@@ -129,6 +130,7 @@ namespace Unity.WebRTC.RuntimeTest
         int width;
         int height;
         RTCRtpCodecCapability videoCodec;
+        Coroutine coroutine;
 
         void Start()
         {
@@ -136,7 +138,11 @@ namespace Unity.WebRTC.RuntimeTest
             cam = camObj.AddComponent<Camera>();
 
             IsTestFinished = true;
+
+            coroutine = StartCoroutine(WebRTC.Update());
         }
+
+
 
         public void SetResolution(int width, int height)
         {
@@ -209,16 +215,11 @@ namespace Unity.WebRTC.RuntimeTest
             Clear();
             DestroyImmediate(camObj);
             camObj = null;
+            StopCoroutine(coroutine);
         }
 
         private void Update()
         {
-            foreach (var reference in VideoStreamTrack.s_tracks.Values)
-            {
-                if (!reference.TryGetTarget(out var track))
-                    continue;
-                track.UpdateTexture();
-            }
         }
 
         public IEnumerator Signaling()

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -73,7 +73,7 @@ namespace Unity.WebRTC.RuntimeTest
         [UnityTest, LongRunning]
         [Timeout(15000)]
         [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformVideoDecoder,
-            "VideoStreamTrack.UpdateReceiveTexture is not supported on Direct3D12")]
+            "VideoStreamTrack.UpdateTexture is not supported on Direct3D12 for decoder")]
         [ConditionalIgnoreMultiple(ConditionalIgnore.UnsupportedPlatformOpenGL,
             "Not support VideoStreamTrack for OpenGL")]
         public IEnumerator VideoReceive([ValueSource(nameof(range))]int index)
@@ -217,8 +217,7 @@ namespace Unity.WebRTC.RuntimeTest
             {
                 if (!reference.TryGetTarget(out var track))
                     continue;
-                track.UpdateSendTexture();
-                track.UpdateReceiveTexture();
+                track.UpdateTexture();
             }
         }
 


### PR DESCRIPTION
I've had some use cases where I'm dealing with multiple recv/send video tracks and it's hard to profile how much time is spent in total when there's multiple command buffer submissions. It'll save some main/render thread processing time if we just submit the requests in batches. If needed to, you could do "once a frame" bookkeeping on the native side, flush, etc.

- Add `WebRTC` label for command buffer
- CPU texture updates through standard Unity plugin interface are simple and ok, but it doesn't scale if you need more performance or deal with multiple tracks. Lay out small groundwork for doing texture updates manually, but the actual changes to video renderer and GraphicsDevice will need to wait another day :) Basically it's uploading to CPU staging texture off render thread and only doing a native texture blit in the render thread for performance. There should be some opportunities to avoid CPU buffers entirely with hardware decoder support.
- WebRTC logging messages coming out from native side don't really benefit from printing out stack traces in developer builds, disable stack trace
