### PR TITLE
Update AudioCustomFilter.cs

### DIFF
--- a/Runtime/Scripts/AudioCustomFilter.cs
+++ b/Runtime/Scripts/AudioCustomFilter.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Unity.WebRTC


### PR DESCRIPTION
Fix "Packages\com.unity.webrtc\Runtime\Scripts\AudioCustomFilter.cs(44,17): error CS0103: The name 'Array' does not exist in the current context"