### PR TITLE
Fix: Cuda thread safety with D3D11

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/CMakeLists.txt
@@ -1,6 +1,13 @@
 target_sources(
-  WebRTCLib PRIVATE GraphicsDevice.cpp GraphicsDevice.h GraphicsUtility.cpp
-                    GraphicsUtility.h IGraphicsDevice.h ITexture2D.h)
+  WebRTCLib
+  PRIVATE GraphicsDevice.cpp
+          GraphicsDevice.h
+          GraphicsUtility.cpp
+          GraphicsUtility.h
+          IGraphicsDevice.h
+          ITexture2D.h
+          ScopedGraphicsDeviceLock.cpp
+          ScopedGraphicsDeviceLock.h)
 
 if(Windows)
   add_subdirectory(Vulkan)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "GpuMemoryBufferCudaHandle.h"
+#include "GraphicsDevice/ScopedGraphicsDeviceLock.h"
 
 namespace unity
 {
@@ -21,6 +22,7 @@ namespace webrtc
 
     GpuMemoryBufferCudaHandle::~GpuMemoryBufferCudaHandle()
     {
+        ScopedGraphicsDeviceLock guard;
         GMB_CUDA_CALL(cuCtxPushCurrent(context));
 
         mappedArray = nullptr;
@@ -48,6 +50,7 @@ namespace webrtc
     std::unique_ptr<GpuMemoryBufferCudaHandle>
     GpuMemoryBufferCudaHandle::CreateHandle(CUcontext context, ID3D11Resource* resource)
     {
+        ScopedGraphicsDeviceLock guard;
         GMB_CUDA_CALL_NULLPTR(cuCtxPushCurrent(context));
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
@@ -65,6 +68,7 @@ namespace webrtc
     std::unique_ptr<GpuMemoryBufferCudaHandle> GpuMemoryBufferCudaHandle::CreateHandle(
         CUcontext context, ID3D12Resource* resource, HANDLE sharedHandle, size_t memorySize)
     {
+        ScopedGraphicsDeviceLock guard;
         GMB_CUDA_CALL_NULLPTR(cuCtxPushCurrent(context));
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
@@ -106,6 +110,7 @@ namespace webrtc
     std::unique_ptr<GpuMemoryBufferCudaHandle>
     GpuMemoryBufferCudaHandle::CreateHandle(CUcontext context, void* exportHandle, size_t memorySize, const Size& size)
     {
+        ScopedGraphicsDeviceLock guard;
         GMB_CUDA_CALL_NULLPTR(cuCtxPushCurrent(context));
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();
@@ -146,6 +151,7 @@ namespace webrtc
     std::unique_ptr<GpuMemoryBufferCudaHandle>
     GpuMemoryBufferCudaHandle::CreateHandle(CUcontext context, GLuint texture)
     {
+        ScopedGraphicsDeviceLock guard;
         GMB_CUDA_CALL_NULLPTR(cuCtxPushCurrent(context));
 
         std::unique_ptr<GpuMemoryBufferCudaHandle> handle = std::make_unique<GpuMemoryBufferCudaHandle>();

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
@@ -33,14 +33,19 @@ namespace webrtc
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
         bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
         bool ResetSync(const ITexture2D* texture) override;
+        void Enter() override;
+        void Leave() override;
+
         virtual rtc::scoped_refptr<::webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
         bool IsCudaSupport() override { return m_isCudaSupport; }
         CUcontext GetCUcontext() override { return m_cudaContext.GetContext(); }
         NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
 
     private:
-        HRESULT Signal(ID3D11Fence* fence);
-        ID3D11Device* m_d3d11Device;
+        HRESULT Signal(ID3D11Fence* fence, uint64_t value);
+        ComPtr<ID3D11Device> m_d3d11Device;
+        ComPtr<ID3D11Device5> m_d3d11Device5;
+        ComPtr<ID3D11Multithread> m_d3d11Multithread;
 
         bool m_isCudaSupport;
         CudaContext m_cudaContext;
@@ -48,7 +53,7 @@ namespace webrtc
 
     //---------------------------------------------------------------------------------------------------------------------
 
-    void* D3D11GraphicsDevice::GetEncodeDevicePtrV() { return reinterpret_cast<void*>(m_d3d11Device); }
+    void* D3D11GraphicsDevice::GetEncodeDevicePtrV() { return reinterpret_cast<void*>(m_d3d11Device.Get()); }
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11Texture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11Texture2D.h
@@ -26,7 +26,7 @@ namespace webrtc
         inline const void* GetEncodeTexturePtrV() const override;
         ID3D11Fence* GetFence() const { return m_fence.Get(); }
         uint64_t GetSyncCount() const { return m_syncCount; }
-        void UpdateSyncCount() const { m_syncCount = m_fence->GetCompletedValue(); }
+        void UpdateSyncCount() const { m_syncCount = m_fence->GetCompletedValue() + 1; }
 
     private:
         ComPtr<ID3D11Texture2D> m_texture;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -49,6 +49,9 @@ namespace webrtc
         virtual bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) { return true; }
         virtual bool ResetSync(const ITexture2D* texture) { return true; }
         virtual bool WaitIdleForTest() { return true; }
+        virtual void Enter() { }
+        virtual void Leave() { }
+
         // Required for software encoding
         virtual ITexture2D*
         CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) = 0;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/ScopedGraphicsDeviceLock.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/ScopedGraphicsDeviceLock.cpp
@@ -1,0 +1,25 @@
+#include "pch.h"
+
+#include "IGraphicsDevice.h"
+#include "ScopedGraphicsDeviceLock.h"
+#include "WebRTCPlugin.h"
+
+namespace unity
+{
+namespace webrtc
+{
+    ScopedGraphicsDeviceLock::ScopedGraphicsDeviceLock()
+    {
+        IGraphicsDevice* device = Plugin::GraphicsDevice();
+        if (device)
+            device->Enter();
+    }
+
+    ScopedGraphicsDeviceLock::~ScopedGraphicsDeviceLock()
+    {
+        IGraphicsDevice* device = Plugin::GraphicsDevice();
+        if (device)
+            device->Leave();
+    }
+}
+}

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/ScopedGraphicsDeviceLock.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/ScopedGraphicsDeviceLock.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace unity
+{
+namespace webrtc
+{
+    class ScopedGraphicsDeviceLock
+    {
+    public:
+        ScopedGraphicsDeviceLock();
+        ~ScopedGraphicsDeviceLock();
+    };
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
+++ b/Plugin~/WebRTCPluginTest/GraphicsDeviceContainer.cpp
@@ -36,10 +36,15 @@
 #pragma clang diagnostic ignored "-Wlanguage-extension-token"
 #endif
 
+#include "WebRTCPlugin.h"
+
 namespace unity
 {
 namespace webrtc
 {
+    // For symbol compatibility with the plugin
+    static IGraphicsDevice* s_gfxDevice = nullptr;
+    IGraphicsDevice* Plugin::GraphicsDevice() { return s_gfxDevice; }
 
 #if defined(SUPPORT_D3D11) // D3D11
 
@@ -532,6 +537,7 @@ namespace webrtc
             device = GraphicsDevice::GetInstance().Init(renderer, nativeGfxDevice_, nullptr, nullptr);
         }
         device_ = std::unique_ptr<IGraphicsDevice>(device);
+        s_gfxDevice = device_.get();
         EXPECT_TRUE(device_->InitV());
     }
 
@@ -539,6 +545,7 @@ namespace webrtc
     {
         if (device_)
             device_->ShutdownV();
+        s_gfxDevice = nullptr;
         if (nativeGfxDevice_)
             DestroyNativeGfxDevice(nativeGfxDevice_, renderer_);
     }


### PR DESCRIPTION
I was doing some testing on PC with Unity editor, though I'm mostly using Vulkan.

I ran into occasional crash issue with D3D11 where the device gets lost and no matter what I did, couldn't repro it with other graphics apis. Someone else had similar issue at https://forums.developer.nvidia.com/t/d3d11-device-context-in-a-separate-thread-gets-corrupted-when-cuda-graphics-resource-mapping-is-used/232326 and luckily applying similar locking fixed the issue for me

I don't recall seeing this issue before, but seems the chances of this happening started after the recent fence change
