### PR TITLE
performance: Use fence to sync between GPU/CPU in D3D11

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -75,8 +75,7 @@ namespace webrtc
             return nullptr;
         }
         ID3D11Fence* fence = nullptr;
-        hr = d3d11Device5->CreateFence(
-            0, D3D11_FENCE_FLAG_NONE, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&fence));
+        hr = d3d11Device5->CreateFence(0, D3D11_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
         if (hr != S_OK)
         {
             RTC_LOG(LS_INFO) << "ID3D11Device5::CreateFence failed. error:" << hr;
@@ -115,8 +114,7 @@ namespace webrtc
             return nullptr;
         }
         ID3D11Fence* fence = nullptr;
-        hr = d3d11Device5->CreateFence(
-            0, D3D11_FENCE_FLAG_NONE, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&fence));
+        hr = d3d11Device5->CreateFence(0, D3D11_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
         if (hr != S_OK)
         {
             RTC_LOG(LS_INFO) << "ID3D11Device5::CreateFence failed. error:" << hr;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -63,10 +63,26 @@ namespace webrtc
         HRESULT result = m_d3d11Device->CreateTexture2D(&desc, nullptr, &texture);
         if (result != S_OK)
         {
-            RTC_LOG(LS_INFO) << "CreateTexture2D failed. error:" << result;
+            RTC_LOG(LS_INFO) << "ID3D11Device::CreateTexture2D failed. error:" << result;
             return nullptr;
         }
-        return new D3D11Texture2D(w, h, texture);
+
+        ID3D11Device5* d3d11Device5 = nullptr;
+        HRESULT hr = m_d3d11Device->QueryInterface<ID3D11Device5>(&d3d11Device5);
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D11Device::QueryInterface failed. error:" << hr;
+            return nullptr;
+        }
+        ID3D11Fence* fence = nullptr;
+        hr = d3d11Device5->CreateFence(
+            0, D3D11_FENCE_FLAG_NONE, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&fence));
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D11Device5::CreateFence failed. error:" << hr;
+            return nullptr;
+        }
+        return new D3D11Texture2D(w, h, texture, fence);
     }
 
     //---------------------------------------------------------------------------------------------------------------------
@@ -88,14 +104,31 @@ namespace webrtc
         HRESULT hr = m_d3d11Device->CreateTexture2D(&desc, nullptr, &texture);
         if (hr != S_OK)
         {
+            RTC_LOG(LS_INFO) << "ID3D11Device::CreateTexture2D failed. error:" << hr;
             return nullptr;
         }
-        return new D3D11Texture2D(w, h, texture);
+        ID3D11Device5* d3d11Device5 = nullptr;
+        hr = m_d3d11Device->QueryInterface<ID3D11Device5>(&d3d11Device5);
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D11Device::QueryInterface failed. error:" << hr;
+            return nullptr;
+        }
+        ID3D11Fence* fence = nullptr;
+        hr = d3d11Device5->CreateFence(
+            0, D3D11_FENCE_FLAG_NONE, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&fence));
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D11Device5::CreateFence failed. error:" << hr;
+            return nullptr;
+        }
+        return new D3D11Texture2D(w, h, texture, fence);
     }
 
     //---------------------------------------------------------------------------------------------------------------------
     bool D3D11GraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src)
     {
+        D3D11Texture2D* texture = static_cast<D3D11Texture2D*>(dest);
         ID3D11Resource* nativeDest = reinterpret_cast<ID3D11Resource*>(dest->GetNativeTexturePtrV());
         ID3D11Resource* nativeSrc = reinterpret_cast<ID3D11Texture2D*>(src->GetNativeTexturePtrV());
         if (nativeSrc == nativeDest)
@@ -106,13 +139,10 @@ namespace webrtc
         ComPtr<ID3D11DeviceContext> context;
         m_d3d11Device->GetImmediateContext(context.GetAddressOf());
         context->CopyResource(nativeDest, nativeSrc);
-
-        // todo(kazuki): Flush incurs a significant amount of overhead.
-        // Should run the process of copying texture asyncnously.
-        HRESULT hr = WaitFlush();
+        HRESULT hr = Signal(texture->GetFence());
         if (hr != S_OK)
         {
-            RTC_LOG(LS_INFO) << "WaitFlush failed. error:" << hr;
+            RTC_LOG(LS_INFO) << "Signal failed. error:" << hr;
             return false;
         }
         return true;
@@ -121,6 +151,7 @@ namespace webrtc
     //---------------------------------------------------------------------------------------------------------------------
     bool D3D11GraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr)
     {
+        D3D11Texture2D* texture = static_cast<D3D11Texture2D*>(dest);
         ID3D11Resource* nativeDest = reinterpret_cast<ID3D11Resource*>(dest->GetNativeTexturePtrV());
         ID3D11Resource* nativeSrc = reinterpret_cast<ID3D11Resource*>(nativeTexturePtr);
         if (nativeSrc == nativeDest)
@@ -132,34 +163,26 @@ namespace webrtc
         m_d3d11Device->GetImmediateContext(context.GetAddressOf());
         context->CopyResource(nativeDest, nativeSrc);
 
-        // todo(kazuki): Flush incurs a significant amount of overhead.
-        // Should run the process of copying texture asyncnously.
-        HRESULT hr = WaitFlush();
+        HRESULT hr = Signal(texture->GetFence());
         if (hr != S_OK)
         {
-            RTC_LOG(LS_INFO) << "WaitFlush failed. error:" << hr;
+            RTC_LOG(LS_INFO) << "Signal failed. error:" << hr;
             return false;
         }
         return true;
     }
 
-    HRESULT D3D11GraphicsDevice::WaitFlush()
+    HRESULT D3D11GraphicsDevice::Signal(ID3D11Fence* fence)
     {
         ComPtr<ID3D11DeviceContext> context;
         m_d3d11Device->GetImmediateContext(context.GetAddressOf());
-        context->Flush();
 
-        D3D11_QUERY_DESC queryDesc = { D3D11_QUERY_EVENT, 0 };
-        ComPtr<ID3D11Query> query;
-        HRESULT hr = m_d3d11Device->CreateQuery(&queryDesc, query.GetAddressOf());
+        ComPtr<ID3D11DeviceContext4> context4;
+        HRESULT hr = context.As(&context4);
         if (hr != S_OK)
-        {
             return hr;
-        }
-        context->End(query.Get());
-        while (S_OK != context->GetData(query.Get(), nullptr, 0, 0))
-            ;
-        return S_OK;
+        uint64_t value = fence->GetCompletedValue() + 1;
+        return context4->Signal(fence, value);
     }
 
     //---------------------------------------------------------------------------------------------------------------------
@@ -217,6 +240,39 @@ namespace webrtc
         GMB_CUDA_CALL_NULLPTR(cuCtxPopCurrent(nullptr));
 
         return std::move(handle);
+    }
+
+    bool D3D11GraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    {
+        const D3D11Texture2D* d3d11Texture = static_cast<const D3D11Texture2D*>(texture);
+        ID3D11Fence* fence = d3d11Texture->GetFence();
+        HANDLE fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+        uint64_t value = d3d11Texture->GetSyncCount() + 1;
+        HRESULT hr = fence->SetEventOnCompletion(value, fenceEvent);
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D11Fence::SetEventOnCompletion failed. error:" << hr;
+            return false;
+        }
+        auto nanoseconds = std::chrono::nanoseconds(nsTimeout);
+        auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(nanoseconds).count();
+
+        if(WaitForSingleObject(fenceEvent, static_cast<DWORD>(milliseconds)) == WAIT_FAILED)
+        {
+            RTC_LOG(LS_INFO) << "WaitForSingleObject failed. error:" << GetLastError();
+            return false;
+        }
+
+        CloseHandle(fenceEvent);
+        return true;
+    }
+
+    bool D3D11GraphicsDevice::ResetSync(const ITexture2D* texture)
+    {
+        const D3D11Texture2D* d3d11Texture = static_cast<const D3D11Texture2D*>(texture);
+        d3d11Texture->UpdateSyncCount();
+        return true;
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -256,7 +256,7 @@ namespace webrtc
         auto nanoseconds = std::chrono::nanoseconds(nsTimeout);
         auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(nanoseconds).count();
 
-        if(WaitForSingleObject(fenceEvent, static_cast<DWORD>(milliseconds)) == WAIT_FAILED)
+        if (WaitForSingleObject(fenceEvent, static_cast<DWORD>(milliseconds)) == WAIT_FAILED)
         {
             RTC_LOG(LS_INFO) << "WaitForSingleObject failed. error:" << GetLastError();
             return false;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <d3d11.h>
+#include <d3d11_4.h>
 #include <memory>
 #include <wrl/client.h>
 
@@ -30,13 +31,15 @@ namespace webrtc
         virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
+        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool ResetSync(const ITexture2D* texture) override;
         virtual rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
         bool IsCudaSupport() override { return m_isCudaSupport; }
         CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
         NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
 
     private:
-        HRESULT WaitFlush();
+        HRESULT Signal(ID3D11Fence* fence);
         ID3D11Device* m_d3d11Device;
 
         bool m_isCudaSupport;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11Texture2D.cpp
@@ -8,9 +8,11 @@ namespace unity
 namespace webrtc
 {
 
-    D3D11Texture2D::D3D11Texture2D(uint32_t w, uint32_t h, ID3D11Texture2D* tex)
+    D3D11Texture2D::D3D11Texture2D(uint32_t w, uint32_t h, ID3D11Texture2D* tex, ID3D11Fence* fence)
         : ITexture2D(w, h)
         , m_texture(tex)
+        , m_fence(fence)
+        , m_syncCount(0)
     {
     }
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11Texture2D.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <d3d11.h>
+#include <d3d11_4.h>
+#include <wrl/client.h>
 
 #include "GpuMemoryBuffer.h"
 #include "GraphicsDevice/ITexture2D.h"
+
+using namespace Microsoft::WRL;
 
 namespace unity
 {
@@ -13,22 +17,27 @@ namespace webrtc
     struct D3D11Texture2D : ITexture2D
     {
     public:
-        ID3D11Texture2D* m_texture;
+        D3D11Texture2D(uint32_t w, uint32_t h, ID3D11Texture2D* tex, ID3D11Fence* fence);
+        ~D3D11Texture2D() override = default;
 
-        D3D11Texture2D(uint32_t w, uint32_t h, ID3D11Texture2D* tex);
+        inline void* GetNativeTexturePtrV() override;
+        inline const void* GetNativeTexturePtrV() const override;
+        inline void* GetEncodeTexturePtrV() override;
+        inline const void* GetEncodeTexturePtrV() const override;
+        ID3D11Fence* GetFence() const { return m_fence.Get(); }
+        uint64_t GetSyncCount() const { return m_syncCount; }
+        void UpdateSyncCount() const { m_syncCount = m_fence->GetCompletedValue(); }
 
-        virtual ~D3D11Texture2D() override { SAFE_RELEASE(m_texture) }
-
-        inline virtual void* GetNativeTexturePtrV() override;
-        inline virtual const void* GetNativeTexturePtrV() const override;
-        inline virtual void* GetEncodeTexturePtrV() override;
-        inline virtual const void* GetEncodeTexturePtrV() const override;
+    private:
+        ComPtr<ID3D11Texture2D> m_texture;
+        ComPtr<ID3D11Fence> m_fence;
+        mutable uint64_t m_syncCount;
     };
 
-    void* D3D11Texture2D::GetNativeTexturePtrV() { return m_texture; }
-    const void* D3D11Texture2D::GetNativeTexturePtrV() const { return m_texture; };
-    void* D3D11Texture2D::GetEncodeTexturePtrV() { return m_texture; }
-    const void* D3D11Texture2D::GetEncodeTexturePtrV() const { return m_texture; }
+    void* D3D11Texture2D::GetNativeTexturePtrV() { return m_texture.Get(); }
+    const void* D3D11Texture2D::GetNativeTexturePtrV() const { return m_texture.Get(); };
+    void* D3D11Texture2D::GetEncodeTexturePtrV() { return m_texture.Get(); }
+    const void* D3D11Texture2D::GetEncodeTexturePtrV() const { return m_texture.Get(); }
 
 } // end namespace webrtc
 } // end namespace unity


### PR DESCRIPTION
This pull request improves the performance of the rendering thread which caused by the waiting time for rendering commands to copy render textures.

The past implementation is waiting the `ID3D11DeviceContext::Flush` to wait completion of rendering process, therefore it increases the load on rendering thread. In this change, by using `ID3D11Fence` to wait GPU process on the worker thread, it decreases the load on the rendering thread.

Currently, we are developing the same change for D3D12.