### PR TITLE
fix: Support scale resolution for h264 codec

### DIFF
--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -2,7 +2,7 @@ check_code_format_nativeplugin:
   name: Checking codes formatting using clang-format
   agent:
     type: Unity::VM
-    image: renderstreaming/ubuntu:v0.2.9-1258156
+    image: renderstreaming/ubuntu:v0.4.1-1294624
     flavor: b1.large
   commands:
     - BuildScripts~/format-plugin.sh

--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -53,8 +53,8 @@ test_platforms:
   - name: linux
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.4.0-1294592
-    gpu_image: renderstreaming/ubuntu:v0.4.0-1294593
+    image: renderstreaming/ubuntu:v0.4.1-1294624
+    gpu_image: renderstreaming/ubuntu:v0.4.1-1294625
     flavor: b1.large
     model: rtx2080
   - name: macos

--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -53,8 +53,8 @@ test_platforms:
   - name: linux
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.3.1-1262596
-    gpu_image: renderstreaming/ubuntu:v0.3.1-1262597
+    image: renderstreaming/ubuntu:v0.4.0-1294592
+    gpu_image: renderstreaming/ubuntu:v0.4.0-1294593
     flavor: b1.large
     model: rtx2080
   - name: macos

--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -4,7 +4,7 @@ build_platforms:
   - name: win
     type: Unity::VM
     flavor: b1.large
-    image: renderstreaming/win10:v0.8.0-1295875
+    image: renderstreaming/win10:v0.8.1-1296107
     build_command: BuildScripts~/build_plugin_win.cmd
     build_testrunner_command: BuildScripts~/build_testrunner_win.cmd
     plugin_path: Runtime/Plugins/x86_64/webrtc.dll
@@ -46,8 +46,8 @@ test_platforms:
   - name: win
     type: Unity::VM
     gpu_type: Unity::VM::GPU
-    image: renderstreaming/win10:v0.8.0-1295875
-    gpu_image: renderstreaming/win10:v0.8.0-1295876
+    image: renderstreaming/win10:v0.8.1-1296107
+    gpu_image: renderstreaming/win10:v0.8.1-1296108
     flavor: b1.large
     model: rtx2080
   - name: linux

--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -12,7 +12,7 @@ build_platforms:
   - name: linux
     type: Unity::VM
     flavor: b1.large
-    image: renderstreaming/ubuntu-16.04:v0.1.0-1257787
+    image: renderstreaming/ubuntu-18.04:v0.3.0-1294653
     build_command: BuildScripts~/build_plugin_linux.sh
     build_testrunner_command: BuildScripts~/build_testrunner_linux.sh
     plugin_path: Runtime/Plugins/x86_64/libwebrtc.so

--- a/.yamato/upm-ci-libwebrtc.yml
+++ b/.yamato/upm-ci-libwebrtc.yml
@@ -3,7 +3,7 @@
 platforms:
   - name: win
     type: Unity::VM
-    image: renderstreaming/win10:v0.8.0-1295875
+    image: renderstreaming/win10:v0.8.1-1296107
     flavor: b1.xlarge
     build_command: BuildScripts~/build_libwebrtc_win.cmd
   - name: macos

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -65,7 +65,7 @@ test_targets:
         platform: standalone
   - name: linux-gpu
     type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.3.1-1262597
+    image: renderstreaming/ubuntu:v0.4.0-1294593
     flavor: b1.large
     model: rtx2080
     is_gpu: true

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -65,7 +65,7 @@ test_targets:
         platform: standalone
   - name: linux-gpu
     type: Unity::VM::GPU
-    image: renderstreaming/ubuntu:v0.4.0-1294593
+    image: renderstreaming/ubuntu:v0.4.1-1294625
     flavor: b1.large
     model: rtx2080
     is_gpu: true

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -5,6 +5,8 @@ export SOLUTION_DIR=$(pwd)/Plugin~
 export OUTPUT_FILEPATH=$(pwd)/Runtime/Plugins/x86_64/libwebrtc.so
 export LIBCXX_BUILD_DIR=$(pwd)/llvm-project/build
 
+source ~/.profile
+
 # Download LibWebRTC 
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -15,5 +15,5 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
-cmake --preset=x64-windows-clang
+cmake --preset=x64-windows-msvc
 cmake --build --preset=release-windows-clang --target=WebRTCPlugin

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -3,7 +3,6 @@
 set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M112/webrtc-win.zip
 set SOLUTION_DIR=%cd%\Plugin~
 
-echo -------------------
 echo Download LibWebRTC
 
 if not exist %SOLUTION_DIR%\webrtc (
@@ -11,8 +10,11 @@ if not exist %SOLUTION_DIR%\webrtc (
   7z x -aoa webrtc.zip -o%SOLUTION_DIR%\webrtc
 )
 
-echo -------------------
 echo Build com.unity.webrtc Plugin
+
+rem CMake doesn't support building CUDA kernel with Clang compiler on Windows. 
+rem https://gitlab.kitware.com/cmake/cmake/-/issues/20776
+rem This program use CUDA kernel to change the video resolution when using NVIDIA Video Codec.
 
 cd %SOLUTION_DIR%
 cmake --preset=x64-windows-msvc

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -15,5 +15,5 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
-cmake --preset=x64-windows-msvc
+cmake --preset=x64-windows-clang
 cmake --build --preset=release-windows-clang --target=WebRTCPlugin

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -15,5 +15,5 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
-cmake --preset=x64-windows-clang
-cmake --build --preset=release-windows-clang --target=WebRTCPlugin
+cmake --preset=x64-windows-msvc
+cmake --build --preset=release-windows-msvc --target=WebRTCPlugin

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -15,5 +15,5 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 cd %SOLUTION_DIR%
-cmake --preset=x64-windows-msvc
-cmake --build --preset=release-windows-msvc --target=WebRTCPlugin
+cmake --preset=x64-windows-clang
+cmake --build --preset=release-windows-clang --target=WebRTCPlugin

--- a/BuildScripts~/build_testrunner_linux.sh
+++ b/BuildScripts~/build_testrunner_linux.sh
@@ -3,6 +3,8 @@
 export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M112/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
+source ~/.profile
+
 # Download LibWebRTC 
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 

--- a/BuildScripts~/build_testrunner_win.cmd
+++ b/BuildScripts~/build_testrunner_win.cmd
@@ -26,4 +26,4 @@ popd
 echo -------------------
 echo Copy test runner
 
-copy %SOLUTION_DIR%\out\build\x64-windows-clang\WebRTCPluginTest\Release\WebRTCLibTest.exe .
+copy %SOLUTION_DIR%\out\build\x64-windows-msvc\WebRTCPluginTest\Release\WebRTCLibTest.exe .

--- a/BuildScripts~/build_testrunner_win.cmd
+++ b/BuildScripts~/build_testrunner_win.cmd
@@ -15,11 +15,11 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 pushd %SOLUTION_DIR%
-cmake --preset=x64-windows-clang
-cmake --build --preset=debug-windows-clang --target=WebRTCLibTest
+cmake --preset=x64-windows-msvc
+cmake --build --preset=debug-windows-msvc --target=WebRTCLibTest
 popd
 
 echo -------------------
 echo Copy test runner
 
-copy %SOLUTION_DIR%\out\build\x64-windows-clang\WebRTCPluginTest\Debug\WebRTCLibTest.exe .
+copy %SOLUTION_DIR%\out\build\x64-windows-msvc\WebRTCPluginTest\Debug\WebRTCLibTest.exe .

--- a/BuildScripts~/build_testrunner_win.cmd
+++ b/BuildScripts~/build_testrunner_win.cmd
@@ -15,11 +15,11 @@ echo -------------------
 echo Build com.unity.webrtc Plugin
 
 pushd %SOLUTION_DIR%
-cmake --preset=x64-windows-msvc
-cmake --build --preset=debug-windows-msvc --target=WebRTCLibTest
+cmake --preset=x64-windows-clang
+cmake --build --preset=debug-windows-clang --target=WebRTCLibTest
 popd
 
 echo -------------------
 echo Copy test runner
 
-copy %SOLUTION_DIR%\out\build\x64-windows-msvc\WebRTCPluginTest\Debug\WebRTCLibTest.exe .
+copy %SOLUTION_DIR%\out\build\x64-windows-clang\WebRTCPluginTest\Debug\WebRTCLibTest.exe .

--- a/BuildScripts~/build_testrunner_win.cmd
+++ b/BuildScripts~/build_testrunner_win.cmd
@@ -14,12 +14,16 @@ if not exist %SOLUTION_DIR%\webrtc (
 echo -------------------
 echo Build com.unity.webrtc Plugin
 
+rem Debug build with MSVC compiler crashes. Release build works fine.
+rem This issue is reported on the webrtc forum.
+rem https://groups.google.com/g/discuss-webrtc/c/N7L6fx784GA
+
 pushd %SOLUTION_DIR%
-cmake --preset=x64-windows-clang
-cmake --build --preset=debug-windows-clang --target=WebRTCLibTest
+cmake --preset=x64-windows-msvc
+cmake --build --preset=release-windows-msvc --target=WebRTCLibTest
 popd
 
 echo -------------------
 echo Copy test runner
 
-copy %SOLUTION_DIR%\out\build\x64-windows-clang\WebRTCPluginTest\Debug\WebRTCLibTest.exe .
+copy %SOLUTION_DIR%\out\build\x64-windows-clang\WebRTCPluginTest\Release\WebRTCLibTest.exe .

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -86,6 +86,7 @@ if(Windows OR Linux)
   find_package(CUDA REQUIRED)
   find_package(Vulkan REQUIRED)
   add_subdirectory(NvCodec)
+  enable_language(CUDA)
 endif()
 
 add_subdirectory(WebRTCPlugin)

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -89,7 +89,7 @@ if(Windows OR Linux)
 
   # Building CUDA kernel is not supported with Clang compiler on Windows.
   # https://gitlab.kitware.com/cmake/cmake/-/issues/20776
-  if((WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR LINUX)
+  if((Windows AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR LINUX)
     enable_language(CUDA)
   endif()
   add_subdirectory(NvCodec)

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -89,7 +89,7 @@ if(Windows OR Linux)
 
   # Building CUDA kernel is not supported with Clang compiler on Windows.
   # https://gitlab.kitware.com/cmake/cmake/-/issues/20776
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  if((WINDOWS AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR LINUX)
     enable_language(CUDA)
   endif()
   add_subdirectory(NvCodec)

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -83,10 +83,11 @@ if(iOS OR macOS)
 endif()
 
 if(Windows OR Linux)
-  find_package(CUDA REQUIRED)
   find_package(Vulkan REQUIRED)
-  add_subdirectory(NvCodec)
+
+  find_package(CUDA REQUIRED)
   enable_language(CUDA)
+  add_subdirectory(NvCodec)
 endif()
 
 add_subdirectory(WebRTCPlugin)

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -86,7 +86,12 @@ if(Windows OR Linux)
   find_package(Vulkan REQUIRED)
 
   find_package(CUDA REQUIRED)
-  enable_language(CUDA)
+
+  # Building CUDA kernel is not supported with Clang compiler on Windows.
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/20776
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    enable_language(CUDA)
+  endif()
   add_subdirectory(NvCodec)
 endif()
 

--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -89,7 +89,7 @@ if(Windows OR Linux)
 
   # Building CUDA kernel is not supported with Clang compiler on Windows.
   # https://gitlab.kitware.com/cmake/cmake/-/issues/20776
-  if((Windows AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR LINUX)
+  if((Windows AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR Linux)
     enable_language(CUDA)
   endif()
   add_subdirectory(NvCodec)

--- a/Plugin~/NvCodec/CMakeLists.txt
+++ b/Plugin~/NvCodec/CMakeLists.txt
@@ -20,6 +20,8 @@ target_include_directories(
   NvCodec PRIVATE ${CUDA_INCLUDE_DIRS} ${Vulkan_INCLUDE_DIR}
                   ${GLEW_INCLUDE_DIRS} ${NVCODEC_INCLUDE_DIR})
 
+set_target_properties(NvCodec PROPERTIES CUDA_ARCHITECTURES "75")
+
 if(Windows)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(CUVID_LIB ${CMAKE_CURRENT_SOURCE_DIR}/lib/x64/nvcuvid.lib)

--- a/Plugin~/NvCodec/Utils/ResizeSurf.cu
+++ b/Plugin~/NvCodec/Utils/ResizeSurf.cu
@@ -124,7 +124,7 @@ CUresult ResizeSurf(CUarray srcArray, CUarray dstArray)
         srcWidth / dstWidth,
         srcHeight / dstHeight);
 
-    result = cuSurfObjectDestroy(dstSurface);
+    result = cuSurfObjectDestroy(srcSurface);
     if (result != CUDA_SUCCESS)
         return result;
     return cuSurfObjectDestroy(dstSurface);

--- a/Plugin~/NvCodec/Utils/ResizeSurf.cu
+++ b/Plugin~/NvCodec/Utils/ResizeSurf.cu
@@ -1,0 +1,131 @@
+#include "ResizeSurf.h"
+
+#include <cuda_runtime.h>
+
+__global__ void ResizeSurfNearestNeiborKernel(
+    CUsurfObject srcSurface,
+    int srcWidth,
+    int srcHeight,
+    CUsurfObject dstSurface,
+    int dstWidth,
+    int dstHeight,
+    float scaleWidth,
+    float scaleHeight)
+{
+    // calculate surface coordinates
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= dstWidth || y >= dstHeight)
+        return;
+
+    uchar4 data;
+    surf2Dread(&data, srcSurface, (x * scaleWidth) * 4, y * scaleHeight);
+
+    // read from global memory and write to cuarray (via surface reference)
+    surf2Dwrite(data, dstSurface, x * 4, y);
+}
+
+__global__ void ResizeSurfBilinearKernel(
+    CUsurfObject srcSurface,
+    int srcWidth,
+    int srcHeight,
+    CUsurfObject dstSurface,
+    int dstWidth,
+    int dstHeight,
+    float scaleWidth,
+    float scaleHeight)
+{
+    // calculate surface coordinates
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= dstWidth || y >= dstHeight)
+        return;
+
+    int x0 = x * scaleWidth - 1;
+    int x1 = x * scaleWidth + 1;
+    int y0 = y * scaleHeight - 1;
+    int y1 = y * scaleHeight + 1;
+
+    if (x0 < 0) 
+        x0 = 0;
+    if (x1 >= srcWidth) 
+        x1 = srcWidth - 1;
+    if (y0 < 0) 
+        y0 = 0;
+    if (y1 >= srcHeight) 
+        y1 = srcHeight - 1;
+
+    uchar4 c00, c01, c10, c11;
+    surf2Dread(&c00, srcSurface, x0 * 4, y0);
+    surf2Dread(&c01, srcSurface, x0 * 4, y1);
+    surf2Dread(&c10, srcSurface, x1 * 4, y0);
+    surf2Dread(&c11, srcSurface, x1 * 4, y1);
+
+    uchar4 data;
+    data.x = 0.5f * (0.5f * c00.x + 0.5f * c01.x) + 0.5f * (0.5f * c10.x + 0.5f * c11.x);
+    data.y = 0.5f * (0.5f * c00.y + 0.5f * c01.y) + 0.5f * (0.5f * c10.y + 0.5f * c11.y);
+    data.z = 0.5f * (0.5f * c00.z + 0.5f * c01.z) + 0.5f * (0.5f * c10.z + 0.5f * c11.z);
+    
+    surf2Dwrite(data, dstSurface, x * 4, y);
+}
+
+CUresult ResizeSurf(CUarray srcArray, CUarray dstArray)
+{
+    CUsurfObject srcSurface;
+    CUDA_RESOURCE_DESC srcResDesc;
+    srcResDesc.flags = 0;
+    srcResDesc.resType = CU_RESOURCE_TYPE_ARRAY;
+    srcResDesc.res.array.hArray = srcArray;
+
+    CUresult result = cuSurfObjectCreate(&srcSurface, &srcResDesc);
+    if (result != CUDA_SUCCESS)
+        return result;
+
+    CUsurfObject dstSurface;
+    CUDA_RESOURCE_DESC dstResDesc;
+    dstResDesc.flags = 0;
+    dstResDesc.resType = CU_RESOURCE_TYPE_ARRAY;
+    dstResDesc.res.array.hArray = dstArray;
+
+    result = cuSurfObjectCreate(&dstSurface, &dstResDesc);
+    if (result != CUDA_SUCCESS)
+        return result;
+
+    CUDA_ARRAY_DESCRIPTOR srcArrayDesc;
+    result = cuArrayGetDescriptor(&srcArrayDesc, srcArray);
+    if (result != CUDA_SUCCESS)
+        return result;
+
+    CUDA_ARRAY_DESCRIPTOR dstArrayDesc;
+    result = cuArrayGetDescriptor(&dstArrayDesc, dstArray);
+    if (result != CUDA_SUCCESS)
+        return result;
+
+    int srcWidth = srcArrayDesc.Width;
+    int srcHeight = srcArrayDesc.Height;
+    int dstWidth = dstArrayDesc.Width;
+    int dstHeight = dstArrayDesc.Height;
+
+    dim3 dimBlock(8, 8, 1);
+
+    int gridX = dstWidth / dimBlock.x + (dstWidth % dimBlock.x ? 1 : 0);
+    int gridY = dstHeight / dimBlock.y + (dstHeight % dimBlock.y ? 1 : 0);
+    dim3 dimGrid(gridX, gridY, 1);
+
+    ResizeSurfBilinearKernel<<<dimGrid, dimBlock>>>(
+        srcSurface,
+        srcWidth,
+        srcHeight,
+        dstSurface,
+        dstWidth,
+        dstHeight,
+        srcWidth / dstWidth,
+        srcHeight / dstHeight);
+
+    result = cuSurfObjectDestroy(dstSurface);
+    if (result != CUDA_SUCCESS)
+        return result;
+    return cuSurfObjectDestroy(dstSurface);
+}

--- a/Plugin~/NvCodec/Utils/ResizeSurf.h
+++ b/Plugin~/NvCodec/Utils/ResizeSurf.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cuda.h>
+
+CUresult ResizeSurf(CUarray srcArray, CUarray dstArray);

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -478,8 +478,8 @@ namespace webrtc
 
     int32_t NvEncoderImpl::ProcessEncodedFrame(std::vector<uint8_t>& packet, const ::webrtc::VideoFrame& inputFrame)
     {
-        m_encodedImage._encodedWidth = inputFrame.video_frame_buffer()->width();
-        m_encodedImage._encodedHeight = inputFrame.video_frame_buffer()->height();
+        m_encodedImage._encodedWidth = m_encoder->GetEncodeWidth();
+        m_encodedImage._encodedHeight = m_encoder->GetEncodeHeight();
         m_encodedImage.SetTimestamp(inputFrame.timestamp());
         m_encodedImage.SetSimulcastIndex(0);
         m_encodedImage.ntp_time_ms_ = inputFrame.ntp_time_ms();

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -382,7 +382,6 @@ namespace webrtc
         {
             void* pSrcArray = static_cast<void*>(handle->mappedArray);
 
-
             // Resize cuda array when the resolution of input buffer is different from output one.
             // The output buffer named m_scaledArray is reused while the resolution is matched.
 #if SUPPORT_CUDA_KERNEL

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -1,5 +1,12 @@
 #include "pch.h"
 
+// todo::
+// CMake doesn't support building CUDA kernel with Clang compiler on Windows.
+// https://gitlab.kitware.com/cmake/cmake/-/issues/20776
+#if _WIN32 && __clang__
+#define NOT_SUPPORTED_CUDA_RESIZE 1
+#endif
+
 #include <absl/strings/match.h>
 #include <api/video/video_codec_constants.h>
 #include <api/video/video_codec_type.h>
@@ -14,7 +21,9 @@
 #include "NvEncoder/NvEncoderCuda.h"
 #include "NvEncoderImpl.h"
 #include "ProfilerMarkerFactory.h"
+#if !NOT_SUPPORTED_CUDA_RESIZE
 #include "ResizeSurf.h"
+#endif
 #include "ScopedProfiler.h"
 #include "UnityVideoTrackSource.h"
 #include "VideoFrameAdapter.h"
@@ -331,7 +340,12 @@ namespace webrtc
                 return result;
             }
         }
+
+#if NOT_SUPPORTED_CUDA_RESIZE
+        return CUDA_SUCCESS;
+#else
         return ResizeSurf(src, dst);
+#endif
     }
 
     bool NvEncoderImpl::CopyResource(

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
@@ -79,7 +79,7 @@ namespace webrtc
             CUcontext context,
             CUmemorytype memoryType);
 
-        void Resize(const CUarray& src, CUarray& dst, const Size& size);
+        CUresult Resize(const CUarray& src, CUarray& dst, const Size& size);
 
         CUcontext m_context;
         CUmemorytype m_memoryType;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
@@ -79,8 +79,6 @@ namespace webrtc
             CUcontext context,
             CUmemorytype memoryType);
 
-        CUresult Resize(const CUarray& src, CUarray& dst, const Size& size);
-
         CUcontext m_context;
         CUmemorytype m_memoryType;
         CUarray m_scaledArray;

--- a/Plugin~/WebRTCPluginTest/FrameGenerator.cpp
+++ b/Plugin~/WebRTCPluginTest/FrameGenerator.cpp
@@ -40,7 +40,7 @@ namespace webrtc
 
     FrameGeneratorInterface::Resolution VideoFrameGenerator::GetResolution() const
     {
-        return { .width = static_cast<size_t>(width_), .height = static_cast<size_t>(height_) };
+        return { static_cast<size_t>(width_), static_cast<size_t>(height_) };
     }
 
     FrameGeneratorInterface::VideoFrameData VideoFrameGenerator::NextFrame()


### PR DESCRIPTION
- Add CUDA kernel for scaling down texture resolution.
- Add **enable_language(CUDA)** in CMakeLists.txt to build CUDA kernel.
- Upgrade **CUDA Toolkit 11.6**, CUDA supports VS2022 since 11.6. 
- Change **msvc** compiler for windows plugin because **clang-cl** is not worked with CUDA compiler.
