### PR TITLE
Fix: Vulkan framerate with vsync enabled

### DIFF
--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Texture synchronization against IUnityGraphicsVulkan::CommandRecordingState
-#define VULKAN_USE_CRS 0
+#define VULKAN_USE_CRS 1
 
 #include <array>
 

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -134,6 +134,8 @@ namespace Unity.WebRTC
 
         private IntPtr batchUpdateFunction;
         private int batchUpdateEventID = -1;
+        private IntPtr postLateUpdateFunction;
+        private int postLateUpdateEventID = -1;
         private IntPtr textureUpdateFunction;
 
         internal Batch batch;
@@ -315,6 +317,16 @@ namespace Unity.WebRTC
             return NativeMethods.GetBatchUpdateEventID();
         }
 
+        public IntPtr GetPostLateUpdateEventFunc()
+        {
+            return NativeMethods.GetPostLateUpdateEventFunc(self);
+        }
+
+        public int GetPostLateUpdateEventID()
+        {
+            return NativeMethods.GetPostLateUpdateEventID();
+        }
+
         public IntPtr GetUpdateTextureFunc()
         {
             return NativeMethods.GetUpdateTextureFunc(self);
@@ -380,7 +392,15 @@ namespace Unity.WebRTC
         {
             batchUpdateFunction = batchUpdateFunction == IntPtr.Zero ? GetBatchUpdateEventFunc() : batchUpdateFunction;
             batchUpdateEventID = batchUpdateEventID == -1 ? GetBatchUpdateEventID() : batchUpdateEventID;
-            VideoUpdateMethods.BatchUpdate(batchUpdateFunction, batchUpdateEventID, batchData);
+            VideoUpdateMethods.PluginEvent(batchUpdateFunction, batchUpdateEventID, batchData);
+        }
+
+        internal void PostLateUpdate()
+        {
+            postLateUpdateFunction = postLateUpdateFunction == IntPtr.Zero ? GetPostLateUpdateEventFunc() : postLateUpdateFunction;
+            postLateUpdateEventID = postLateUpdateEventID == -1 ? GetPostLateUpdateEventID() : postLateUpdateEventID;
+            VideoUpdateMethods.PluginEvent(postLateUpdateFunction, postLateUpdateEventID, IntPtr.Zero);
+            VideoUpdateMethods.Flush();
         }
 
         internal void UpdateRendererTexture(uint rendererId, UnityEngine.Texture texture)

--- a/Tests/Runtime/NativeAPITest.cs
+++ b/Tests/Runtime/NativeAPITest.cs
@@ -365,7 +365,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(1.0f);
 
             Marshal.StructureToPtr(batch.data, batch.ptr, false);
-            VideoUpdateMethods.BatchUpdate(batchUpdateEvent, batchUpdateEventID, batch.ptr);
+            VideoUpdateMethods.PluginEvent(batchUpdateEvent, batchUpdateEventID, batch.ptr);
             VideoUpdateMethods.Flush();
 
             yield return new WaitForSeconds(1.0f);
@@ -420,7 +420,7 @@ namespace Unity.WebRTC.RuntimeTest
             yield return new WaitForSeconds(1.0f);
 
             Marshal.StructureToPtr(batch.data, batch.ptr, false);
-            VideoUpdateMethods.BatchUpdate(batchUpdateEvent, batchUpdateEventID, batch.ptr);
+            VideoUpdateMethods.PluginEvent(batchUpdateEvent, batchUpdateEventID, batch.ptr);
 
             // this method is not supported on Direct3D12
             VideoUpdateMethods.UpdateRendererTexture(updateTextureEvent, receiveTexture, rendererId);


### PR DESCRIPTION
Small follow-up to #966 @karasusan @BrianHarrisonUnity 

If the goal is to depend on Unity's Vulkan graphics pipeline and state as much as possible, then using a custom command buffers and fences is not an option. :)

But Unity plugin interface doesn't expose enough information to operate with fences directly (unlike DX12 interface), instead it uses frame counters. A safe frame counter is typically updated by the end of the frame and there is nothing that triggers IUnityGraphicsVulkan::CommandRecordingState updates for you automatically if you try to do multi-threaded processing that depends on synchronization.

It seems the approach in #966 should be mostly good enough, but there's some platforms like LinuxStandalone and Android where the framerate drops noticeably compared to previous approach when vsync is enabled.

After some debugging, it seems the earliest phase when Unity graphics device has updated the safe frame counter is after `PostLateUpdate.PresentAfterDraw` so we can synchronize CommandRecordingState state to plugin side graphics device. It doesn't seem there's a user friendly way to ensure a custom synchronization to rendering plugin happens, without adding a custom pass through PlayerLoop.

Tested with LinuxStandalone vsync on/off on my custom branch, runs steady 1080p60 with both options but previously with vsync on the framerate was 20fps.

My assumption is that this will also help Android a lot and likely avoids the need for I420Buffer::Create workaround at GpuMemoryBufferFromUnity::ToI420 due to timing out.
