### PR TITLE
fix: Reset command buffer allocator once in one frame in DX12

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -260,7 +260,6 @@ namespace webrtc
 
     bool D3D12GraphicsDevice::ResetSync(const ITexture2D* texture) { return true; }
 
-
     bool D3D12GraphicsDevice::WaitIdleForTest()
     {
         HANDLE handle = CreateEvent(nullptr, FALSE, FALSE, nullptr);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -168,8 +168,6 @@ namespace webrtc
 
             states.push_back(UnityGraphicsD3D12ResourceState {
                 srcResource, D3D12_RESOURCE_STATE_COPY_SOURCE, D3D12_RESOURCE_STATE_COPY_SOURCE });
-            //states.push_back(UnityGraphicsD3D12ResourceState {
-            //    destResource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COPY_DEST });
         }
 
         ThrowIfFailed(m_commandList->Close());

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -131,7 +131,7 @@ namespace webrtc
         uint64_t nextFrameFenceValue = GetNextFrameFenceValue();
 
         // Reset m_commandAllocator when the process is arriving here first time in the frame.
-        if(m_nextFrameFenceValue < nextFrameFenceValue)
+        if (m_nextFrameFenceValue < nextFrameFenceValue)
         {
             m_nextFrameFenceValue = nextFrameFenceValue;
             ThrowIfFailed(m_commandAllocator->Reset());

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -81,7 +81,7 @@ namespace webrtc
 
         virtual ITexture2D*
         CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
-        virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
+        virtual rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* texture) override;
 
         bool IsCudaSupport() override { return m_isCudaSupport; }
         CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
@@ -94,6 +94,7 @@ namespace webrtc
         ComPtr<ID3D12Device> m_d3d12Device;
         ComPtr<ID3D12CommandQueue> m_d3d12CommandQueue;
         ComPtr<ID3D12Fence> m_fence;
+        uint64_t m_nextFrameFenceValue;
 
         bool m_isCudaSupport;
         CudaContext m_cudaContext;
@@ -102,6 +103,7 @@ namespace webrtc
         ID3D12CommandAllocatorPtr m_commandAllocator;
         ID3D12GraphicsCommandList4Ptr m_commandList;
 
+        uint64_t GetNextFrameFenceValue() const;
         uint64_t ExecuteCommandList(
             int listCount,
             ID3D12GraphicsCommandList* commandList,

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -78,6 +78,7 @@ namespace webrtc
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
         bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
         bool ResetSync(const ITexture2D* texture) override;
+        bool WaitIdleForTest();
 
         virtual ITexture2D*
         CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;


### PR DESCRIPTION
The command buffer allocator should be reset once in one frame.
According to [the API document](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12commandallocator-reset):

> Unlike [ID3D12GraphicsCommandList::Reset](https://learn.microsoft.com/en-us/windows/desktop/api/d3d12/nf-d3d12-id3d12graphicscommandlist-reset), it is not recommended that you call Reset on the command allocator while a command list is still being executed.

In [the last PR](https://github.com/Unity-Technologies/com.unity.webrtc/pull/924), the copy texture process was changed asyncnous. This is no problem when using one video source. However, it is failed by using multiple video sources.