### PR TITLE
feat: Add configurable logger

### DIFF
--- a/Plugin~/WebRTCPlugin/Logger.cpp
+++ b/Plugin~/WebRTCPlugin/Logger.cpp
@@ -14,15 +14,15 @@ namespace webrtc
 {
     DelegateDebugLog delegateDebugLog = nullptr;
 
-    void debugLog(const char* buf)
+    void debugLog(rtc::LoggingSeverity severity, const char* buf)
     {
         if (delegateDebugLog != nullptr)
         {
-            delegateDebugLog(buf);
+            delegateDebugLog(buf, severity);
         }
     }
 
-    void LogPrint(const char* fmt, ...)
+    void LogPrint(rtc::LoggingSeverity severity, const char* fmt, ...)
     {
 #if _DEBUG
         va_list vl;
@@ -33,7 +33,7 @@ namespace webrtc
 #else
         vsprintf(buf, fmt, vl);
 #endif
-        debugLog(buf);
+        debugLog(severity, buf);
         va_end(vl);
 #endif
     }

--- a/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
+++ b/Plugin~/WebRTCPlugin/PeerConnectionObject.cpp
@@ -231,7 +231,7 @@ namespace webrtc
         const auto error = connection->SetConfiguration(_config);
         if (!error.ok())
         {
-            LogPrint(error.message());
+            LogPrint(rtc::LoggingSeverity::LS_ERROR, error.message());
         }
         return error.type();
     }

--- a/Plugin~/WebRTCPlugin/UnityLogStream.cpp
+++ b/Plugin~/WebRTCPlugin/UnityLogStream.cpp
@@ -11,10 +11,12 @@ namespace webrtc
 
     void UnityLogStream::OnLogMessage(const std::string& message)
     {
-        if (on_log_message != nullptr)
-        {
-            on_log_message(message.c_str());
-        }
+        logMessage(message, rtc::LoggingSeverity::LS_INFO);
+    }
+
+    void UnityLogStream::OnLogMessage(const std::string& message, rtc::LoggingSeverity severity)
+    {
+        logMessage(message, severity);
     }
 
     void UnityLogStream::AddLogStream(DelegateDebugLog callback, rtc::LoggingSeverity loggingSeverity)
@@ -30,6 +32,14 @@ namespace webrtc
         {
             rtc::LogMessage::RemoveLogToStream(log_stream.get());
             log_stream.reset();
+        }
+    }
+
+    void UnityLogStream::logMessage(const std::string& message, rtc::LoggingSeverity severity)
+    {
+        if (on_log_message != nullptr)
+        {
+            on_log_message(message.c_str(), severity);
         }
     }
 

--- a/Plugin~/WebRTCPlugin/UnityLogStream.h
+++ b/Plugin~/WebRTCPlugin/UnityLogStream.h
@@ -19,12 +19,14 @@ namespace webrtc
 
         // log format can be defined in this interface
         void OnLogMessage(const std::string& message) override;
+        void OnLogMessage(const std::string& message, rtc::LoggingSeverity severity) override;
 
-        static void AddLogStream(DelegateDebugLog callback, rtc::LoggingSeverity loggingSeverity);
+        static void AddLogStream(DelegateDebugLog callback, rtc::LoggingSeverity minLoggingSeverity);
         static void RemoveLogStream();
 
     private:
         DelegateDebugLog on_log_message;
+        void logMessage(const std::string& message, rtc::LoggingSeverity severity);
 
         static std::unique_ptr<UnityLogStream> log_stream;
     };

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.h
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.h
@@ -21,7 +21,7 @@ namespace webrtc
     enum class RTCPeerConnectionEventType;
     struct MediaStreamEvent;
 
-    using DelegateDebugLog = void (*)(const char*);
+    using DelegateDebugLog = void (*)(const char*, rtc::LoggingSeverity severity);
     using DelegateSetResolution = void (*)(int32_t*, int32_t*);
     using DelegateMediaStreamOnAddTrack = void (*)(MediaStreamInterface*, MediaStreamTrackInterface*);
     using DelegateMediaStreamOnRemoveTrack = void (*)(MediaStreamInterface*, MediaStreamTrackInterface*);

--- a/Plugin~/WebRTCPlugin/pch.h
+++ b/Plugin~/WebRTCPlugin/pch.h
@@ -102,16 +102,15 @@ namespace unity
 {
 namespace webrtc
 {
-
-    void LogPrint(const char* fmt, ...);
-    void LogPrint(const wchar_t* fmt, ...);
+    void LogPrint(rtc::LoggingSeverity severity, const char* fmt, ...);
+    void LogPrint(rtc::LoggingSeverity severity, const wchar_t* fmt, ...);
     void checkf(bool result, const char* msg);
-#define DebugLog(...) LogPrint("webrtc Log: " __VA_ARGS__)
-#define DebugWarning(...) LogPrint("webrtc Warning: " __VA_ARGS__)
-#define DebugError(...) LogPrint("webrtc Error: " __VA_ARGS__)
-#define DebugLogW(...) LogPrint(L"webrtc Log: " __VA_ARGS__)
-#define DebugWarningW(...) LogPrint(L"webrtc Warning: " __VA_ARGS__)
-#define DebugErrorW(...) LogPrint(L"webrtc Error: " __VA_ARGS__)
+#define DebugLog(...) LogPrint(rtc::LoggingSeverity::LS_INFO, "webrtc Log: " __VA_ARGS__)
+#define DebugWarning(...) LogPrint(rtc::LoggingSeverity::LS_WARNING, "webrtc Warning: " __VA_ARGS__)
+#define DebugError(...) LogPrint(rtc::LoggingSeverity::LS_ERROR, "webrtc Error: " __VA_ARGS__)
+#define DebugLogW(...) LogPrint(rtc::LoggingSeverity::LS_INFO, L"webrtc Log: " __VA_ARGS__)
+#define DebugWarningW(...) LogPrint(rtc::LoggingSeverity::LS_WARNING, L"webrtc Warning: " __VA_ARGS__)
+#define DebugErrorW(...) LogPrint(rtc::LoggingSeverity::LS_ERROR, L"webrtc Error: " __VA_ARGS__)
 #define NV_RESULT(NvFunction) NvFunction == NV_ENC_SUCCESS
 
 #if !UNITY_WIN

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -42,6 +42,10 @@ namespace Unity.WebRTC.RuntimeTest
         [Test]
         public void QuitAndInitContextManager()
         {
+            // ignore error message
+            // Unhandled log message: '[Exception] [000:016](rtp_transceiver.cc:598): PeerConnection is closed. (INVALID_STATE)
+            UnityEngine.TestTools.LogAssert.ignoreFailingMessages = true;
+
             // ContextManager.Init is already called when the process reaches here.
             ContextManager.Quit();
             ContextManager.Init();
@@ -50,6 +54,7 @@ namespace Unity.WebRTC.RuntimeTest
             // Reinitialize
             WebRTC.InitializeInternal();
 #endif
+            UnityEngine.TestTools.LogAssert.ignoreFailingMessages = false;
         }
 
         [Test]

--- a/Tests/Runtime/ContextTest.cs
+++ b/Tests/Runtime/ContextTest.cs
@@ -1,14 +1,30 @@
 using System;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Unity.WebRTC.RuntimeTest
 {
     class ContextTest
     {
         [AOT.MonoPInvokeCallback(typeof(DelegateDebugLog))]
-        static void DebugLog(string str)
+        static void DebugLog(string str, NativeLoggingSeverity severity)
         {
-            UnityEngine.Debug.Log(str);
+            LogType logType = LogType.Log;
+            switch (severity)
+            {
+                case NativeLoggingSeverity.Warning:
+                {
+                    logType = LogType.Warning;
+                    break;
+                }
+                case NativeLoggingSeverity.Error:
+                {
+                    logType = LogType.Exception;
+                    break;
+                }
+            }
+
+            UnityEngine.Debug.unityLogger.Log(logType, str);
         }
 
         [SetUp]

--- a/Tests/Runtime/MockLogger.cs
+++ b/Tests/Runtime/MockLogger.cs
@@ -1,0 +1,93 @@
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Unity.WebRTC.RuntimeTest
+{
+    public class MockLogger : ILogger
+    {
+        public void LogFormat(LogType logType, Object context, string format, params object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogException(Exception exception, Object context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsLogTypeAllowed(LogType logType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(LogType logType, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(LogType logType, object message, Object context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(LogType logType, string tag, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(LogType logType, string tag, object message, Object context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(string tag, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(string tag, object message, Object context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogWarning(string tag, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogWarning(string tag, object message, Object context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogError(string tag, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogError(string tag, object message, Object context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogFormat(LogType logType, string format, params object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LogException(Exception exception)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ILogHandler logHandler { get; set; }
+        public bool logEnabled { get; set; }
+        public LogType filterLogType { get; set; }
+    }
+}

--- a/Tests/Runtime/MockLogger.cs.meta
+++ b/Tests/Runtime/MockLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 934a1755a037f5d42a33d19feac14ab0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -7,6 +7,12 @@ namespace Unity.WebRTC.RuntimeTest
 {
     class WebRTCTest
     {
+        [TearDown]
+        public void TearDown()
+        {
+            WebRTC.Logger = Debug.unityLogger;
+        }
+
         [Test]
         public void GraphicsFormat()
         {
@@ -102,6 +108,28 @@ namespace Unity.WebRTC.RuntimeTest
         public void ValidateLegacyGraphicsFormat(GraphicsFormat format)
         {
             Assert.That(() => WebRTC.ValidateGraphicsFormat(format), Throws.Nothing);
+        }
+
+        [Test]
+        public void EnableLogging()
+        {
+            Assert.DoesNotThrow(() => WebRTC.ConfigureNativeLogging(true, NativeLoggingSeverity.Verbose));
+            Assert.DoesNotThrow(() => WebRTC.ConfigureNativeLogging(false, NativeLoggingSeverity.None));
+        }
+
+        [Test]
+        public void Logger()
+        {
+            Assert.NotNull(WebRTC.Logger);
+            Assert.AreEqual(WebRTC.Logger, Debug.unityLogger);
+
+            Assert.That(() => WebRTC.Logger = null, Throws.ArgumentNullException);
+
+            MockLogger logger = new MockLogger();
+            Assert.That(() => WebRTC.Logger = logger, Throws.Nothing);
+            Assert.AreEqual(logger, WebRTC.Logger);
+
+            Assert.That(() => WebRTC.Logger = Debug.unityLogger, Throws.Nothing);
         }
     }
 }


### PR DESCRIPTION
Description of changes:

- Added configurable logger to WebRTC to enable users to customize logging for their environment.
- Added API to allow for configuring native logging.
- Updated logging inside the package to use the settable logger instead of the built in Unity logging.

How this was tested:

- Tested by running the WebRTC package tests & Native tests.
- Ran through the package samples to ensure it's working properly with and without a new logger set.