### PR TITLE
add SimulcastEncoderFactory and initial simulcast support for NvEncoder

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/Codec/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(
-  WebRTCLib PRIVATE CreateVideoCodecFactory.cpp CreateVideoCodecFactory.h
-                    H264ProfileLevelId.cpp H264ProfileLevelId.h)
+  WebRTCLib
+  PRIVATE CreateVideoCodecFactory.cpp CreateVideoCodecFactory.h
+          H264ProfileLevelId.cpp H264ProfileLevelId.h
+          SimulcastEncoderFactory.cpp SimulcastEncoderFactory.h)
 
 if(Windows OR Linux)
   add_subdirectory(NvCodec)

--- a/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
@@ -9,6 +9,7 @@
 
 #if CUDA_PLATFORM
 #include "Codec/NvCodec/NvCodec.h"
+#include "SimulcastEncoderFactory.h"
 #endif
 
 #if UNITY_OSX || UNITY_IOS
@@ -57,7 +58,9 @@ namespace webrtc
             {
                 CUcontext context = gfxDevice->GetCUcontext();
                 NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();
-                return new NvEncoderFactory(context, format, profiler);
+                std::unique_ptr<VideoEncoderFactory> factory =
+                    std::make_unique<NvEncoderFactory>(context, format, profiler);
+                return CreateSimulcastEncoderFactory(std::move(factory));
             }
 #endif
         }

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -13,6 +13,7 @@
 #include <common_video/h264/h264_common.h>
 #include <media/base/media_constants.h>
 #include <modules/video_coding/include/video_codec_interface.h>
+#include <modules/video_coding/utility/simulcast_utility.h>
 
 #include "Codec/H264ProfileLevelId.h"
 #include "Codec/NvCodec/NvEncoderCudaWithCUarray.h"
@@ -154,8 +155,6 @@ namespace webrtc
         , m_encoder(nullptr)
         , m_format(format)
         , m_encodedCompleteCallback(nullptr)
-        , m_encode_fps(1000, 1000)
-        , m_clock(Clock::GetRealTimeClock())
         , m_profiler(profiler)
     {
         RTC_CHECK(absl::EqualsIgnoreCase(codec.name, cricket::kH264CodecName));
@@ -188,6 +187,7 @@ namespace webrtc
         VideoEncoder::EncoderInfo info;
         info.implementation_name = "NvCodec";
         info.is_hardware_accelerated = true;
+        info.supports_native_handle = true;
         return info;
     }
 
@@ -204,6 +204,14 @@ namespace webrtc
         if (codec->width < 1 || codec->height < 1)
         {
             return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+        }
+
+        int number_of_streams = SimulcastUtility::NumberOfSimulcastStreams(*codec);
+        bool doing_simulcast = (number_of_streams > 1);
+
+        if (doing_simulcast && !SimulcastUtility::ValidSimulcastParameters(*codec, number_of_streams))
+        {
+            return WEBRTC_VIDEO_CODEC_ERR_SIMULCAST_PARAMETERS_NOT_SUPPORTED;
         }
 
         m_codec = *codec;
@@ -236,11 +244,10 @@ namespace webrtc
             return ret;
         }
 
-        const int number_of_streams = 1;
         m_configurations.resize(number_of_streams);
 
         const CUresult result = cuCtxSetCurrent(m_context);
-        if (!ck(result))
+        if (result != CUDA_SUCCESS)
         {
             return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
         }
@@ -279,9 +286,6 @@ namespace webrtc
         m_configurations[0].key_frame_interval = m_codec.H264()->keyFrameInterval;
         m_configurations[0].max_bps = m_codec.maxBitrate * 1000;
         m_configurations[0].target_bps = m_codec.startBitrate * 1000;
-
-        m_bitrateAdjuster = std::make_unique<BitrateAdjuster>(0.5f, 0.95f);
-        m_bitrateAdjuster->SetTargetBitrateBps(m_configurations[0].target_bps);
 
         m_initializeParams.version = NV_ENC_INITIALIZE_PARAMS_VER;
         m_encodeConfig.version = NV_ENC_CONFIG_VER;
@@ -425,8 +429,7 @@ namespace webrtc
             return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
 
         auto frameBuffer = frame.video_frame_buffer();
-        if (frameBuffer->type() != VideoFrameBuffer::Type::kNative || frameBuffer->width() != m_codec.width ||
-            frameBuffer->height() != m_codec.height)
+        if (frameBuffer->type() != VideoFrameBuffer::Type::kNative)
             return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
 
         auto videoFrameBuffer = static_cast<ScalableBufferInterface*>(frameBuffer.get());
@@ -451,40 +454,45 @@ namespace webrtc
             }
         }
 
-        Size encodeSize(m_encoder->GetEncodeWidth(), m_encoder->GetEncodeHeight());
-
-        const NvEncInputFrame* encoderInputFrame = m_encoder->GetNextInputFrame();
-
-        // Copy CUDA buffer in VideoFrame to encoderInputFrame.
-        auto buffer = video_frame->GetGpuMemoryBuffer();
-        if (!CopyResource(encoderInputFrame, buffer, encodeSize, m_context, m_memoryType))
-            return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
-
-        NV_ENC_PIC_PARAMS picParams = NV_ENC_PIC_PARAMS();
-        picParams.version = NV_ENC_PIC_PARAMS_VER;
-        picParams.encodePicFlags = 0;
-        if (send_key_frame)
+        try
         {
-            picParams.encodePicFlags =
-                NV_ENC_PIC_FLAG_FORCEINTRA | NV_ENC_PIC_FLAG_FORCEIDR | NV_ENC_PIC_FLAG_OUTPUT_SPSPPS;
-            m_configurations[0].key_frame_request = false;
-        }
+            Size encodeSize(m_encoder->GetEncodeWidth(), m_encoder->GetEncodeHeight());
 
-        std::vector<std::vector<uint8_t>> vPacket;
-        m_encoder->EncodeFrame(vPacket, &picParams);
+            const NvEncInputFrame* encoderInputFrame = m_encoder->GetNextInputFrame();
 
-        for (std::vector<uint8_t>& packet : vPacket)
-        {
-            int32_t result = ProcessEncodedFrame(packet, frame);
-            if (result != WEBRTC_VIDEO_CODEC_OK)
+            // Copy CUDA buffer in VideoFrame to encoderInputFrame.
+            auto buffer = video_frame->GetGpuMemoryBuffer();
+            if (!CopyResource(encoderInputFrame, buffer, encodeSize, m_context, m_memoryType))
+                return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+
+            NV_ENC_PIC_PARAMS picParams = NV_ENC_PIC_PARAMS();
+            picParams.version = NV_ENC_PIC_PARAMS_VER;
+            picParams.encodePicFlags = 0;
+            if (send_key_frame)
             {
-                return result;
+                picParams.encodePicFlags =
+                    NV_ENC_PIC_FLAG_FORCEINTRA | NV_ENC_PIC_FLAG_FORCEIDR | NV_ENC_PIC_FLAG_OUTPUT_SPSPPS;
+                m_configurations[0].key_frame_request = false;
             }
-            m_bitrateAdjuster->Update(packet.size());
 
-            int64_t now_ms = m_clock->TimeInMilliseconds();
-            m_encode_fps.Update(1, now_ms);
+            std::vector<std::vector<uint8_t>> vPacket;
+            m_encoder->EncodeFrame(vPacket, &picParams);
+
+            for (std::vector<uint8_t>& packet : vPacket)
+            {
+                int32_t result = ProcessEncodedFrame(packet, frame);
+                if (result != WEBRTC_VIDEO_CODEC_OK)
+                {
+                    return result;
+                }
+            }
         }
+        catch (const NVENCException& e)
+        {
+            RTC_LOG(LS_ERROR) << "Failed EncodeFrame NvEncoder " << e.what();
+            return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+        }
+
         return WEBRTC_VIDEO_CODEC_OK;
     }
 
@@ -552,11 +560,8 @@ namespace webrtc
             return;
         }
 
-        m_bitrateAdjuster->SetTargetBitrateBps(parameters.bitrate.get_sum_bps());
-        const uint32_t bitrate = m_bitrateAdjuster->GetAdjustedBitrateBps();
-
         m_codec.maxFramerate = static_cast<uint32_t>(parameters.framerate_fps);
-        m_codec.maxBitrate = bitrate;
+        m_codec.maxBitrate = parameters.bitrate.GetSpatialLayerSum(0);
 
         // Check required level.
         auto requiredLevel = NvEncRequiredLevel(m_codec, s_formats, m_profileGuid);

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.h
@@ -5,9 +5,7 @@
 #include <api/video_codecs/video_codec.h>
 #include <api/video_codecs/video_encoder.h>
 #include <common_video/h264/h264_bitstream_parser.h>
-#include <common_video/include/bitrate_adjuster.h>
 #include <media/base/codec.h>
-#include <system_wrappers/include/clock.h>
 
 #include "NvCodec.h"
 #include "NvEncoder/NvEncoderCuda.h"
@@ -94,9 +92,6 @@ namespace webrtc
         EncodedImage m_encodedImage;
         //    RTPFragmentationHeader m_fragHeader;
         H264BitstreamParser m_h264BitstreamParser;
-        std::unique_ptr<BitrateAdjuster> m_bitrateAdjuster;
-        RateStatistics m_encode_fps;
-        Clock* const m_clock;
         GUID m_profileGuid;
         NV_ENC_LEVEL m_level;
         ProfilerMarkerFactory* m_profiler;

--- a/Plugin~/WebRTCPlugin/Codec/SimulcastEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/SimulcastEncoderFactory.cpp
@@ -1,0 +1,73 @@
+#include "pch.h"
+
+#include <memory>
+#include <vector>
+
+#include <absl/strings/match.h>
+#include <api/video_codecs/sdp_video_format.h>
+#include <api/video_codecs/video_encoder.h>
+#include <media/base/codec.h>
+#include <media/base/media_constants.h>
+#include <media/engine/encoder_simulcast_proxy.h>
+#include <media/engine/internal_encoder_factory.h>
+#include <rtc_base/checks.h>
+
+#include "SimulcastEncoderFactory.h"
+
+namespace unity
+{
+namespace webrtc
+{
+
+    namespace
+    {
+
+        using namespace ::webrtc;
+
+        // This class wraps the internal factory and adds simulcast.
+        class SimulcastEncoderFactory : public VideoEncoderFactory
+        {
+        public:
+            SimulcastEncoderFactory(std::unique_ptr<VideoEncoderFactory> factory)
+                : internal_encoder_factory_(std::move(factory))
+            {
+            }
+
+            VideoEncoderFactory::CodecSupport
+            QueryCodecSupport(const SdpVideoFormat& format, absl::optional<std::string> scalability_mode) const override
+            {
+                // Format must be one of the internal formats.
+                RTC_DCHECK(format.IsCodecInList(internal_encoder_factory_->GetSupportedFormats()));
+                return internal_encoder_factory_->QueryCodecSupport(format, scalability_mode);
+            }
+
+            std::unique_ptr<VideoEncoder> CreateVideoEncoder(const SdpVideoFormat& format) override
+            {
+                // Try creating internal encoder.
+                std::unique_ptr<VideoEncoder> internal_encoder;
+                if (format.IsCodecInList(internal_encoder_factory_->GetSupportedFormats()))
+                {
+                    internal_encoder = std::make_unique<EncoderSimulcastProxy>(internal_encoder_factory_.get(), format);
+                }
+
+                return internal_encoder;
+            }
+
+            std::vector<SdpVideoFormat> GetSupportedFormats() const override
+            {
+                return internal_encoder_factory_->GetSupportedFormats();
+            }
+
+        private:
+            const std::unique_ptr<VideoEncoderFactory> internal_encoder_factory_;
+        };
+
+    } // namespace
+
+    VideoEncoderFactory* CreateSimulcastEncoderFactory(std::unique_ptr<VideoEncoderFactory> factory)
+    {
+        return new SimulcastEncoderFactory(std::move(factory));
+    }
+
+} // namespace webrtc
+} // namespace unity

--- a/Plugin~/WebRTCPlugin/Codec/SimulcastEncoderFactory.h
+++ b/Plugin~/WebRTCPlugin/Codec/SimulcastEncoderFactory.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "api/video_codecs/video_encoder_factory.h"
+#include <memory>
+
+namespace unity
+{
+
+namespace webrtc
+{
+
+    ::webrtc::VideoEncoderFactory*
+    CreateSimulcastEncoderFactory(std::unique_ptr<::webrtc::VideoEncoderFactory> factory);
+
+} // namespace webrtc
+} // namespace unity

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -469,6 +469,7 @@ extern "C"
         PeerConnectionInterface::RTCConfiguration config;
         config.sdp_semantics = SdpSemantics::kUnifiedPlan;
         config.enable_implicit_rollback = true;
+        config.set_suspend_below_min_bitrate(false);
         return context->CreatePeerConnection(config);
     }
 
@@ -481,6 +482,7 @@ extern "C"
 
         config.sdp_semantics = SdpSemantics::kUnifiedPlan;
         config.enable_implicit_rollback = true;
+        config.set_suspend_below_min_bitrate(false);
         return context->CreatePeerConnection(config);
     }
 


### PR DESCRIPTION
SimulcastEncoderFactory using alternative to https://github.com/Unity-Technologies/com.unity.webrtc/pull/955

Cherry-picked from a branch with lots of other customizations in progress, haven't even tried to compile it against vanilla 
version. :) 

#955 has the Simulcast example scene in progress, but I didn't try running it. After rebasing and catching up with latest main, seems to still work for our internal use case. 

In addition, we've exposed PC SetBitrate/webrtc::BitrateSettings to C# but things should work without fine-grained control, I can cherry-pick that one in too if interested