### PR TITLE
feat: libwebrtc m116

### DIFF
--- a/.yamato/package.metafile
+++ b/.yamato/package.metafile
@@ -2,7 +2,7 @@ upm:
   registry_url: https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
   package_version: stable
 webrtc_version:
-  name: M115
+  name: M116
 
 editors:
   - version: 2020.3

--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=5790
+export WEBRTC_VERSION=5845
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 export PYTHON3_BIN="$(pwd)/depot_tools/python-bin/python3"

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=5790
+export WEBRTC_VERSION=5845
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 export PYTHON3_BIN="$(pwd)/depot_tools/python-bin/python3"

--- a/BuildScripts~/build_libwebrtc_linux.sh
+++ b/BuildScripts~/build_libwebrtc_linux.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=5790
+export WEBRTC_VERSION=5845
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 export PYTHON3_BIN="$(pwd)/depot_tools/python-bin/python3"

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -7,7 +7,7 @@ fi
 
 export COMMAND_DIR=$(cd $(dirname $0); pwd)
 export PATH="$(pwd)/depot_tools:$PATH"
-export WEBRTC_VERSION=5790
+export WEBRTC_VERSION=5845
 export OUTPUT_DIR="$(pwd)/out"
 export ARTIFACTS_DIR="$(pwd)/artifacts"
 export PYTHON3_BIN="$(pwd)/depot_tools/python-bin/python3"

--- a/BuildScripts~/build_libwebrtc_win.cmd
+++ b/BuildScripts~/build_libwebrtc_win.cmd
@@ -6,7 +6,7 @@ if not exist depot_tools (
 
 set COMMAND_DIR=%~dp0
 set PATH=%cd%\depot_tools;%PATH%
-set WEBRTC_VERSION=5790
+set WEBRTC_VERSION=5845
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 set GYP_GENERATORS=ninja,msvs-ninja
 set GYP_MSVS_VERSION=2022

--- a/BuildScripts~/build_plugin_android.sh
+++ b/BuildScripts~/build_plugin_android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-android.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-android.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export PLUGIN_DIR=$(pwd)/Runtime/Plugins/Android
 

--- a/BuildScripts~/build_plugin_ios.sh
+++ b/BuildScripts~/build_plugin_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-ios.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export WEBRTC_FRAMEWORK_DIR=$(pwd)/Runtime/Plugins/iOS
 export WEBRTC_ARCHIVE_DIR=build/webrtc.xcarchive

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-linux.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export OUTPUT_FILEPATH=$(pwd)/Runtime/Plugins/x86_64/libwebrtc.so
 export LIBCXX_BUILD_DIR=$(pwd)/llvm-project/build

--- a/BuildScripts~/build_plugin_mac.sh
+++ b/BuildScripts~/build_plugin_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-mac.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-mac.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export DYLIB_FILE=$(pwd)/Runtime/Plugins/macOS/libwebrtc.dylib
 

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-win.zip
+set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-win.zip
 set SOLUTION_DIR=%cd%\Plugin~
 
 echo Download LibWebRTC

--- a/BuildScripts~/build_testrunner_android.sh
+++ b/BuildScripts~/build_testrunner_android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-android.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-android.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export ARCH_ABI=arm64-v8a
 

--- a/BuildScripts~/build_testrunner_linux.sh
+++ b/BuildScripts~/build_testrunner_linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-linux.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-linux.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 source ~/.profile

--- a/BuildScripts~/build_testrunner_mac.sh
+++ b/BuildScripts~/build_testrunner_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-mac.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-mac.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 # Install cmake

--- a/BuildScripts~/build_testrunner_win.cmd
+++ b/BuildScripts~/build_testrunner_win.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-win.zip
+set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-win.zip
 set SOLUTION_DIR=%cd%\Plugin~
 
 echo -------------------

--- a/BuildScripts~/patches/fetch_exclude_examples.patch
+++ b/BuildScripts~/patches/fetch_exclude_examples.patch
@@ -1,13 +1,13 @@
---- depot_tools/fetch_configs/webrtc.py	2023-03-22 06:38:50.000000000 +0900
-+++ depot_tools/fetch_configs/webrtc.py.patch	2023-03-27 09:33:06.000000000 +0900
-@@ -22,7 +22,9 @@ class WebRTC(config_util.Config):
-           'url': url,
-           'deps_file': 'DEPS',
-           'managed': False,
--          'custom_deps': {},
-+          'custom_deps': {
-+            "src/examples/androidtests/third_party/gradle": None
-+          },
-         },
-       ],
-       'with_branch_heads': True,
+--- fetch_configs/webrtc.py	2023-09-07 18:44:46.485574800 +0900
++++ fetch_configs/webrtc.py.patch	2023-09-07 18:46:11.601268700 +0900
+@@ -21,7 +21,9 @@
+                     'url': url,
+                     'deps_file': 'DEPS',
+                     'managed': False,
+-                    'custom_deps': {},
++                    'custom_deps': {
++                        "src/examples/androidtests/third_party/gradle": None
++		    },
+                 },
+             ],
+             'with_branch_heads':

--- a/BuildScripts~/test_plugin_android.sh
+++ b/BuildScripts~/test_plugin_android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-android.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-android.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 export ARCH_ABI=arm64-v8a
 

--- a/BuildScripts~/test_plugin_ios.sh
+++ b/BuildScripts~/test_plugin_ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M115/webrtc-ios.zip
+export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116/webrtc-ios.zip
 export SOLUTION_DIR=$(pwd)/Plugin~
 
 # Install cmake

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -194,7 +194,7 @@ namespace webrtc
     std::unique_ptr<VideoEncoder> NvEncoderFactory::CreateVideoEncoder(const SdpVideoFormat& format)
     {
         // todo(kazuki):: add CUmemorytype::CU_MEMORYTYPE_DEVICE option
-        return NvEncoder::Create(cricket::VideoCodec(format), context_, CU_MEMORYTYPE_ARRAY, format_, profiler_);
+        return NvEncoder::Create(cricket::CreateVideoCodec(format), context_, CU_MEMORYTYPE_ARRAY, format_, profiler_);
     }
 
     NvDecoderFactory::NvDecoderFactory(CUcontext context, ProfilerMarkerFactory* profiler)
@@ -211,7 +211,7 @@ namespace webrtc
 
     std::unique_ptr<VideoDecoder> NvDecoderFactory::CreateVideoDecoder(const SdpVideoFormat& format)
     {
-        return NvDecoder::Create(cricket::VideoCodec(format), context_, profiler_);
+        return NvDecoder::Create(cricket::CreateVideoCodec(format), context_, profiler_);
     }
 }
 }

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
@@ -47,14 +47,14 @@ namespace webrtc
     protected:
         std::unique_ptr<VideoEncoder> CreateEncoder() override
         {
-            cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+            cricket::VideoCodec codec = cricket::CreateVideoCodec(cricket::kH264CodecName);
             codec.SetParam(cricket::kH264FmtpProfileLevelId, kProfileLevelIdString());
             return NvEncoder::Create(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
         }
 
         std::unique_ptr<VideoDecoder> CreateDecoder() override
         {
-            cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+            cricket::VideoCodec codec = cricket::CreateVideoCodec(cricket::kH264CodecName);
             codec.SetParam(cricket::kH264FmtpProfileLevelId, kProfileLevelIdString());
             return NvDecoder::Create(codec, context_, nullptr);
         }

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvEncoderImplTest.cpp
@@ -40,7 +40,7 @@ namespace webrtc
 
     TEST_P(NvEncoderImplTest, CanInitializeWithDefaultParameters)
     {
-        cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+        cricket::VideoCodec codec = cricket::CreateVideoCodec(cricket::kH264CodecName);
         codec.SetParam(cricket::kH264FmtpProfileLevelId, kProfileLevelIdString());
         NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
 
@@ -53,7 +53,7 @@ namespace webrtc
     {
         H264ProfileLevelId profileLevelId(H264Profile::kProfileBaseline, H264Level::kLevel5_1);
 
-        cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+        cricket::VideoCodec codec = cricket::CreateVideoCodec(cricket::kH264CodecName);
         codec.SetParam(cricket::kH264FmtpProfileLevelId, *H264ProfileLevelIdToString(profileLevelId));
         NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
 
@@ -69,7 +69,7 @@ namespace webrtc
     {
         H264ProfileLevelId profileLevelId(H264Profile::kProfileBaseline, H264Level::kLevel5_1);
 
-        cricket::VideoCodec codec = cricket::VideoCodec(cricket::kH264CodecName);
+        cricket::VideoCodec codec = cricket::CreateVideoCodec(cricket::kH264CodecName);
         codec.SetParam(cricket::kH264FmtpProfileLevelId, *H264ProfileLevelIdToString(profileLevelId));
         NvEncoderImpl encoder(codec, context_, CU_MEMORYTYPE_ARRAY, NV_ENC_BUFFER_FORMAT_ARGB, nullptr);
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please read this if you have an interest to customize native code in this projec
 | `3.0.0-pre.4` | [M107](https://groups.google.com/g/discuss-webrtc/c/StVFkKuSRc8) | - Fix bugs | Jan 2023 |
 | `3.0.0-pre.5` | [M107](https://groups.google.com/g/discuss-webrtc/c/StVFkKuSRc8) | - Encoded Transform API | Apr 2023 |
 | `3.0.0-pre.6` | [M112](https://groups.google.com/g/discuss-webrtc/c/V-XFau9W9gY) | - Fix bugs | Jul 2023 |
-| `3.0.0-pre.7` | [M115](https://groups.google.com/g/discuss-webrtc/c/1CTKFxJsrmQ) | - Fix bugs | Sep 2023 |
+| `3.0.0-pre.7` | [M116](https://groups.google.com/g/discuss-webrtc/c/bEsO8Lz7psE) | - Fix bugs | Sep 2023 |
 
 ## Licenses
 

--- a/Runtime/Scripts/RTCStats.cs
+++ b/Runtime/Scripts/RTCStats.cs
@@ -840,12 +840,6 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
-        [Obsolete]
-        public string trackId { get { return GetString("trackId"); } }
-
-        /// <summary>
-        ///
-        /// </summary>
         public string transportId { get { return GetString("transportId"); } }
 
         /// <summary>
@@ -886,7 +880,7 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
-        public uint packetsSent { get { return GetUnsignedInt("packetsSent"); } }
+        public ulong packetsSent { get { return GetUnsignedLong("packetsSent"); } }
 
         /// <summary>
         ///
@@ -1036,7 +1030,7 @@ namespace Unity.WebRTC
         /// <summary>
         ///
         /// </summary>
-        public int framesReceived { get { return GetInt("framesReceived"); } }
+        public uint framesReceived { get { return GetUnsignedInt("framesReceived"); } }
 
         /// <summary>
         ///

--- a/Tests/Runtime/StatsReportTest.cs
+++ b/Tests/Runtime/StatsReportTest.cs
@@ -117,10 +117,9 @@ namespace Unity.WebRTC.RuntimeTest
                 case RTCStatsType.InboundRtp:
                     var inboundRtpStreamStats = stats as RTCInboundRTPStreamStats;
                     Assert.NotNull(inboundRtpStreamStats);
-                    Assert.AreEqual(65, inboundRtpStreamStats.Dict.Count);
+                    Assert.AreEqual(64, inboundRtpStreamStats.Dict.Count);
                     Ignore.Pass(inboundRtpStreamStats.ssrc);
                     Assert.IsNotEmpty(inboundRtpStreamStats.kind);
-                    // Obsolete:  Ignore.Pass(inboundRtpStreamStats.trackId);
                     Assert.IsNotEmpty(inboundRtpStreamStats.transportId);
                     Ignore.Pass(inboundRtpStreamStats.codecId);
                     Ignore.Pass(inboundRtpStreamStats.jitter);
@@ -244,10 +243,9 @@ namespace Unity.WebRTC.RuntimeTest
                 case RTCStatsType.OutboundRtp:
                     var outboundRtpStreamStats = stats as RTCOutboundRTPStreamStats;
                     Assert.NotNull(outboundRtpStreamStats);
-                    Assert.AreEqual(37, outboundRtpStreamStats.Dict.Count);
+                    Assert.AreEqual(36, outboundRtpStreamStats.Dict.Count);
                     Ignore.Pass(outboundRtpStreamStats.ssrc);
                     Assert.IsNotEmpty(outboundRtpStreamStats.kind);
-                    // Obsolete: Ignore.Pass(outboundRtpStreamStats.trackId);
                     Assert.IsNotEmpty(outboundRtpStreamStats.transportId);
                     Ignore.Pass(outboundRtpStreamStats.codecId);
                     Ignore.Pass(outboundRtpStreamStats.mediaSourceId);


### PR DESCRIPTION
The previous update of libwebrtc is here. 
https://github.com/Unity-Technologies/com.unity.webrtc/pull/960

However, building libwebrtc is failed because of android_toolchain in third_party folder in Chromium. We got the error below.

```
Traceback (most recent call last):
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/metrics.py", line 296, in print_notice_and_exit
    yield
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/gclient.py", line 3770, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/gclient.py", line 3756, in main
    return dispatcher.execute(OptionParser(), argv)
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/subcommand.py", line 252, in execute
    return command(parser, args[1:])
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/gclient.py", line 3239, in CMDsync
    ret = client.RunOnDeps('update', args)
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/gclient.py", line 2170, in RunOnDeps
    gclient_scm.scm.GIT.Capture(['checkout', tail], cwd=cwd)
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/scm.py", line 116, in Capture
    output = subprocess2.check_output(
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/subprocess2.py", line 255, in check_output
    return check_call_out(args, stdout=PIPE, **kwargs)[0]
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/subprocess2.py", line 215, in check_call_out
    out, returncode = communicate(args, **kwargs)
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/subprocess2.py", line 190, in communicate
    proc = Popen(args, **kwargs)
  File "/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/depot_tools/subprocess2.py", line 169, in __init__
    raise OSError('Execution failed with error: %s.\n'
OSError: Execution failed with error: [Errno 2] No such file or directory: '/home/bokken/build/output/Unity-Technologies/com.unity.webrtc/src/third_party/android_toolchain'.
Check that /home/bokken/build/output/Unity-Technologies/com.unity.webrtc/src/third_party/android_toolchain or git exist and have execution permission.
```

To fix this, we must remove dependencies by `android_toolchain` or adding the library ourselves. It's easy to imagine this work is troublesome. Therefore we skipped the version M115, and use the next version M116 which has fixed this issue.