### PR TITLE
fix: checks for DLLs before calling NvEncoder APIs

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
@@ -54,12 +54,6 @@ namespace webrtc
         if (impl == kNvCodecImpl)
         {
 #if CUDA_PLATFORM
-            HMODULE hModule = LoadLibrary(TEXT("nvEncodeAPI64.dll"));
-            if (hModule == NULL)
-            {
-                return nullptr;
-            }
-
             if (gfxDevice && gfxDevice->IsCudaSupport() && NvEncoder::IsSupported())
             {
                 CUcontext context = gfxDevice->GetCUcontext();

--- a/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
@@ -54,6 +54,12 @@ namespace webrtc
         if (impl == kNvCodecImpl)
         {
 #if CUDA_PLATFORM
+            HMODULE hModule = LoadLibrary(TEXT("nvEncodeAPI64.dll"));
+            if (hModule == NULL)
+            {
+                return nullptr;
+            }
+
             if (gfxDevice && gfxDevice->IsCudaSupport() && NvEncoder::IsSupported())
             {
                 CUcontext context = gfxDevice->GetCUcontext();

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Cuda/CudaContext.cpp
@@ -31,6 +31,7 @@ namespace unity
 namespace webrtc
 {
     static void* s_hModule = nullptr;
+    static void* nvEncode_Module = nullptr;
     static bool FindModule()
     {
         if (s_hModule)
@@ -45,6 +46,14 @@ namespace webrtc
             return false;
         }
         s_hModule = module;
+
+        HMODULE module2 = LoadLibrary(TEXT("nvEncodeAPI64.dll"));
+        if (!module2)
+        {
+            RTC_LOG(LS_INFO) << "nvEncodeAPI64.dll is not found.";
+            return false;
+        }
+        nvEncode_Module = module2;
 #elif UNITY_LINUX
         s_hModule = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_GLOBAL);
         if (!s_hModule)
@@ -271,6 +280,13 @@ namespace webrtc
             dlclose(s_hModule);
 #endif
             s_hModule = nullptr;
+        }
+        if (nvEncode_Module)
+        {
+#if UNITY_WIN
+            FreeLibrary((HMODULE)nvEncode_Module);
+            nvEncode_Module = nullptr;
+#endif
         }
     }
 


### PR DESCRIPTION
Some CUDA platforms do not support NvEncoder, so using the relevant API without confirmation will cause a crash.
https://github.com/Unity-Technologies/com.unity.webrtc/issues/806
 I referred to Nvidia's GitHub project, we can see that it checks for DLLs before calling NvEncoder APIs. 
https://github.com/NVIDIA/video-sdk-samples/blob/aa3544dcea2fe63122e4feb83bf805ea40e58dbe/Samples/NvCodec/NvEncoder/NvEncoder.cpp#L58