### PR TITLE
fix: Implement VideoFrameAdapter::ScaledBuffer::CropAndScale

### DIFF
--- a/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
+++ b/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
@@ -57,9 +57,10 @@ namespace webrtc
     rtc::scoped_refptr<VideoFrameBuffer> VideoFrameAdapter::ScaledBuffer::CropAndScale(
         int offset_x, int offset_y, int crop_width, int crop_height, int scaled_width, int scaled_height)
     {
-        RTC_DCHECK_NOTREACHED();
-
-        return nullptr;
+        //RTC_DCHECK_NOTREACHED();
+        //return nullptr;
+        return rtc::make_ref_counted<ScaledBuffer>(
+            rtc::scoped_refptr<VideoFrameAdapter>(parent_), scaled_width, scaled_height);
     }
 
     VideoFrameAdapter::VideoFrameAdapter(rtc::scoped_refptr<VideoFrame> frame)

--- a/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
+++ b/Plugin~/WebRTCPlugin/VideoFrameAdapter.cpp
@@ -57,8 +57,6 @@ namespace webrtc
     rtc::scoped_refptr<VideoFrameBuffer> VideoFrameAdapter::ScaledBuffer::CropAndScale(
         int offset_x, int offset_y, int crop_width, int crop_height, int scaled_width, int scaled_height)
     {
-        //RTC_DCHECK_NOTREACHED();
-        //return nullptr;
         return rtc::make_ref_counted<ScaledBuffer>(
             rtc::scoped_refptr<VideoFrameAdapter>(parent_), scaled_width, scaled_height);
     }


### PR DESCRIPTION
- #890

The VP8 encoder on macOS calls `ScaledBuffer::CropAndScale`, so it have to be implemented.