### PR TITLE
fix: Fix crash on Android when using VP8 encoder

### DIFF
--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -42,6 +42,9 @@ patch -N "src/build/config/compiler/BUILD.gn" < "$COMMAND_DIR/patches/add_nooutl
 patch -N "src/build/android/gyp/compile_java.py" < "$COMMAND_DIR/patches/downgradeJDKto8_compile_java.patch"
 patch -N "src/build/android/gyp/turbine.py" < "$COMMAND_DIR/patches/downgradeJDKto8_turbine.patch"
 
+# Fix SetRawImagePlanes() in LibvpxVp8Encoder
+patch -N "src/modules/video_coding/codecs/vp8/libvpx_vp8_encoder.cc" < "$COMMAND_DIR/patches/libvpx_vp8_encoder.patch"
+
 # Fix AdaptedVideoTrackSource::video_adapter()
 pushd src
 patch -p1 < "$COMMAND_DIR/patches/fix_adaptedvideotracksource.patch"

--- a/BuildScripts~/build_libwebrtc_ios.sh
+++ b/BuildScripts~/build_libwebrtc_ios.sh
@@ -33,6 +33,9 @@ patch -N "src/api/task_queue/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queu
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 
+# Fix SetRawImagePlanes() in LibvpxVp8Encoder
+patch -N "src/modules/video_coding/codecs/vp8/libvpx_vp8_encoder.cc" < "$COMMAND_DIR/patches/libvpx_vp8_encoder.patch"
+
 # use included python
 export PATH="$(pwd)/depot_tools/bootstrap-3.8.0.chromium.8_bin/python/bin:$PATH"
 

--- a/BuildScripts~/build_libwebrtc_linux.sh
+++ b/BuildScripts~/build_libwebrtc_linux.sh
@@ -26,6 +26,9 @@ fi
 # add jsoncpp
 patch -N "src/BUILD.gn" < "$COMMAND_DIR/patches/add_jsoncpp.patch"
 
+# Fix SetRawImagePlanes() in LibvpxVp8Encoder
+patch -N "src/modules/video_coding/codecs/vp8/libvpx_vp8_encoder.cc" < "$COMMAND_DIR/patches/libvpx_vp8_encoder.patch"
+
 mkdir -p "$ARTIFACTS_DIR/lib"
 
 for target_cpu in "x64"

--- a/BuildScripts~/build_libwebrtc_macos.sh
+++ b/BuildScripts~/build_libwebrtc_macos.sh
@@ -33,6 +33,9 @@ patch -N "src/api/task_queue/BUILD.gn" < "$COMMAND_DIR/patches/disable_task_queu
 # add objc library to use videotoolbox
 patch -N "src/sdk/BUILD.gn" < "$COMMAND_DIR/patches/add_objc_deps.patch"
 
+# Fix SetRawImagePlanes() in LibvpxVp8Encoder
+patch -N "src/modules/video_coding/codecs/vp8/libvpx_vp8_encoder.cc" < "$COMMAND_DIR/patches/libvpx_vp8_encoder.patch"
+
 mkdir -p "$ARTIFACTS_DIR/lib"
 
 for is_debug in "true" "false"

--- a/BuildScripts~/build_libwebrtc_win.cmd
+++ b/BuildScripts~/build_libwebrtc_win.cmd
@@ -36,6 +36,9 @@ patch -N "src\third_party\abseil-cpp/absl/base/config.h" < "%COMMAND_DIR%\patche
 rem fix task_queue_base
 patch -N "src\api\task_queue\task_queue_base.h" < "%COMMAND_DIR%\patches\fix_task_queue_base.patch"
 
+rem fix SetRawImagePlanes() in LibvpxVp8Encoder
+patch -N "src\modules\video_coding\codecs\vp8\libvpx_vp8_encoder.cc" < "%COMMAND_DIR%\patches\libvpx_vp8_encoder.patch"
+
 mkdir "%ARTIFACTS_DIR%\lib"
 
 setlocal enabledelayedexpansion

--- a/BuildScripts~/patches/libvpx_vp8_encoder.patch
+++ b/BuildScripts~/patches/libvpx_vp8_encoder.patch
@@ -1,0 +1,60 @@
+--- libvpx_vp8_encoder.cc	2023-10-16 16:47:15.259207300 +0900
++++ libvpx_vp8_encoder.cc.patch	2023-10-16 16:47:02.581135100 +0900
+@@ -175,12 +175,14 @@ bool IsCompatibleVideoFrameBufferType(Vi
+   return left == right;
+ }
+ 
+-void SetRawImagePlanes(vpx_image_t* raw_image, VideoFrameBuffer* buffer) {
++bool SetRawImagePlanes(vpx_image_t* raw_image, VideoFrameBuffer* buffer) {
+   switch (buffer->type()) {
+     case VideoFrameBuffer::Type::kI420:
+     case VideoFrameBuffer::Type::kI420A: {
+       const I420BufferInterface* i420_buffer = buffer->GetI420();
+-      RTC_DCHECK(i420_buffer);
++      if (!i420_buffer) {
++        return false;
++      }
+       raw_image->planes[VPX_PLANE_Y] =
+           const_cast<uint8_t*>(i420_buffer->DataY());
+       raw_image->planes[VPX_PLANE_U] =
+@@ -194,7 +196,9 @@ void SetRawImagePlanes(vpx_image_t* raw_
+     }
+     case VideoFrameBuffer::Type::kNV12: {
+       const NV12BufferInterface* nv12_buffer = buffer->GetNV12();
+-      RTC_DCHECK(nv12_buffer);
++      if (!nv12_buffer) {
++        return false;
++      }
+       raw_image->planes[VPX_PLANE_Y] =
+           const_cast<uint8_t*>(nv12_buffer->DataY());
+       raw_image->planes[VPX_PLANE_U] =
+@@ -208,6 +212,7 @@ void SetRawImagePlanes(vpx_image_t* raw_
+     default:
+       RTC_DCHECK_NOTREACHED();
+   }
++  return true;
+ }
+ 
+ }  // namespace
+@@ -1376,7 +1381,9 @@ LibvpxVp8Encoder::PrepareBuffers(rtc::sc
+   // Prepare `raw_images_` from `mapped_buffer` and, if simulcast, scaled
+   // versions of `buffer`.
+   std::vector<rtc::scoped_refptr<VideoFrameBuffer>> prepared_buffers;
+-  SetRawImagePlanes(&raw_images_[0], mapped_buffer.get());
++  if (!SetRawImagePlanes(&raw_images_[0], mapped_buffer.get())) {
++    return {};
++  }
+   prepared_buffers.push_back(mapped_buffer);
+   for (size_t i = 1; i < encoders_.size(); ++i) {
+     // Native buffers should implement optimized scaling and is the preferred
+@@ -1419,7 +1426,9 @@ LibvpxVp8Encoder::PrepareBuffers(rtc::sc
+           << VideoFrameBufferTypeToString(mapped_buffer->type());
+       return {};
+     }
+-    SetRawImagePlanes(&raw_images_[i], scaled_buffer.get());
++    if (!SetRawImagePlanes(&raw_images_[i], scaled_buffer.get())) {
++      return {};
++    }
+     prepared_buffers.push_back(scaled_buffer);
+   }
+   return prepared_buffers;


### PR DESCRIPTION
This crash is occurred by `SetRawImagePlanes` in [libvpx_vp8_encoder.cc](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/video_coding/codecs/vp8/libvpx_vp8_encoder.cc).

I created a patch file to avoid null pointer exception in the VP8 encoder.

Related issue.

- #993