### PR TITLE
fix: Fix crash when sending videos from multiple peers with DX12

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -28,7 +28,6 @@ namespace webrtc
         , m_unityInterface(unityInterface)
         , m_d3d12Device(nativeDevice)
         , m_d3d12CommandQueue(unityInterface->GetCommandQueue())
-        , m_nextFrameFenceValue(0)
     {
     }
     //---------------------------------------------------------------------------------------------------------------------
@@ -41,7 +40,6 @@ namespace webrtc
         , m_unityInterface(nullptr)
         , m_d3d12Device(nativeDevice)
         , m_d3d12CommandQueue(commandQueue)
-        , m_nextFrameFenceValue(0)
     {
     }
 
@@ -271,8 +269,9 @@ namespace webrtc
         HANDLE handle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
         if (!handle)
             return false;
-        ThrowIfFailed(m_d3d12CommandQueue->Signal(m_fence.Get(), m_nextFrameFenceValue));
-        ThrowIfFailed(m_fence->SetEventOnCompletion(m_nextFrameFenceValue, handle));
+        uint64_t nextFrameFenceValue = GetNextFrameFenceValue();
+        ThrowIfFailed(m_d3d12CommandQueue->Signal(m_fence.Get(), nextFrameFenceValue));
+        ThrowIfFailed(m_fence->SetEventOnCompletion(nextFrameFenceValue, handle));
         DWORD ret = WaitForSingleObject(handle, INFINITE);
         CloseHandle(handle);
         if (ret != WAIT_OBJECT_0)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -89,7 +89,21 @@ namespace webrtc
         NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
 
     private:
+        struct Frame
+        {
+            ID3D12CommandAllocatorPtr commandAllocator;
+            ID3D12GraphicsCommandList4Ptr commandList;
+            uint64_t fenceValue;
+        };
         D3D12Texture2D* CreateSharedD3D12Texture(uint32_t w, uint32_t h);
+        uint64_t GetNextFrameFenceValue() const;
+        uint64_t ExecuteCommandList(
+            int listCount,
+            ID3D12GraphicsCommandList* commandList,
+            int stateCount,
+            UnityGraphicsD3D12ResourceState* states);
+        ID3D12Fence* GetFence();
+        bool CreateFrame(Frame& frame);
 
         IUnityGraphicsD3D12v5* m_unityInterface;
         ComPtr<ID3D12Device> m_d3d12Device;
@@ -100,21 +114,7 @@ namespace webrtc
         bool m_isCudaSupport;
         CudaContext m_cudaContext;
 
-        struct Frame
-        {
-            ID3D12CommandAllocatorPtr commandAllocator;
-            ID3D12GraphicsCommandList4Ptr commandList;
-            uint64_t fenceValue;
-        };
-        Frame m_frames[2];
-
-        uint64_t GetNextFrameFenceValue() const;
-        uint64_t ExecuteCommandList(
-            int listCount,
-            ID3D12GraphicsCommandList* commandList,
-            int stateCount,
-            UnityGraphicsD3D12ResourceState* states);
-        ID3D12Fence* GetFence();
+        std::vector<Frame> m_frames;
     };
 
     //---------------------------------------------------------------------------------------------------------------------

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -109,7 +109,6 @@ namespace webrtc
         ComPtr<ID3D12Device> m_d3d12Device;
         ComPtr<ID3D12CommandQueue> m_d3d12CommandQueue;
         ComPtr<ID3D12Fence> m_fence;
-        uint64_t m_nextFrameFenceValue;
 
         bool m_isCudaSupport;
         CudaContext m_cudaContext;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -100,9 +100,13 @@ namespace webrtc
         bool m_isCudaSupport;
         CudaContext m_cudaContext;
 
-        //[TODO-sin: 2019-12-2] //This should be allocated for each frame.
-        ID3D12CommandAllocatorPtr m_commandAllocator;
-        ID3D12GraphicsCommandList4Ptr m_commandList;
+        struct Frame
+        {
+            ID3D12CommandAllocatorPtr commandAllocator;
+            ID3D12GraphicsCommandList4Ptr commandList;
+            uint64_t fenceValue;
+        };
+        Frame m_frames[2];
 
         uint64_t GetNextFrameFenceValue() const;
         uint64_t ExecuteCommandList(


### PR DESCRIPTION
There is a previous fix here. 
https://github.com/Unity-Technologies/com.unity.webrtc/pull/939

**ID3D12CommandAllocator::Reset** should not be called before the command execution is complete. However, if only one ID3D12CommandAllocator is used, the previous command may not be completed in time. 

This fix uses multiple ID3D12CommandAllocator so that the ID3D12CommandAllocator in use is not discarded.