### PR TITLE
fix: Change android minimum level because the api level is obsoleted

### DIFF
--- a/Editor/BuildProcessor.cs
+++ b/Editor/BuildProcessor.cs
@@ -29,9 +29,9 @@ namespace Unity.WebRTC.Editor
         ///
         /// </summary>
 #if UNITY_2021_1_OR_NEWER
-        public const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel22;
+        public const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel23;
 #else
-        public const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel21;
+        public const AndroidSdkVersions RequiredAndroidSdkVersion = AndroidSdkVersions.AndroidApiLevel22;
 #endif
         /// <summary>
         ///


### PR DESCRIPTION
**AndroidSdkVersions.AndroidApiLevel22** is already obsoleted on Unity2020.3 LTS.