### PR TITLE
performance: Use GLsync to wait commandbuffer GPU process on GLCore/GLES

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -176,7 +176,7 @@ namespace webrtc
         // Create sync object.
         GLsync sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
         GLenum error = glGetError();
-        if(error != GL_NO_ERROR)
+        if (error != GL_NO_ERROR)
         {
             RTC_LOG(LS_INFO) << "glFenceSync returns error " << error;
             return false;
@@ -284,20 +284,20 @@ namespace webrtc
 
         const OpenGLTexture2D* glTexture2D = static_cast<const OpenGLTexture2D*>(texture);
         GLsync sync = glTexture2D->GetSync();
-        if(sync == 0)
+        if (sync == 0)
         {
             RTC_LOG(LS_INFO) << "The sync object is already reset.";
             return true;
         }
         GLenum ret = glClientWaitSync(sync, GL_SYNC_FLUSH_COMMANDS_BIT, nsTimeout);
         GLenum error = glGetError();
-        if(error != GL_NO_ERROR)
+        if (error != GL_NO_ERROR)
         {
             RTC_LOG(LS_INFO) << "glClientWaitSync returns error " << error;
             return false;
         }
 
-        switch(ret)
+        switch (ret)
         {
         case GL_CONDITION_SATISFIED:
         case GL_ALREADY_SIGNALED:
@@ -311,14 +311,14 @@ namespace webrtc
     {
         const OpenGLTexture2D* glTexture2D = static_cast<const OpenGLTexture2D*>(texture);
         GLsync sync = glTexture2D->GetSync();
-        if(sync == 0)
+        if (sync == 0)
         {
             RTC_LOG(LS_INFO) << "The sync object is already reset.";
             return true;
         }
         glDeleteSync(sync);
         GLenum error = glGetError();
-        if(error != GL_NO_ERROR)
+        if (error != GL_NO_ERROR)
         {
             RTC_LOG(LS_INFO) << "glDeleteSync returns error " << error;
             return false;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -111,20 +111,19 @@ namespace webrtc
         OpenGLTexture2D* srcTexture = static_cast<OpenGLTexture2D*>(src);
         OpenGLTexture2D* dstTexture = static_cast<OpenGLTexture2D*>(dst);
         const GLuint srcName = srcTexture->GetTexture();
-        const GLuint dstName = dstTexture->GetTexture();
-        return CopyResource(dstName, srcName);
+        return CopyResource(dstTexture, srcName);
     }
 
     bool OpenGLGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dst, void* nativeTexturePtr)
     {
-        OpenGLTexture2D* dstTexture = static_cast<OpenGLTexture2D*>(dst);
+        OpenGLTexture2D* texture2D = static_cast<OpenGLTexture2D*>(dst);
         const GLuint srcName = reinterpret_cast<uintptr_t>(nativeTexturePtr);
-        const GLuint dstName = dstTexture->GetTexture();
-        return CopyResource(dstName, srcName);
+        return CopyResource(texture2D, srcName);
     }
 
-    bool OpenGLGraphicsDevice::CopyResource(GLuint dstName, GLuint srcName)
+    bool OpenGLGraphicsDevice::CopyResource(OpenGLTexture2D* texture, GLuint srcName)
     {
+        const GLuint dstName = texture->GetTexture();
         if (srcName == dstName)
         {
             RTC_LOG(LS_INFO) << "Same texture";
@@ -176,8 +175,15 @@ namespace webrtc
 
         // todo(kazuki): "glFinish" is used to sync GPU for waiting to copy the texture buffer.
         // But this command affects graphics performance.
-        glFinish();
-
+        //glFinish();
+        GLsync sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+        GLenum error = glGetError();
+        if(error != GL_NO_ERROR)
+        {
+            RTC_LOG(LS_INFO) << "glFenceSync returns error " << error;
+            return false;
+        }
+        texture->SetSync(sync);
         return true;
     }
 
@@ -271,6 +277,42 @@ namespace webrtc
 #else
         return nullptr;
 #endif
+    }
+
+    bool OpenGLGraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    {
+        const OpenGLTexture2D* glTexture2D = static_cast<const OpenGLTexture2D*>(texture);
+        GLsync sync = glTexture2D->GetSync();
+        GLenum ret = glClientWaitSync(sync, GL_SYNC_FLUSH_COMMANDS_BIT, nsTimeout);
+        GLenum error = glGetError();
+        if(error != GL_NO_ERROR)
+        {
+            RTC_LOG(LS_INFO) << "glClientWaitSync returns error " << error;
+            return false;
+        }
+
+        switch(ret)
+        {
+        case GL_CONDITION_SATISFIED:
+        case GL_ALREADY_SIGNALED:
+            return true;
+        }
+        RTC_LOG(LS_INFO) << "glClientWaitSync returns " << ret;
+        return false;
+    }
+
+    bool OpenGLGraphicsDevice::ResetSync(const ITexture2D* texture)
+    {
+        const OpenGLTexture2D* glTexture2D = static_cast<const OpenGLTexture2D*>(texture);
+        GLsync sync = glTexture2D->GetSync();
+        glDeleteSync(sync);
+        GLenum error = glGetError();
+        if(error != GL_NO_ERROR)
+        {
+            RTC_LOG(LS_INFO) << "glDeleteSync returns error " << error;
+            return false;
+        }
+        return true;
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
@@ -37,15 +37,16 @@ namespace webrtc
         rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
         bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
+        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool ResetSync(const ITexture2D* texture) override;
 
 #if CUDA_PLATFORM
         bool IsCudaSupport() override { return m_isCudaSupport; }
         CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
         NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ABGR; }
 #endif
-
     private:
-        bool CopyResource(GLuint dstName, GLuint srcName);
+        bool CopyResource(OpenGLTexture2D* texture, GLuint srcName);
         void ReleaseTexture(OpenGLTexture2D* texture);
 #if CUDA_PLATFORM
         CudaContext m_cudaContext;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.cpp
@@ -7,13 +7,11 @@ namespace unity
 {
 namespace webrtc
 {
-
-    //---------------------------------------------------------------------------------------------------------------------
-
     OpenGLTexture2D::OpenGLTexture2D(uint32_t w, uint32_t h, GLuint tex, ReleaseOpenGLTextureCallback callback)
         : ITexture2D(w, h)
         , m_texture(tex)
         , m_pbo(0)
+        , m_sync(0)
         , m_callback(callback)
     {
         RTC_DCHECK(m_texture);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLTexture2D.h
@@ -36,9 +36,13 @@ namespace webrtc
         GLuint GetTexture() const { return m_texture; }
         void Release();
 
+        void SetSync(GLsync sync) { m_sync = sync; }
+        GLsync GetSync() const { return m_sync; }
+
     private:
         GLuint m_texture;
         GLuint m_pbo;
+        GLsync m_sync;
         std::vector<byte> m_buffer;
         ReleaseOpenGLTextureCallback m_callback;
     };


### PR DESCRIPTION
This PR improves a CPU load of Render thread when using video encoding with OpenGL or GLES. 
It uses **GLSync** instead of **glFinish**  to sync GPU and CPU.

Specifically, the process time of **UnityVideoTrackSource.OnFrameCaptured** is dramatically reduced.

## Before
![Screenshot from 2023-08-30 14-26-10](https://github.com/Unity-Technologies/com.unity.webrtc/assets/1132081/14a8137e-5202-4b67-8fdd-ca6a23fd4e5d)

## After 
![Screenshot from 2023-08-30 14-21-42](https://github.com/Unity-Technologies/com.unity.webrtc/assets/1132081/e4315ba8-9103-471b-ad01-3cacf90022a4)
