### PR TITLE
fix: rare audio crash during shutdown

### DIFF
--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -144,6 +144,11 @@ namespace Unity.WebRTC
                     return;
                 }
 
+                if (_filter != null)
+                {
+                    _filter.onAudioRead -= SetData;
+                    WebRTC.DestroyOnMainThread(_filter);
+                }
                 if (self != IntPtr.Zero && !WebRTC.Context.IsNull)
                 {
                     if (_track != null && WebRTC.Table.ContainsKey(_track.self))
@@ -151,11 +156,6 @@ namespace Unity.WebRTC
                     WebRTC.Table.Remove(self);
                     WebRTC.Context.DeleteAudioTrackSink(self);
                     self = IntPtr.Zero;
-                }
-                if (_filter != null)
-                {
-                    _filter.onAudioRead -= SetData;
-                    WebRTC.DestroyOnMainThread(_filter);
                 }
                 this.disposed = true;
                 GC.SuppressFinalize(this);


### PR DESCRIPTION
I'm experiencing a rare audio related crash, maybe once a month. Either in the player or the editor when the whole application is being shut down.

I do have some other audio changes on plugin side that made the issue less likely, but right now it feels like this C# side code ordering change should be good to apply regardless.

```
=================================================================
	Native Crash Reporting
=================================================================
Got a UNKNOWN while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries 
used by your application.
=================================================================

=================================================================
	Managed Stacktrace:
=================================================================
	  at <unknown> <0xffffffff>
	  at Unity.WebRTC.NativeMethods:AudioTrackSinkProcessAudio <0x00131>
	  at AudioStreamRenderer:SetData <0x000ba>
	  at <Module>:invoke_void_single[]_int_int <0x00188>
	  at Unity.WebRTC.AudioCustomFilter:OnAudioFilterRead <0x000cb>
	  at <Module>:runtime_invoke_void__this___object_int <0x00109>
=================================================================
Crash!!!
```