### PR TITLE
feat: Added support for horizontal flip sourceTexture

### DIFF
--- a/Runtime/Scripts/VideoStreamTrack.cs
+++ b/Runtime/Scripts/VideoStreamTrack.cs
@@ -156,11 +156,11 @@ namespace Unity.WebRTC
 
             var dest = CreateRenderTexture(texture.width, texture.height);
 
+            m_source = source;
             if (copyTexture != null)
             {
                 m_source.copyTexture_ = copyTexture;
             }
-            m_source = source;
             m_source.sourceTexture_ = texture;
             m_source.destTexture_ = dest;
             m_source.destTexturePtr_ = dest.GetNativeTexturePtr();


### PR DESCRIPTION
When I added support for "VUZIX M400 SMART GLASSES" to the project, the picture from the glasses was diagonally flipped. So I added the horizontal and diagonal flip.

```
videoStreamTrack = new VideoStreamTrack(webCamTexture, false, true); //Flip horizontaly
sourceRawImage.uvRect = new Rect(1, 1, -1, -1); //Flip diagonally for display
```