### PR TITLE
fix: Support calling AudioStreamTrack.SetData on worker thread

### DIFF
--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
@@ -259,30 +260,13 @@ namespace Unity.WebRTC
             base.Dispose();
         }
 
-#if UNITY_2020_1_OR_NEWER
         /// <summary>
         ///
         /// </summary>
         /// <param name="nativeArray"></param>
         /// <param name="channels"></param>
         /// <param name="sampleRate"></param>
-        public void SetData(ref NativeArray<float>.ReadOnly nativeArray, int channels, int sampleRate)
-        {
-            unsafe
-            {
-                void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio(_trackSource, (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
-            }
-        }
-#endif
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="nativeArray"></param>
-        /// <param name="channels"></param>
-        /// <param name="sampleRate"></param>
-        public void SetData(ref NativeArray<float> nativeArray, int channels, int sampleRate)
+        public void SetData(NativeArray<float>.ReadOnly nativeArray, int channels, int sampleRate)
         {
             unsafe
             {
@@ -297,7 +281,7 @@ namespace Unity.WebRTC
         /// <param name="nativeSlice"></param>
         /// <param name="channels"></param>
         /// <param name="sampleRate"></param>
-        public void SetData(ref NativeSlice<float> nativeSlice, int channels, int sampleRate)
+        public void SetData(NativeSlice<float> nativeSlice, int channels, int sampleRate)
         {
             unsafe
             {
@@ -326,9 +310,31 @@ namespace Unity.WebRTC
         {
             if (array == null)
                 throw new ArgumentNullException("array is null");
-            NativeArray<float> nativeArray = new NativeArray<float>(array, Allocator.Temp);
-            SetData(ref nativeArray, channels, sampleRate);
-            nativeArray.Dispose();
+
+            unsafe
+            {
+                fixed (float* ptr = array)
+                {
+                    ProcessAudio(_trackSource, (IntPtr)ptr, sampleRate, channels, array.Length);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="span"></param>
+        /// <param name="channels"></param>
+        /// <param name="sampleRate"></param>
+        public void SetData(ReadOnlySpan<float> span, int channels, int sampleRate)
+        {
+            unsafe
+            {
+                fixed (float* ptr = span)
+                {
+                    ProcessAudio(_trackSource, (IntPtr)ptr, sampleRate, channels, span.Length);
+                }
+            }
         }
     }
 

--- a/Tests/Runtime/AudioStreamTrackTest.cs
+++ b/Tests/Runtime/AudioStreamTrackTest.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Linq;
 using NUnit.Framework;
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -198,12 +199,16 @@ namespace Unity.WebRTC.RuntimeTest
             Assert.That(() => track.SetData(data, 1, 0), Throws.ArgumentException);
             Assert.That(() => track.SetData(data, 0, 48000), Throws.ArgumentException);
             Assert.That(() => track.SetData(data, 1, 48000), Throws.Nothing);
-            Assert.That(() => track.SetData(ref nativeArray, 1, 48000), Throws.Nothing);
 
             var array = nativeArray.AsReadOnly();
-            Assert.That(() => track.SetData(ref array, 1, 48000), Throws.Nothing);
+            Assert.That(() => track.SetData(array, 1, 48000), Throws.Nothing);
             var slice = nativeArray.Slice();
-            Assert.That(() => track.SetData(ref slice, 1, 48000), Throws.Nothing);
+            Assert.That(() => track.SetData(slice, 1, 48000), Throws.Nothing);
+
+            unsafe
+            {
+                Assert.That(() => track.SetData(new ReadOnlySpan<float>(nativeArray.GetUnsafePtr(), nativeArray.Length), 1, 48000), Throws.Nothing);
+            }
 
             nativeArray.Dispose();
             track.Dispose();

--- a/Tests/Runtime/TransceiverTest.cs
+++ b/Tests/Runtime/TransceiverTest.cs
@@ -188,7 +188,7 @@ namespace Unity.WebRTC.RuntimeTest
 
             yield return new WaitUntil(() =>
 			{
-	            track.SetData(ref nativeArray, 1, 48000);
+	            track.SetData(nativeArray.AsReadOnly(), 1, 48000);
 				return receiver2.GetContributingSources().Length > 0;
 			});
             var sources2 = receiver2.GetContributingSources();


### PR DESCRIPTION
**AudioStreamTrack.SetData** is not able to called from the worker thread.

This PR adds **public void SetData(ReadOnlySpan<float> span, int channels, int sampleRate)** to set audio buffer from the worker thread.