### PR TITLE
fix: Revert change of GpuMemoryBuffer to fix video rendering issue

### DIFF
--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -85,7 +85,7 @@ namespace webrtc
             RTC_LOG(LS_INFO) << "WaitSync failed.";
 
             // returns buffer because the video encoders don't check nullptr.
-            return I420Buffer::Create(textureCpuRead_->GetWidth(), textureCpuRead_->GetHeight());
+            return nullptr;
         }
         return device_->ConvertRGBToI420(textureCpuRead_.get());
     }

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -83,8 +83,6 @@ namespace webrtc
         if (!device_->WaitSync(textureCpuRead_.get(), timeout.count()))
         {
             RTC_LOG(LS_INFO) << "WaitSync failed.";
-
-            // returns buffer because the video encoders don't check nullptr.
             return nullptr;
         }
         return device_->ConvertRGBToI420(textureCpuRead_.get());

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -63,6 +63,11 @@ namespace webrtc
         {
             return;
         }
+        if (!buffer)
+        {
+            RTC_LOG(LS_INFO) << "The video buffer is already released.";
+            return;
+        }
 
         if (m_frameBuffer == nullptr || m_frameBuffer->width() != buffer->width() ||
             m_frameBuffer->height() != buffer->height())
@@ -83,7 +88,7 @@ namespace webrtc
             tempBuffer.resize(size);
 
         // return a previous texture buffer when framebuffer is returned null.
-        if (frame == nullptr)
+        if (!frame)
             return tempBuffer.data();
 
         rtc::scoped_refptr<webrtc::I420BufferInterface> i420_buffer;

--- a/Tests/Runtime/VideoReceiveTest.cs
+++ b/Tests/Runtime/VideoReceiveTest.cs
@@ -21,7 +21,7 @@ namespace Unity.WebRTC.RuntimeTest
     }
 
     [TestFixture]
-    [UnityPlatform(exclude = new[] { RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.OSXEditor, RuntimePlatform.LinuxPlayer })]
+    [UnityPlatform(exclude = new[] { RuntimePlatform.Android, RuntimePlatform.IPhonePlayer, RuntimePlatform.OSXPlayer, RuntimePlatform.OSXEditor, RuntimePlatform.LinuxPlayer })]
     [ConditionalIgnore(ConditionalIgnore.UnsupportedPlatformOpenGL, "Not support VideoStreamTrack for OpenGL")]
     class VideoReceiveTestWithVP8Codec : VideoReceiveTestBase
     {


### PR DESCRIPTION
This is a revert commit to fix a video rendering issue which occurs when using the WebRTC package for Unity Render Streaming.
The previous PR is #966.

- #966

Applicable parts is here.

https://github.com/Unity-Technologies/com.unity.webrtc/pull/966/files#diff-bd9da9905e2651e2f1924415998c4a3d6545dcf51a4441e27fcc567e376e6464

https://github.com/Unity-Technologies/com.unity.webrtc/assets/1132081/a612057a-6dbe-4771-8026-55f211e814fb

I checked Android and Windows with Vulkan graphic API.