### PR TITLE
performance: Use semaphore to wait command buffer completion on macos/ios

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
@@ -11,6 +11,7 @@ namespace webrtc
 {
     using namespace ::webrtc;
     class MetalDevice;
+    struct MetalTexture2D;
     class MetalGraphicsDevice : public IGraphicsDevice
     {
     public:
@@ -30,11 +31,13 @@ namespace webrtc
         bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         rtc::scoped_refptr<I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override { return nullptr; }
-
+        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool ResetSync(const ITexture2D* texture) override;
+        
     private:
         MetalDevice* m_device;
         id<MTLCommandQueue> m_queue;
-        bool CopyTexture(id<MTLTexture> dest, id<MTLTexture> src);
+        bool CopyTexture(MetalTexture2D* dest, id<MTLTexture> src);
         static MTLPixelFormat ConvertFormat(UnityRenderingExtTextureFormat format);
     };
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
@@ -33,7 +33,7 @@ namespace webrtc
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override { return nullptr; }
         bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
         bool ResetSync(const ITexture2D* texture) override;
-        
+
     private:
         MetalDevice* m_device;
         id<MTLCommandQueue> m_queue;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -66,7 +66,7 @@ namespace webrtc
         id<MTLTexture> mtlTexture = (__bridge id<MTLTexture>)dest->GetNativeTexturePtrV();
         __block dispatch_semaphore_t semaphore = dest->GetSemaphore();
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-        
+
         RTC_DCHECK_NE(src, mtlTexture);
         RTC_DCHECK_EQ(src.pixelFormat, mtlTexture.pixelFormat);
         RTC_DCHECK_EQ(src.width, mtlTexture.width);
@@ -98,10 +98,7 @@ namespace webrtc
             [blit synchronizeResource:mtlTexture];
 #endif
         [blit endEncoding];
-        [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer)
-        {
-            dispatch_semaphore_signal(semaphore);
-        }];
+        [commandBuffer addCompletedHandler:^(id<MTLCommandBuffer> buffer) { dispatch_semaphore_signal(semaphore); }];
 
         // Commit the current command buffer and wait until the GPU process is completed.
         [commandBuffer commit];
@@ -114,7 +111,7 @@ namespace webrtc
         dispatch_semaphore_t semaphore = texture2D->GetSemaphore();
 
         intptr_t value = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, nsTimeout));
-        if(value != 0)
+        if (value != 0)
         {
             RTC_LOG(LS_INFO) << "The timeout occurred.";
             return false;
@@ -122,11 +119,7 @@ namespace webrtc
         return true;
     }
 
-    bool MetalGraphicsDevice::ResetSync(const ITexture2D* texture)
-    {
-        return true;
-    }
-
+    bool MetalGraphicsDevice::ResetSync(const ITexture2D* texture) { return true; }
 
     ITexture2D* MetalGraphicsDevice::CreateCPUReadTextureV(
         uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat)
@@ -158,11 +151,11 @@ namespace webrtc
     {
         MetalTexture2D* texture2D = static_cast<MetalTexture2D*>(texture);
         rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = texture2D->ConvertI420Buffer();
-        
+
         //
         dispatch_semaphore_t semaphore = texture2D->GetSemaphore();
         dispatch_semaphore_signal(semaphore);
-        
+
         return i420_buffer;
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -52,8 +52,9 @@ namespace webrtc
 
     bool MetalGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr)
     {
-        if (nativeTexturePtr == nullptr)
+        if (!nativeTexturePtr)
         {
+            RTC_LOG(LS_INFO) << "nativeTexturePtr is nullptr.";
             return false;
         }
         id<MTLTexture> srcTexture = (__bridge id<MTLTexture>)nativeTexturePtr;
@@ -152,7 +153,7 @@ namespace webrtc
         MetalTexture2D* texture2D = static_cast<MetalTexture2D*>(texture);
         rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer = texture2D->ConvertI420Buffer();
 
-        //
+        // Notify finishing usage of semaphore.
         dispatch_semaphore_t semaphore = texture2D->GetSemaphore();
         dispatch_semaphore_signal(semaphore);
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
@@ -25,8 +25,9 @@ namespace webrtc
 
         void SetSemaphore(dispatch_semaphore_t semaphore) { m_semaphore = semaphore; }
         dispatch_semaphore_t GetSemaphore() const { return m_semaphore; }
-        
+
         rtc::scoped_refptr<I420Buffer> ConvertI420Buffer();
+
     private:
         id<MTLTexture> m_texture;
         dispatch_semaphore_t m_semaphore;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
@@ -19,8 +19,11 @@ namespace webrtc
         inline void* GetEncodeTexturePtrV() override;
         inline const void* GetEncodeTexturePtrV() const override;
 
+        void SetSemaphore(dispatch_semaphore_t semaphore) { m_semaphore = semaphore; }
+        dispatch_semaphore_t GetSemaphore() const { return m_semaphore; }
     private:
         id<MTLTexture> m_texture;
+        dispatch_semaphore_t m_semaphore;
     };
 
     void* MetalTexture2D::GetNativeTexturePtrV() { return m_texture; }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.h
@@ -3,10 +3,14 @@
 #include "GraphicsDevice/ITexture2D.h"
 #include "WebRTCMacros.h"
 
+#include <api/video/i420_buffer.h>
+
 namespace unity
 {
 namespace webrtc
 {
+    using namespace ::webrtc;
+
     class MTLTexture;
     struct MetalTexture2D : ITexture2D
     {
@@ -21,9 +25,13 @@ namespace webrtc
 
         void SetSemaphore(dispatch_semaphore_t semaphore) { m_semaphore = semaphore; }
         dispatch_semaphore_t GetSemaphore() const { return m_semaphore; }
+        
+        rtc::scoped_refptr<I420Buffer> ConvertI420Buffer();
     private:
         id<MTLTexture> m_texture;
         dispatch_semaphore_t m_semaphore;
+        std::vector<uint8_t> m_buffer;
+        rtc::scoped_refptr<I420Buffer> m_i420Buffer;
     };
 
     void* MetalTexture2D::GetNativeTexturePtrV() { return m_texture; }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -18,6 +18,10 @@ namespace webrtc
 
     MetalTexture2D::~MetalTexture2D()
     {
+        // waiting for finishing usage of semaphore
+        dispatch_semaphore_wait(m_semaphore, DISPATCH_TIME_FOREVER);
+        dispatch_semaphore_signal(m_semaphore);
+        
         dispatch_release(m_semaphore);
         [m_texture release];
     }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -2,6 +2,8 @@
 
 #include "MetalTexture2D.h"
 
+#include <third_party/libyuv/include/libyuv/convert.h>
+
 namespace unity
 {
 namespace webrtc
@@ -18,6 +20,42 @@ namespace webrtc
     {
         dispatch_release(m_semaphore);
         [m_texture release];
+    }
+
+    rtc::scoped_refptr<I420Buffer> MetalTexture2D::ConvertI420Buffer()
+    {
+        RTC_DCHECK(m_texture);
+        RTC_DCHECK_GT(m_width, 0);
+        RTC_DCHECK_GT(m_height, 0);
+        
+        const uint32_t BYTES_PER_PIXEL = 4;
+        const uint32_t bytesPerRow = m_width * BYTES_PER_PIXEL;
+        const uint32_t bufferSize = bytesPerRow * m_height;
+
+        if(m_buffer.size() != bufferSize)
+            m_buffer.resize(bufferSize);
+
+        [m_texture getBytes:m_buffer.data()
+             bytesPerRow:bytesPerRow
+             fromRegion:MTLRegionMake2D(0, 0, m_width, m_height)
+             mipmapLevel:0];
+        
+        if(!m_i420Buffer)
+            m_i420Buffer = I420Buffer::Create(static_cast<int32_t>(m_width), static_cast<int32_t>(m_height));
+
+        libyuv::ARGBToI420(
+            m_buffer.data(),
+            static_cast<int32_t>(bytesPerRow),
+            m_i420Buffer->MutableDataY(),
+            m_i420Buffer->StrideY(),
+            m_i420Buffer->MutableDataU(),
+            m_i420Buffer->StrideU(),
+            m_i420Buffer->MutableDataV(),
+            m_i420Buffer->StrideV(),
+            static_cast<int32_t>(m_width),
+            static_cast<int32_t>(m_height));
+        
+        return m_i420Buffer;
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -11,6 +11,7 @@ namespace webrtc
         : ITexture2D(w, h)
         , m_texture(tex)
     {
+        
     }
 
     MetalTexture2D::~MetalTexture2D() { [m_texture release]; }

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -27,20 +27,20 @@ namespace webrtc
         RTC_DCHECK(m_texture);
         RTC_DCHECK_GT(m_width, 0);
         RTC_DCHECK_GT(m_height, 0);
-        
+
         const uint32_t BYTES_PER_PIXEL = 4;
         const uint32_t bytesPerRow = m_width * BYTES_PER_PIXEL;
         const uint32_t bufferSize = bytesPerRow * m_height;
 
-        if(m_buffer.size() != bufferSize)
+        if (m_buffer.size() != bufferSize)
             m_buffer.resize(bufferSize);
 
         [m_texture getBytes:m_buffer.data()
-             bytesPerRow:bytesPerRow
-             fromRegion:MTLRegionMake2D(0, 0, m_width, m_height)
-             mipmapLevel:0];
-        
-        if(!m_i420Buffer)
+                bytesPerRow:bytesPerRow
+                 fromRegion:MTLRegionMake2D(0, 0, m_width, m_height)
+                mipmapLevel:0];
+
+        if (!m_i420Buffer)
             m_i420Buffer = I420Buffer::Create(static_cast<int32_t>(m_width), static_cast<int32_t>(m_height));
 
         libyuv::ARGBToI420(
@@ -54,7 +54,7 @@ namespace webrtc
             m_i420Buffer->StrideV(),
             static_cast<int32_t>(m_width),
             static_cast<int32_t>(m_height));
-        
+
         return m_i420Buffer;
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -10,11 +10,15 @@ namespace webrtc
     MetalTexture2D::MetalTexture2D(uint32_t w, uint32_t h, id<MTLTexture> tex)
         : ITexture2D(w, h)
         , m_texture(tex)
+        , m_semaphore(dispatch_semaphore_create(1))
     {
-        
     }
 
-    MetalTexture2D::~MetalTexture2D() { [m_texture release]; }
+    MetalTexture2D::~MetalTexture2D()
+    {
+        dispatch_release(m_semaphore);
+        [m_texture release];
+    }
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalTexture2D.mm
@@ -21,7 +21,7 @@ namespace webrtc
         // waiting for finishing usage of semaphore
         dispatch_semaphore_wait(m_semaphore, DISPATCH_TIME_FOREVER);
         dispatch_semaphore_signal(m_semaphore);
-        
+
         dispatch_release(m_semaphore);
         [m_texture release];
     }


### PR DESCRIPTION
This is a performance optimization fix for Metal.

Previously, when copying textures for video transmission, [MTLCommandBuffer::waitUntilCompleted](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1443039-waituntilcompleted?language=objc) was used to detect when the texture copy command was finished. Since this method is called on the rendering thread, it could cause subsequent graphics-related operations to block.

This fix uses [MTLCommandBuffer::addCompletedHandler](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1442997-addcompletedhandler?language=objc) and semaphores to implement the wait process. It waits for the semaphore's signal on the worker thread, the load on the rendering thread is reduced.

Refer to [this sample](https://developer.apple.com/documentation/metal/resource_synchronization/synchronizing_cpu_and_gpu_work?language=objc) provided by Apple.