### PR TITLE
performance: Use fence to sync GPU/CPU when using D3D12

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -117,13 +117,13 @@ namespace webrtc
         if (!dest)
             return false;
 
-        ID3D12Resource* nativeDest = reinterpret_cast<ID3D12Resource*>(dest->GetNativeTexturePtrV());
-        ID3D12Resource* nativeSrc = reinterpret_cast<ID3D12Resource*>(nativeTexturePtr);
-        ID3D12Resource* readbackResource = dest->GetReadbackResource();
+        ID3D12Resource* destResource = reinterpret_cast<ID3D12Resource*>(dest->GetNativeTexturePtrV());
+        ID3D12Resource* srcResource = reinterpret_cast<ID3D12Resource*>(nativeTexturePtr);
+        bool isReadbackResource = dest->IsReadbackResource();
 
-        if (nativeSrc == nativeDest)
+        if (srcResource == destResource)
             return false;
-        if (!nativeSrc)
+        if (!srcResource || !destResource)
             return false;
 
         ThrowIfFailed(m_commandAllocator->Reset());
@@ -132,35 +132,33 @@ namespace webrtc
         std::vector<UnityGraphicsD3D12ResourceState> states;
 
         // for GPU accessible texture
-        if (nativeDest)
+        if (!isReadbackResource)
         {
-            m_commandList->CopyResource(nativeDest, nativeSrc);
+            m_commandList->CopyResource(destResource, srcResource);
             states.push_back(UnityGraphicsD3D12ResourceState {
-                nativeSrc, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE });
+                srcResource, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE });
             states.push_back(UnityGraphicsD3D12ResourceState {
-                nativeDest, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COPY_DEST });
+                destResource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COPY_DEST });
         }
-
-        // for CPU accessible texture
-        if (readbackResource)
+        else
         {
             const D3D12ResourceFootprint* resFP = dest->GetNativeTextureFootprint();
 
             // Change dest state, copy, change dest state back
             D3D12_TEXTURE_COPY_LOCATION srcLoc = {};
-            srcLoc.pResource = nativeSrc;
+            srcLoc.pResource = srcResource;
             srcLoc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
             srcLoc.SubresourceIndex = 0;
 
             D3D12_TEXTURE_COPY_LOCATION dstLoc = {};
-            dstLoc.pResource = readbackResource;
+            dstLoc.pResource = destResource;
             dstLoc.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
             dstLoc.PlacedFootprint = resFP->Footprint;
 
             m_commandList->CopyTextureRegion(&dstLoc, 0, 0, 0, &srcLoc, nullptr);
 
             states.push_back(UnityGraphicsD3D12ResourceState {
-                nativeSrc, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE });
+                srcResource, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE });
         }
 
         ThrowIfFailed(m_commandList->Close());
@@ -255,7 +253,53 @@ namespace webrtc
     ITexture2D*
     D3D12GraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat)
     {
-        return D3D12Texture2D::CreateReadbackResource(m_d3d12Device.Get(), w, h);
+        D3D12_RESOURCE_DESC desc {};
+        desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        desc.Alignment = 0;
+        desc.Width = w;
+        desc.Height = h;
+        desc.DepthOrArraySize = 1;
+        desc.MipLevels = 1;
+        desc.Format =
+            DXGI_FORMAT_B8G8R8A8_UNORM; // We only support this format which has 4 bytes -> DX12_BYTES_PER_PIXEL
+        desc.SampleDesc.Count = 1;
+        desc.SampleDesc.Quality = 0;
+        desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
+
+        D3D12ResourceFootprint footprint = {};
+        m_d3d12Device->GetCopyableFootprints(
+            &desc, 0, 1, 0, &footprint.Footprint, &footprint.NumRows, &footprint.RowSize, &footprint.ResourceSize);
+
+        // Create the readback buffer for the texture.
+        D3D12_RESOURCE_DESC descBuffer {};
+        descBuffer.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        descBuffer.Alignment = 0;
+        descBuffer.Width = footprint.ResourceSize;
+        descBuffer.Height = 1;
+        descBuffer.DepthOrArraySize = 1;
+        descBuffer.MipLevels = 1;
+        descBuffer.Format = DXGI_FORMAT_UNKNOWN;
+        descBuffer.SampleDesc.Count = 1;
+        descBuffer.SampleDesc.Quality = 0;
+        descBuffer.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        descBuffer.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+        ID3D12Resource* resource = nullptr;
+        const HRESULT hr = m_d3d12Device->CreateCommittedResource(
+            &D3D12_READBACK_HEAP_PROPS,
+            D3D12_HEAP_FLAG_NONE,
+            &descBuffer,
+            D3D12_RESOURCE_STATE_COPY_DEST,
+            nullptr,
+            IID_PPV_ARGS(&resource));
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D12Device::CreateCommittedResource failed. " << hr;
+            return nullptr;
+        }
+        return new D3D12Texture2D(w, h, resource, footprint);
     }
 
     //----------------------------------------------------------------------------------------------------------------------
@@ -265,7 +309,7 @@ namespace webrtc
         if (!tex)
             return nullptr;
 
-        ID3D12Resource* readbackResource = tex->GetReadbackResource();
+        ID3D12Resource* readbackResource = reinterpret_cast<ID3D12Resource*>(tex->GetNativeTexturePtrV());
         assert(readbackResource);
         if (!readbackResource) // the texture has to be prepared for CPU access
             return nullptr;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -76,6 +76,8 @@ namespace webrtc
         virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
+        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool ResetSync(const ITexture2D* texture) override;
 
         virtual ITexture2D*
         CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
@@ -87,14 +89,8 @@ namespace webrtc
 
     private:
         D3D12Texture2D* CreateSharedD3D12Texture(uint32_t w, uint32_t h);
-        HRESULT Signal(ID3D12Fence* fence);
-        //void WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue);
-        void Barrier(
-            ID3D12Resource* res,
-            const D3D12_RESOURCE_STATES stateBefore,
-            const D3D12_RESOURCE_STATES stateAfter,
-            const UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES);
 
+        IUnityGraphicsD3D12v5* m_unityInterface;
         ComPtr<ID3D12Device> m_d3d12Device;
         ComPtr<ID3D12CommandQueue> m_d3d12CommandQueue;
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -93,6 +93,7 @@ namespace webrtc
         IUnityGraphicsD3D12v5* m_unityInterface;
         ComPtr<ID3D12Device> m_d3d12Device;
         ComPtr<ID3D12CommandQueue> m_d3d12CommandQueue;
+        ComPtr<ID3D12Fence> m_fence;
 
         bool m_isCudaSupport;
         CudaContext m_cudaContext;
@@ -101,7 +102,12 @@ namespace webrtc
         ID3D12CommandAllocatorPtr m_commandAllocator;
         ID3D12GraphicsCommandList4Ptr m_commandList;
 
-        // Fence to copy resource on GPU (and CPU if the texture was created with CPU-access)
+        uint64_t ExecuteCommandList(
+            int listCount,
+            ID3D12GraphicsCommandList* commandList,
+            int stateCount,
+            UnityGraphicsD3D12ResourceState* states);
+        ID3D12Fence* GetFence();
     };
 
     //---------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -87,7 +87,8 @@ namespace webrtc
 
     private:
         D3D12Texture2D* CreateSharedD3D12Texture(uint32_t w, uint32_t h);
-        void WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue);
+        HRESULT Signal(ID3D12Fence* fence);
+        //void WaitForFence(ID3D12Fence* fence, HANDLE handle, uint64_t* fenceValue);
         void Barrier(
             ID3D12Resource* res,
             const D3D12_RESOURCE_STATES stateBefore,
@@ -105,9 +106,6 @@ namespace webrtc
         ID3D12GraphicsCommandList4Ptr m_commandList;
 
         // Fence to copy resource on GPU (and CPU if the texture was created with CPU-access)
-        ComPtr<ID3D12Fence> m_copyResourceFence;
-        HANDLE m_copyResourceEventHandle;
-        uint64_t m_copyResourceFenceValue = 1;
     };
 
     //---------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
@@ -13,12 +13,11 @@ namespace webrtc
 
     //---------------------------------------------------------------------------------------------------------------------
 
-    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle, ID3D12Fence* fence)
+    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(handle)
         , m_readbackResource(nullptr)
-        , m_fence(fence)
         , m_syncCount(0)
 
     {
@@ -26,43 +25,59 @@ namespace webrtc
 
     //----------------------------------------------------------------------------------------------------------------------
 
-    HRESULT D3D12Texture2D::CreateReadbackResource(ID3D12Device* device)
+    D3D12Texture2D* D3D12Texture2D::CreateReadbackResource(ID3D12Device* device, uint32_t w, uint32_t h)
     {
-        m_readbackResource.Reset();
-
-        D3D12_RESOURCE_DESC origDesc = m_nativeTexture->GetDesc();
-        device->GetCopyableFootprints(
-            &origDesc,
-            0,
-            1,
-            0,
-            &m_nativeTextureFootprint.Footprint,
-            &m_nativeTextureFootprint.NumRows,
-            &m_nativeTextureFootprint.RowSize,
-            &m_nativeTextureFootprint.ResourceSize);
-
-        // Create the readback buffer for the texture.
         D3D12_RESOURCE_DESC desc {};
-        desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
         desc.Alignment = 0;
-        desc.Width = m_nativeTextureFootprint.ResourceSize;
-        desc.Height = 1;
+        desc.Width = w;
+        desc.Height = h;
         desc.DepthOrArraySize = 1;
         desc.MipLevels = 1;
-        desc.Format = DXGI_FORMAT_UNKNOWN;
+        desc.Format =
+            DXGI_FORMAT_B8G8R8A8_UNORM; // We only support this format which has 4 bytes -> DX12_BYTES_PER_PIXEL
         desc.SampleDesc.Count = 1;
         desc.SampleDesc.Quality = 0;
-        desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-        desc.Flags = D3D12_RESOURCE_FLAG_NONE;
+        desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+        desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
 
+        D3D12ResourceFootprint footprint = {};
+        device->GetCopyableFootprints(
+            &desc, 0, 1, 0, &footprint.Footprint, &footprint.NumRows, &footprint.RowSize, &footprint.ResourceSize);
+
+        // Create the readback buffer for the texture.
+        D3D12_RESOURCE_DESC descBuffer {};
+        descBuffer.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+        descBuffer.Alignment = 0;
+        descBuffer.Width = footprint.ResourceSize;
+        descBuffer.Height = 1;
+        descBuffer.DepthOrArraySize = 1;
+        descBuffer.MipLevels = 1;
+        descBuffer.Format = DXGI_FORMAT_UNKNOWN;
+        descBuffer.SampleDesc.Count = 1;
+        descBuffer.SampleDesc.Quality = 0;
+        descBuffer.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        descBuffer.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+        ID3D12Resource* resource = nullptr;
         const HRESULT hr = device->CreateCommittedResource(
             &D3D12_READBACK_HEAP_PROPS,
             D3D12_HEAP_FLAG_NONE,
-            &desc,
+            &descBuffer,
             D3D12_RESOURCE_STATE_COPY_DEST,
             nullptr,
-            IID_PPV_ARGS(&m_readbackResource));
-        return hr;
+            IID_PPV_ARGS(&resource));
+        if (hr != S_OK)
+        {
+            RTC_LOG(LS_INFO) << "ID3D12Device::CreateCommittedResource failed. " << hr;
+            return nullptr;
+        }
+
+        D3D12Texture2D* texture = new D3D12Texture2D(w, h, nullptr);
+        texture->m_readbackResource = resource;
+        texture->m_nativeTextureFootprint = footprint;
+        return texture;
     }
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
@@ -13,11 +13,14 @@ namespace webrtc
 
     //---------------------------------------------------------------------------------------------------------------------
 
-    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
+    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle, ID3D12Fence* fence)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(handle)
         , m_readbackResource(nullptr)
+        , m_fence(fence)
+        , m_syncCount(0)
+
     {
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
@@ -10,8 +10,7 @@ namespace unity
 {
 namespace webrtc
 {
-    D3D12Texture2D::D3D12Texture2D(
-        uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
+    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(handle)
@@ -20,7 +19,8 @@ namespace webrtc
     {
     }
 
-    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, const D3D12ResourceFootprint& footprint)
+    D3D12Texture2D::D3D12Texture2D(
+        uint32_t w, uint32_t h, ID3D12Resource* nativeTex, const D3D12ResourceFootprint& footprint)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(nullptr)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.cpp
@@ -10,74 +10,24 @@ namespace unity
 {
 namespace webrtc
 {
-
-    //---------------------------------------------------------------------------------------------------------------------
-
-    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
+    D3D12Texture2D::D3D12Texture2D(
+        uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle)
         : ITexture2D(w, h)
         , m_nativeTexture(nativeTex)
         , m_sharedHandle(handle)
-        , m_readbackResource(nullptr)
         , m_syncCount(0)
-
+        , m_readbackResource(false)
     {
     }
 
-    //----------------------------------------------------------------------------------------------------------------------
-
-    D3D12Texture2D* D3D12Texture2D::CreateReadbackResource(ID3D12Device* device, uint32_t w, uint32_t h)
+    D3D12Texture2D::D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, const D3D12ResourceFootprint& footprint)
+        : ITexture2D(w, h)
+        , m_nativeTexture(nativeTex)
+        , m_sharedHandle(nullptr)
+        , m_syncCount(0)
+        , m_nativeTextureFootprint(footprint)
+        , m_readbackResource(true)
     {
-        D3D12_RESOURCE_DESC desc {};
-        desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        desc.Alignment = 0;
-        desc.Width = w;
-        desc.Height = h;
-        desc.DepthOrArraySize = 1;
-        desc.MipLevels = 1;
-        desc.Format =
-            DXGI_FORMAT_B8G8R8A8_UNORM; // We only support this format which has 4 bytes -> DX12_BYTES_PER_PIXEL
-        desc.SampleDesc.Count = 1;
-        desc.SampleDesc.Quality = 0;
-        desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
-        desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
-
-        D3D12ResourceFootprint footprint = {};
-        device->GetCopyableFootprints(
-            &desc, 0, 1, 0, &footprint.Footprint, &footprint.NumRows, &footprint.RowSize, &footprint.ResourceSize);
-
-        // Create the readback buffer for the texture.
-        D3D12_RESOURCE_DESC descBuffer {};
-        descBuffer.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
-        descBuffer.Alignment = 0;
-        descBuffer.Width = footprint.ResourceSize;
-        descBuffer.Height = 1;
-        descBuffer.DepthOrArraySize = 1;
-        descBuffer.MipLevels = 1;
-        descBuffer.Format = DXGI_FORMAT_UNKNOWN;
-        descBuffer.SampleDesc.Count = 1;
-        descBuffer.SampleDesc.Quality = 0;
-        descBuffer.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-        descBuffer.Flags = D3D12_RESOURCE_FLAG_NONE;
-
-        ID3D12Resource* resource = nullptr;
-        const HRESULT hr = device->CreateCommittedResource(
-            &D3D12_READBACK_HEAP_PROPS,
-            D3D12_HEAP_FLAG_NONE,
-            &descBuffer,
-            D3D12_RESOURCE_STATE_COPY_DEST,
-            nullptr,
-            IID_PPV_ARGS(&resource));
-        if (hr != S_OK)
-        {
-            RTC_LOG(LS_INFO) << "ID3D12Device::CreateCommittedResource failed. " << hr;
-            return nullptr;
-        }
-
-        D3D12Texture2D* texture = new D3D12Texture2D(w, h, nullptr);
-        texture->m_readbackResource = resource;
-        texture->m_nativeTextureFootprint = footprint;
-        return texture;
     }
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
@@ -17,7 +17,11 @@ namespace webrtc
     class D3D12Texture2D : public ITexture2D
     {
     public:
-        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle = nullptr);
+        // copy to GPU texture
+        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle);
+
+        // copy to CPU buffer
+        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, const D3D12ResourceFootprint& footprint);
 
         virtual ~D3D12Texture2D() override { CloseHandle(m_sharedHandle); }
 
@@ -27,10 +31,10 @@ namespace webrtc
         inline const void* GetEncodeTexturePtrV() const override;
         uint64_t GetSyncCount() const { return m_syncCount; }
         void SetSyncCount(uint64_t value) { m_syncCount = value; }
-        inline ID3D12Resource* GetReadbackResource() const;
         inline const D3D12ResourceFootprint* GetNativeTextureFootprint() const;
         HANDLE GetHandle() const { return m_sharedHandle; }
         D3D12_RESOURCE_DESC GetDesc() const { return m_nativeTexture->GetDesc(); }
+        bool IsReadbackResource() { return m_readbackResource; }
 
         static D3D12Texture2D* CreateReadbackResource(ID3D12Device* device, uint32_t w, uint32_t h);
 
@@ -38,10 +42,9 @@ namespace webrtc
         ComPtr<ID3D12Resource> m_nativeTexture;
         HANDLE m_sharedHandle;
         mutable uint64_t m_syncCount;
-
-        // For CPU Read
-        ComPtr<ID3D12Resource> m_readbackResource;
         D3D12ResourceFootprint m_nativeTextureFootprint;
+
+        bool m_readbackResource;
     };
 
     void* D3D12Texture2D::GetNativeTexturePtrV() { return m_nativeTexture.Get(); }
@@ -49,7 +52,6 @@ namespace webrtc
 
     void* D3D12Texture2D::GetEncodeTexturePtrV() { return m_nativeTexture.Get(); }
     const void* D3D12Texture2D::GetEncodeTexturePtrV() const { return m_nativeTexture.Get(); }
-    ID3D12Resource* D3D12Texture2D::GetReadbackResource() const { return m_readbackResource.Get(); }
     const D3D12ResourceFootprint* D3D12Texture2D::GetNativeTextureFootprint() const
     {
         return &m_nativeTextureFootprint;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
@@ -37,7 +37,6 @@ namespace webrtc
     private:
         ComPtr<ID3D12Resource> m_nativeTexture;
         HANDLE m_sharedHandle;
-        ID3D11Texture2D* m_sharedTexture; // Shared between DX11 and DX12
         mutable uint64_t m_syncCount;
 
         // For CPU Read

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
@@ -17,7 +17,7 @@ namespace webrtc
     class D3D12Texture2D : public ITexture2D
     {
     public:
-        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle);
+        D3D12Texture2D(uint32_t w, uint32_t h, ID3D12Resource* nativeTex, HANDLE handle = nullptr);
 
         virtual ~D3D12Texture2D() override { CloseHandle(m_sharedHandle); }
 
@@ -25,20 +25,19 @@ namespace webrtc
         inline const void* GetNativeTexturePtrV() const override;
         inline void* GetEncodeTexturePtrV() override;
         inline const void* GetEncodeTexturePtrV() const override;
-        ID3D12Fence* GetFence() const { return m_fence.Get(); }
         uint64_t GetSyncCount() const { return m_syncCount; }
-        void UpdateSyncCount() const { m_syncCount = m_fence->GetCompletedValue(); }
-        HRESULT CreateReadbackResource(ID3D12Device* device);
+        void SetSyncCount(uint64_t value) { m_syncCount = value; }
         inline ID3D12Resource* GetReadbackResource() const;
         inline const D3D12ResourceFootprint* GetNativeTextureFootprint() const;
         HANDLE GetHandle() const { return m_sharedHandle; }
         D3D12_RESOURCE_DESC GetDesc() const { return m_nativeTexture->GetDesc(); }
 
+        static D3D12Texture2D* CreateReadbackResource(ID3D12Device* device, uint32_t w, uint32_t h);
+
     private:
         ComPtr<ID3D12Resource> m_nativeTexture;
         HANDLE m_sharedHandle;
         ID3D11Texture2D* m_sharedTexture; // Shared between DX11 and DX12
-        ComPtr<ID3D12Fence> m_fence;
         mutable uint64_t m_syncCount;
 
         // For CPU Read

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12Texture2D.h
@@ -25,6 +25,9 @@ namespace webrtc
         inline const void* GetNativeTexturePtrV() const override;
         inline void* GetEncodeTexturePtrV() override;
         inline const void* GetEncodeTexturePtrV() const override;
+        ID3D12Fence* GetFence() const { return m_fence.Get(); }
+        uint64_t GetSyncCount() const { return m_syncCount; }
+        void UpdateSyncCount() const { m_syncCount = m_fence->GetCompletedValue(); }
         HRESULT CreateReadbackResource(ID3D12Device* device);
         inline ID3D12Resource* GetReadbackResource() const;
         inline const D3D12ResourceFootprint* GetNativeTextureFootprint() const;
@@ -34,6 +37,9 @@ namespace webrtc
     private:
         ComPtr<ID3D12Resource> m_nativeTexture;
         HANDLE m_sharedHandle;
+        ID3D11Texture2D* m_sharedTexture; // Shared between DX11 and DX12
+        ComPtr<ID3D12Fence> m_fence;
+        mutable uint64_t m_syncCount;
 
         // For CPU Read
         ComPtr<ID3D12Resource> m_readbackResource;

--- a/Plugin~/WebRTCPluginTest/FrameGenerator.cpp
+++ b/Plugin~/WebRTCPluginTest/FrameGenerator.cpp
@@ -45,7 +45,7 @@ namespace webrtc
         const UnityRenderingExtTextureFormat kFormat = kUnityRenderingExtFormatR8G8B8A8_SRGB;
 
         ITexture2D* texture =
-            device_->CreateCPUReadTextureV(static_cast<uint32_t>(width_), static_cast<uint32_t>(height_), kFormat);
+            device_->CreateDefaultTextureV(static_cast<uint32_t>(width_), static_cast<uint32_t>(height_), kFormat);
 
         queue_.push(std::unique_ptr<ITexture2D>(texture));
         rtc::scoped_refptr<VideoFrame> frame = CreateTestFrame(device_, texture, kFormat);

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceTest.cpp
@@ -49,7 +49,6 @@ namespace webrtc
         const std::unique_ptr<ITexture2D> tex(device()->CreateCPUReadTextureV(width, height, format()));
         EXPECT_TRUE(device()->WaitIdleForTest());
         EXPECT_TRUE(tex->IsSize(width, height));
-        EXPECT_NE(nullptr, tex->GetNativeTexturePtrV());
         EXPECT_FALSE(tex->IsSize(0, 0));
     }
 


### PR DESCRIPTION
Related this PR.
https://github.com/Unity-Technologies/com.unity.webrtc/pull/923

This PR fixes the native code of DX12 graphic device to improve performance of the rendering thread. I profiled the loads of the rendering thread, and compared two results. This comparison can show the performance improvement that reduces the loads of waiting time for command buffer to copy texture.

Before
![image](https://github.com/Unity-Technologies/com.unity.webrtc/assets/1132081/8db252ad-3dcb-4f72-80c1-d33626d88427)

After
![profile-ssao-dx12](https://github.com/Unity-Technologies/com.unity.webrtc/assets/1132081/730274f8-e228-4b25-a4a4-6fc4000c31eb)

We will deal with other graphics device Metal and GLCore near future.