### PR TITLE
refactor: Remove accessing the legacy interface in DX12

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <comdef.h>
-#include <d3d11_4.h>
 #include <d3d12.h>
 #include <stdexcept>
 #include <wrl/client.h>
@@ -12,11 +11,12 @@
 #include "GraphicsDevice/Cuda/CudaContext.h"
 #include "GraphicsDevice/IGraphicsDevice.h"
 
+using namespace Microsoft::WRL;
+
 namespace unity
 {
 namespace webrtc
 {
-    using namespace Microsoft::WRL;
     namespace webrtc = ::webrtc;
 
 #define DefPtr(_a) _COM_SMARTPTR_TYPEDEF(_a, __uuidof(_a))
@@ -97,11 +97,6 @@ namespace webrtc
         ComPtr<ID3D12Device> m_d3d12Device;
         ComPtr<ID3D12CommandQueue> m_d3d12CommandQueue;
 
-        //[Note-sin: 2019-10-30] sharing res from d3d12 to d3d11 require d3d11.1. Fence is supported in d3d11.4 or
-        // newer.
-        ComPtr<ID3D11Device5> m_d3d11Device;
-        ComPtr<ID3D11DeviceContext4> m_d3d11Context;
-
         bool m_isCudaSupport;
         CudaContext m_cudaContext;
 
@@ -113,15 +108,12 @@ namespace webrtc
         ComPtr<ID3D12Fence> m_copyResourceFence;
         HANDLE m_copyResourceEventHandle;
         uint64_t m_copyResourceFenceValue = 1;
-
-        CUcontext m_context;
-        CUdevice m_device;
     };
 
     //---------------------------------------------------------------------------------------------------------------------
 
     // use D3D11. See notes below
-    void* D3D12GraphicsDevice::GetEncodeDevicePtrV() { return reinterpret_cast<void*>(m_d3d11Device.Get()); }
+    void* D3D12GraphicsDevice::GetEncodeDevicePtrV() { return reinterpret_cast<void*>(m_d3d12Device.Get()); }
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
@@ -13,8 +13,7 @@ namespace webrtc
 
     //---------------------------------------------------------------------------------------------------------------------
 
-    D3D12Texture2D::D3D12Texture2D(
-        uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
+    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(handle)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
@@ -14,11 +14,10 @@ namespace webrtc
     //---------------------------------------------------------------------------------------------------------------------
 
     D3D12Texture2D::D3D12Texture2D(
-        uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle, ID3D11Texture2D* sharedTex)
+        uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(handle)
-        , m_sharedTexture(sharedTex)
         , m_readbackResource(nullptr)
     {
     }
@@ -27,7 +26,7 @@ namespace webrtc
 
     HRESULT D3D12Texture2D::CreateReadbackResource(ID3D12Device* device)
     {
-        SAFE_RELEASE(m_readbackResource)
+        m_readbackResource.Reset();
 
         D3D12_RESOURCE_DESC origDesc = m_nativeTexture->GetDesc();
         device->GetCopyableFootprints(

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
@@ -19,10 +19,7 @@ namespace webrtc
     public:
         D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle);
 
-        virtual ~D3D12Texture2D() override
-        {
-            CloseHandle(m_sharedHandle);
-        }
+        virtual ~D3D12Texture2D() override { CloseHandle(m_sharedHandle); }
 
         inline void* GetNativeTexturePtrV() override;
         inline const void* GetNativeTexturePtrV() const override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
@@ -1,28 +1,27 @@
 #pragma once
 
-#include <d3d11.h>
+#include <d3d12.h>
+#include <wrl/client.h>
 
 #include "D3D12ResourceFootprint.h"
 #include "GraphicsDevice/ITexture2D.h"
 #include "PlatformBase.h"
 #include "WebRTCMacros.h"
 
+using namespace Microsoft::WRL;
+
 namespace unity
 {
 namespace webrtc
 {
-
     class D3D12Texture2D : public ITexture2D
     {
     public:
-        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle, ID3D11Texture2D* sharedTex);
+        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle);
 
         virtual ~D3D12Texture2D() override
         {
-            SAFE_RELEASE(m_readbackResource)
-            SAFE_RELEASE(m_sharedTexture)
             CloseHandle(m_sharedHandle);
-            SAFE_RELEASE(m_nativeTexture)
         }
 
         inline void* GetNativeTexturePtrV() override;
@@ -36,23 +35,20 @@ namespace webrtc
         D3D12_RESOURCE_DESC GetDesc() const { return m_nativeTexture->GetDesc(); }
 
     private:
-        ID3D12Resource* m_nativeTexture;
+        ComPtr<ID3D12Resource> m_nativeTexture;
         HANDLE m_sharedHandle;
-        ID3D11Texture2D* m_sharedTexture; // Shared between DX11 and DX12
 
         // For CPU Read
-        ID3D12Resource* m_readbackResource;
+        ComPtr<ID3D12Resource> m_readbackResource;
         D3D12ResourceFootprint m_nativeTextureFootprint;
     };
 
-    //---------------------------------------------------------------------------------------------------------------------
+    void* D3D12Texture2D::GetNativeTexturePtrV() { return m_nativeTexture.Get(); }
+    const void* D3D12Texture2D::GetNativeTexturePtrV() const { return m_nativeTexture.Get(); };
 
-    void* D3D12Texture2D::GetNativeTexturePtrV() { return m_nativeTexture; }
-    const void* D3D12Texture2D::GetNativeTexturePtrV() const { return m_nativeTexture; };
-
-    void* D3D12Texture2D::GetEncodeTexturePtrV() { return m_sharedTexture; }
-    const void* D3D12Texture2D::GetEncodeTexturePtrV() const { return m_sharedTexture; }
-    ID3D12Resource* D3D12Texture2D::GetReadbackResource() const { return m_readbackResource; }
+    void* D3D12Texture2D::GetEncodeTexturePtrV() { return m_nativeTexture.Get(); }
+    const void* D3D12Texture2D::GetEncodeTexturePtrV() const { return m_nativeTexture.Get(); }
+    ID3D12Resource* D3D12Texture2D::GetReadbackResource() const { return m_readbackResource.Get(); }
     const D3D12ResourceFootprint* D3D12Texture2D::GetNativeTextureFootprint() const
     {
         return &m_nativeTextureFootprint;


### PR DESCRIPTION
In the past, DX12 graphics device accessed the legacy interface to ensure the compatibility. 
However, we have already changed the process about DX12 resources, therefore these were not needed.