### PR TITLE
fix: Revert: Vulkan CPU texture read performance, improve Unity pipeline state integration

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.cpp
+++ b/Plugin~/WebRTCPlugin/Context.cpp
@@ -8,6 +8,7 @@
 #include "AudioTrackSinkAdapter.h"
 #include "Context.h"
 #include "EncodedStreamTransformer.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "GraphicsDevice/IGraphicsDevice.h"
 #include "MediaStreamObserver.h"
 #include "UnityAudioDecoderFactory.h"

--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -79,7 +79,7 @@ namespace webrtc
     rtc::scoped_refptr<I420BufferInterface> GpuMemoryBufferFromUnity::ToI420()
     {
         using namespace std::chrono_literals;
-        const std::chrono::nanoseconds timeout(30ms); // 30ms
+        const std::chrono::nanoseconds timeout(60ms); // 60ms
         if (!device_->WaitSync(textureCpuRead_.get(), timeout.count()))
         {
             RTC_LOG(LS_INFO) << "WaitSync failed.";
@@ -91,7 +91,7 @@ namespace webrtc
     const GpuMemoryBufferHandle* GpuMemoryBufferFromUnity::handle() const
     {
         using namespace std::chrono_literals;
-        const std::chrono::nanoseconds timeout(30ms); // 30ms
+        const std::chrono::nanoseconds timeout(60ms); // 60ms
         if (!device_->WaitSync(texture_.get(), timeout.count()))
         {
             RTC_LOG(LS_INFO) << "WaitSync failed.";

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/CMakeLists.txt
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/CMakeLists.txt
@@ -1,7 +1,13 @@
 target_sources(
   WebRTCLib
-  PRIVATE GraphicsDevice.cpp GraphicsDevice.h IGraphicsDevice.h ITexture2D.h
-          ScopedGraphicsDeviceLock.cpp ScopedGraphicsDeviceLock.h)
+  PRIVATE GraphicsDevice.cpp
+          GraphicsDevice.h
+          GraphicsUtility.cpp
+          GraphicsUtility.h
+          IGraphicsDevice.h
+          ITexture2D.h
+          ScopedGraphicsDeviceLock.cpp
+          ScopedGraphicsDeviceLock.h)
 
 if(Windows)
   add_subdirectory(Vulkan)

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -5,7 +5,7 @@
 #include "D3D11GraphicsDevice.h"
 #include "D3D11Texture2D.h"
 #include "GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h"
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "NvCodecUtils.h"
 
 using namespace ::webrtc;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -7,7 +7,7 @@
 #include "D3D12Texture2D.h"
 #include "GraphicsDevice/Cuda/GpuMemoryBufferCudaHandle.h"
 #include "GraphicsDevice/D3D11/D3D11Texture2D.h"
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "NvCodecUtils.h"
 
 // nonstandard extension used : class rvalue used as lvalue

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.cpp
@@ -1,0 +1,31 @@
+#include "pch.h"
+
+#include "GraphicsUtility.h"
+
+#if SUPPORT_VULKAN
+#include "Vulkan/VulkanGraphicsDevice.h"
+#endif
+
+namespace unity
+{
+namespace webrtc
+{
+
+    namespace webrtc = ::webrtc;
+
+    void* GraphicsUtility::TextureHandleToNativeGraphicsPtr(
+        void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer)
+    {
+#if SUPPORT_VULKAN
+        if (renderer == kUnityGfxRendererVulkan)
+        {
+            VulkanGraphicsDevice* vulkanDevice = static_cast<VulkanGraphicsDevice*>(device);
+            std::unique_ptr<UnityVulkanImage> unityVulkanImage = vulkanDevice->AccessTexture(textureHandle);
+            return unityVulkanImage.release();
+        }
+#endif
+        return textureHandle;
+    }
+
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsUtility.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "IGraphicsDevice.h"
+
+namespace unity
+{
+namespace webrtc
+{
+
+    class GraphicsUtility
+    {
+    public:
+        static void*
+        TextureHandleToNativeGraphicsPtr(void* textureHandle, IGraphicsDevice* device, UnityGfxRenderer renderer);
+    };
+
+} // end namespace webrtc
+} // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/ITexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/ITexture2D.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include <stdint.h>
 
 namespace unity
@@ -40,29 +39,6 @@ namespace webrtc
     protected:
         uint32_t m_width;
         uint32_t m_height;
-
-    public:
-        inline static std::mutex s_TexturePtrMapMutex;
-        typedef std::map<void*, ITexture2D*> ITexture2DNativePtrMap;
-        inline static ITexture2DNativePtrMap s_TexturePtrMap;
-
-        static void BindTexture(void* nativePtr, ITexture2D* texturePtr)
-        {
-            std::lock_guard<std::mutex> trackLock(s_TexturePtrMapMutex);
-            s_TexturePtrMap.insert(std::make_pair(nativePtr, texturePtr));
-        }
-
-        static ITexture2D* GetTexturePtr(void* nativePtr)
-        {
-            ITexture2DNativePtrMap::const_iterator it = s_TexturePtrMap.find(nativePtr);
-            return (it == s_TexturePtrMap.end()) ? NULL : it->second;
-        }
-
-        static void RemoveTextureBinding(void* nativePtr)
-        {
-            std::lock_guard<std::mutex> trackLock(s_TexturePtrMapMutex);
-            s_TexturePtrMap.erase(nativePtr);
-        }
     };
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -1,6 +1,6 @@
 #include "pch.h"
 
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "MetalDevice.h"
 #include "MetalGraphicsDevice.h"
 #include "MetalTexture2D.h"

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -7,7 +7,7 @@
 
 #include "third_party/libyuv/include/libyuv.h"
 
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "OpenGLGraphicsDevice.h"
 #include "OpenGLTexture2D.h"
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -2,7 +2,7 @@
 
 #include <third_party/libyuv/include/libyuv/convert.h>
 
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "UnityVulkanInterfaceFunctions.h"
 #include "VulkanGraphicsDevice.h"
 #include "VulkanTexture2D.h"
@@ -27,39 +27,24 @@ namespace webrtc
         : IGraphicsDevice(renderer, profiler)
         , m_unityVulkan(unityVulkan)
         , m_Instance(*unityVulkanInstance)
-        , m_hasHostCachedMemory(false)
         , m_commandPool(VK_NULL_HANDLE)
-#if VULKAN_USE_CRS
         , m_commandBuffer(VK_NULL_HANDLE)
         , m_fence(VK_NULL_HANDLE)
-#endif
 #if CUDA_PLATFORM
         , m_isCudaSupport(false)
 #endif
     {
+        if (profiler)
+            m_maker = profiler->CreateMarker(
+                "VulkanGraphicsDevice.CopyImage", kUnityProfilerCategoryOther, kUnityProfilerMarkerFlagDefault, 0);
     }
 
     bool VulkanGraphicsDevice::InitV()
     {
-        VkPhysicalDeviceMemoryProperties memory;
-        vkGetPhysicalDeviceMemoryProperties(m_Instance.physicalDevice, &memory);
-
-        for (uint32_t i = 0; i < memory.memoryTypeCount; ++i)
-        {
-            const VkMemoryPropertyFlags propertyFlags = memory.memoryTypes[i].propertyFlags;
-            if ((propertyFlags & (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)) ==
-                (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT))
-                m_hasHostCachedMemory = true;
-        }
-
 #if CUDA_PLATFORM
         m_isCudaSupport = InitCudaContext();
 #endif
-#if VULKAN_USE_CRS
         return true;
-#else
-        return VK_SUCCESS == CreateCommandPool();
-#endif
     }
 
 #if CUDA_PLATFORM
@@ -81,7 +66,6 @@ namespace webrtc
 #if CUDA_PLATFORM
         m_cudaContext.Shutdown();
 #endif
-#if VULKAN_USE_CRS
         if (m_fence)
         {
             vkDestroyFence(m_Instance.device, m_fence, nullptr);
@@ -93,35 +77,32 @@ namespace webrtc
             m_commandBuffer = VK_NULL_HANDLE;
         }
         VULKAN_SAFE_DESTROY_COMMAND_POOL(m_Instance.device, m_commandPool, VK_NULL_HANDLE)
-#else
-        VULKAN_SAFE_DESTROY_COMMAND_POOL(m_Instance.device, m_commandPool, VK_NULL_HANDLE)
-#endif
     }
 
-#if !VULKAN_USE_CRS
-    static VkResult QueueSubmit(VkQueue queue, VkCommandBuffer commandBuffer, VkFence fence)
+    std::unique_ptr<UnityVulkanImage> VulkanGraphicsDevice::AccessTexture(void* ptr) const
     {
-        VkSubmitInfo submitInfo = {};
-        submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submitInfo.commandBufferCount = 1;
-        submitInfo.pCommandBuffers = &commandBuffer;
-        return vkQueueSubmit(queue, 1, &submitInfo, fence);
+        // cannot do resource uploads inside renderpass
+        m_unityVulkan->EnsureOutsideRenderPass();
+
+        std::unique_ptr<UnityVulkanImage> unityVulkanImage = std::make_unique<UnityVulkanImage>();
+
+        VkImageSubresource subResource { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
+        if (!m_unityVulkan->AccessTexture(
+                ptr,
+                &subResource,
+                VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_ACCESS_TRANSFER_READ_BIT,
+                kUnityVulkanResourceAccess_PipelineBarrier,
+                unityVulkanImage.get()))
+        {
+            return nullptr;
+        }
+        return unityVulkanImage;
     }
 
-    VkResult VulkanGraphicsDevice::CreateCommandPool()
+    VkCommandBuffer VulkanGraphicsDevice::GetCommandBuffer()
     {
-        VkCommandPoolCreateInfo poolInfo = {};
-        poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-        poolInfo.queueFamilyIndex = m_Instance.queueFamilyIndex;
-        poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-
-        return vkCreateCommandPool(m_Instance.device, &poolInfo, VK_NULL_HANDLE, &m_commandPool);
-    }
-#endif
-
-    VkCommandBuffer VulkanGraphicsDevice::GetCommandBuffer(VulkanTexture2D* texture)
-    {
-#if VULKAN_USE_CRS
         if (m_unityVulkan)
         {
             UnityVulkanRecordingState recordingState;
@@ -172,24 +153,10 @@ namespace webrtc
             VULKAN_API_CALL_ARG(vkBeginCommandBuffer(m_commandBuffer, &beginInfo), nullptr);
             return m_commandBuffer;
         }
-#else
-        VkCommandBuffer commandBuffer = texture->GetCommandBuffer();
-        if (!commandBuffer)
-            return nullptr;
-
-        VkCommandBufferBeginInfo beginInfo = {};
-        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-        VkResult result = vkBeginCommandBuffer(commandBuffer, &beginInfo);
-
-        if (result != VK_SUCCESS)
-            return nullptr;
-        return commandBuffer;
-#endif
     }
 
-    void VulkanGraphicsDevice::SubmitCommandBuffer(VulkanTexture2D* texture)
+    void VulkanGraphicsDevice::SubmitCommandBuffer()
     {
-#if VULKAN_USE_CRS
         if (m_unityVulkan)
             return;
 
@@ -209,25 +176,6 @@ namespace webrtc
             VULKAN_API_CALL(vkResetFences(m_Instance.device, 1, &m_fence));
             VULKAN_API_CALL(vkResetCommandBuffer(m_commandBuffer, 0));
         }
-#else
-        VkCommandBuffer commandBuffer = texture->GetCommandBuffer();
-        if (!commandBuffer)
-            return;
-
-        VkResult result = vkEndCommandBuffer(commandBuffer);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_ERROR) << "vkEndCommandBuffer failed. result:" << result;
-            return;
-        }
-
-        result = QueueSubmit(m_Instance.graphicsQueue, commandBuffer, texture->GetFence());
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_ERROR) << "vkQueueSubmit failed. result:" << result;
-            return;
-        }
-#endif
     }
 
     // Returns null if failed
@@ -235,199 +183,178 @@ namespace webrtc
         const uint32_t w, const uint32_t h, UnityRenderingExtTextureFormat textureFormat)
     {
         std::unique_ptr<VulkanTexture2D> vulkanTexture = std::make_unique<VulkanTexture2D>(w, h);
-        if (!vulkanTexture->Init(&m_Instance, m_commandPool))
+        if (!vulkanTexture->Init(&m_Instance))
         {
             RTC_LOG(LS_ERROR) << "VulkanTexture2D::Init failed.";
             return nullptr;
         }
-
-        VkCommandBuffer commandBuffer = GetCommandBuffer(vulkanTexture.get());
-        if (!commandBuffer)
-        {
-            RTC_LOG(LS_ERROR) << "GetCommandBuffer failed";
-            return nullptr;
-        }
-
-        VulkanUtility::DoImageLayoutTransition(
-            commandBuffer,
-            vulkanTexture->GetUnityVulkanImage(),
-            VK_IMAGE_LAYOUT_UNDEFINED,
-            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            true);
-
-        SubmitCommandBuffer(vulkanTexture.get());
         return vulkanTexture.release();
     }
 
     ITexture2D*
     VulkanGraphicsDevice::CreateCPUReadTextureV(uint32_t w, uint32_t h, UnityRenderingExtTextureFormat textureFormat)
     {
-        bool writable = false;
         std::unique_ptr<VulkanTexture2D> vulkanTexture = std::make_unique<VulkanTexture2D>(w, h);
-        if (!vulkanTexture->InitStaging(&m_Instance, m_commandPool, writable, m_hasHostCachedMemory))
+        if (!vulkanTexture->InitCpuRead(&m_Instance))
         {
             RTC_LOG(LS_ERROR) << "VulkanTexture2D::InitCpuRead failed.";
             return nullptr;
         }
-
-        VkCommandBuffer commandBuffer = GetCommandBuffer(vulkanTexture.get());
-        if (!commandBuffer)
-        {
-            RTC_LOG(LS_ERROR) << "GetCommandBuffer failed";
-            return nullptr;
-        }
-
-        VulkanUtility::DoImageLayoutTransition(
-            commandBuffer,
-            vulkanTexture->GetUnityVulkanImage(),
-            VK_IMAGE_LAYOUT_UNDEFINED,
-            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-            (writable ? VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL),
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            true);
-
-        SubmitCommandBuffer(vulkanTexture.get());
         return vulkanTexture.release();
-    }
-
-    bool VulkanGraphicsDevice::LookupUnityVulkanImage(
-        VkImage src, UnityVulkanImage* outImage, bool* setLayout, VkImageLayout layout)
-    {
-        VulkanTexture2D* vulkanTexture = static_cast<VulkanTexture2D*>(ITexture2D::GetTexturePtr(src));
-
-        *setLayout = false;
-        if (vulkanTexture != nullptr)
-        {
-            *outImage = *vulkanTexture->GetUnityVulkanImage();
-            // We need to do this after CommandRecordingState and AccessTexture
-            *setLayout = true;
-
-#if VULKAN_USE_CRS
-            if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && m_unityVulkan)
-                vulkanTexture->currentFrameNumber = m_LastState.currentFrameNumber;
-#endif
-            return true;
-        }
-
-        VkAccessFlagBits access = (VkAccessFlagBits)0; // VK_ACCESS_NONE is VK_VERSION_1_3
-        if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
-            access = VK_ACCESS_TRANSFER_WRITE_BIT;
-        else if (layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
-            access = VK_ACCESS_TRANSFER_READ_BIT;
-
-        // IUnityGraphicsVulkan bugs:
-        //
-        // UnityVulkanImage.layout is not filled by the plugin interface.
-        //
-        // Calling AccessTexture SHOULD be enough, but current Unity versions have a bug where pipeline barriers
-        // are not flushed/restored. This means even if you do AccessTexture before calling out CommandRecordingState,
-        // the validation layer will complain during custom call to vkCmdCopyImage.
-        //
-        // To avoid Vulkan validation layer from complaining, you could call DoImageLayoutTransition after
-        // AccessTexture and restore the state after CopyImage, but it seems to prevent copy texture from
-        // working with GTX 1080 while it works ok with RTX series.
-        //
-        // AccessTexture flushing pipeline barriers should be fixed with Unity 2022.1+
-        if (m_unityVulkan &&
-            m_unityVulkan->AccessTexture(
-                (void*)src,
-                UnityVulkanWholeImage,
-                layout,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                access,
-                kUnityVulkanResourceAccess_PipelineBarrier,
-                outImage))
-        {
-            return true;
-        }
-        return false;
-    }
-
-    bool VulkanGraphicsDevice::CopyTexture(void* dst, void* src, uint32_t width, uint32_t height)
-    {
-        if (!dst || !src)
-            return false;
-
-        VkImage nativeDst = reinterpret_cast<VkImage>(dst);
-        VkImage nativeSrc = reinterpret_cast<VkImage>(src);
-
-        if (nativeDst == nativeSrc)
-            return false;
-
-        UnityVulkanImage nativeDstUnity;
-        bool setDstLayout = false;
-        if (!LookupUnityVulkanImage(nativeDst, &nativeDstUnity, &setDstLayout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL))
-            return false;
-
-        UnityVulkanImage nativeSrcUnity;
-        bool setSrcLayout = false;
-        if (!LookupUnityVulkanImage(nativeSrc, &nativeSrcUnity, &setSrcLayout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL))
-            return false;
-
-        VulkanTexture2D* vulkanTexture = nullptr;
-#if !VULKAN_USE_CRS
-        vulkanTexture = static_cast<VulkanTexture2D*>(ITexture2D::GetTexturePtr(nativeDst));
-        if (!vulkanTexture)
-            vulkanTexture = static_cast<VulkanTexture2D*>(ITexture2D::GetTexturePtr(nativeSrc));
-        if (!vulkanTexture)
-            return false;
-#endif
-
-        VkCommandBuffer commandBuffer = GetCommandBuffer(vulkanTexture);
-        if (!commandBuffer)
-        {
-            RTC_LOG(LS_ERROR) << "GetCommandBuffer failed";
-            return false;
-        }
-
-        if (setDstLayout)
-        {
-            VulkanUtility::DoImageLayoutTransition(
-                commandBuffer,
-                &nativeDstUnity,
-                nativeDstUnity.layout,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                VK_PIPELINE_STAGE_TRANSFER_BIT);
-        }
-        if (setSrcLayout)
-        {
-            VulkanUtility::DoImageLayoutTransition(
-                commandBuffer,
-                &nativeSrcUnity,
-                nativeSrcUnity.layout,
-                VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                VK_PIPELINE_STAGE_TRANSFER_BIT);
-        }
-        VulkanUtility::CopyImage(commandBuffer, nativeSrcUnity.image, nativeDstUnity.image, width, height);
-        SubmitCommandBuffer(vulkanTexture);
-        return true;
     }
 
     bool VulkanGraphicsDevice::CopyResourceV(ITexture2D* dest, ITexture2D* src)
     {
         VulkanTexture2D* destTexture = reinterpret_cast<VulkanTexture2D*>(dest);
         VulkanTexture2D* srcTexture = reinterpret_cast<VulkanTexture2D*>(src);
-
+        if (destTexture == srcTexture)
+            return false;
         if (!destTexture || !srcTexture)
             return false;
 
-        if (destTexture == srcTexture)
+        VkCommandBuffer commandBuffer = GetCommandBuffer();
+        if (!commandBuffer)
+        {
+            RTC_LOG(LS_ERROR) << "GetCommandBuffer failed";
             return false;
+        }
 
-        return CopyTexture(
-            destTexture->GetImage(), srcTexture->GetImage(), destTexture->GetWidth(), destTexture->GetHeight());
+        // Transition the src texture layout.
+        VkResult result = VulkanUtility::DoImageLayoutTransition(
+            commandBuffer,
+            srcTexture->GetImage(),
+            srcTexture->GetTextureFormat(),
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_ERROR) << "DoImageLayoutTransition failed. result:" << result;
+            return false;
+        }
+
+        // Transition the dst texture layout.
+        result = VulkanUtility::DoImageLayoutTransition(
+            commandBuffer,
+            destTexture->GetImage(),
+            destTexture->GetTextureFormat(),
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_ERROR) << "DoImageLayoutTransition failed. result:" << result;
+            return false;
+        }
+
+        result = VulkanUtility::CopyImage(
+            commandBuffer,
+            srcTexture->GetImage(),
+            destTexture->GetImage(),
+            destTexture->GetWidth(),
+            destTexture->GetHeight());
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_ERROR) << "CopyImage failed. result:" << result;
+            return false;
+        }
+        // transition the src texture layout back to VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+        result = VulkanUtility::DoImageLayoutTransition(
+            commandBuffer,
+            srcTexture->GetImage(),
+            srcTexture->GetTextureFormat(),
+            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_ERROR) << "DoImageLayoutTransition failed. result:" << result;
+            return false;
+        }
+
+        destTexture->currentFrameNumber = m_LastState.currentFrameNumber;
+        SubmitCommandBuffer();
+        return true;
     }
 
     bool VulkanGraphicsDevice::CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr)
     {
-        VulkanTexture2D* destTexture = reinterpret_cast<VulkanTexture2D*>(dest);
-        VkImage nativeSrc = reinterpret_cast<VkImage>(nativeTexturePtr);
+        if (!nativeTexturePtr)
+        {
+            RTC_LOG(LS_ERROR) << "nativeTexturePtr is nullptr.";
+            return false;
+        }
 
-        return CopyTexture(destTexture->GetImage(), nativeSrc, destTexture->GetWidth(), destTexture->GetHeight());
+        if (!dest)
+        {
+            RTC_LOG(LS_ERROR) << "dest is nullptr.";
+            return false;
+        }
+        VulkanTexture2D* destTexture = reinterpret_cast<VulkanTexture2D*>(dest);
+        UnityVulkanImage* unityVulkanImage = static_cast<UnityVulkanImage*>(nativeTexturePtr);
+
+        VkCommandBuffer commandBuffer = GetCommandBuffer();
+        if (!commandBuffer)
+        {
+            RTC_LOG(LS_ERROR) << "GetCommandBuffer failed";
+            return false;
+        }
+
+        // Transition the src texture layout.
+        VkResult result = VulkanUtility::DoImageLayoutTransition(
+            commandBuffer,
+            unityVulkanImage->image,
+            unityVulkanImage->format,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_ERROR) << "DoImageLayoutTransition failed. result:" << result;
+            return false;
+        }
+
+        // Transition the dst texture layout.
+        result = VulkanUtility::DoImageLayoutTransition(
+            commandBuffer,
+            destTexture->GetImage(),
+            destTexture->GetTextureFormat(),
+            VK_IMAGE_LAYOUT_UNDEFINED,
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_PIPELINE_STAGE_TRANSFER_BIT);
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_ERROR) << "DoImageLayoutTransition failed. result:" << result;
+            return false;
+        }
+
+        VkImage image = unityVulkanImage->image;
+        if (destTexture->GetImage() == image)
+            return false;
+        {
+            std::unique_ptr<const ScopedProfiler> profiler;
+            if (m_profiler)
+                profiler = m_profiler->CreateScopedProfiler(*m_maker);
+
+            // The layouts of All VulkanTexture2D should be VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            // so no transition for destTex
+            VkResult result = VulkanUtility::CopyImage(
+                commandBuffer, image, destTexture->GetImage(), destTexture->GetWidth(), destTexture->GetHeight());
+            if (result != VK_SUCCESS)
+            {
+                RTC_LOG(LS_ERROR) << "CopyImage failed. result:" << result;
+                return false;
+            }
+        }
+
+        destTexture->currentFrameNumber = m_LastState.currentFrameNumber;
+        SubmitCommandBuffer();
+        return true;
     }
 
     rtc::scoped_refptr<webrtc::I420Buffer> VulkanGraphicsDevice::ConvertRGBToI420(ITexture2D* tex)
@@ -435,18 +362,29 @@ namespace webrtc
         VulkanTexture2D* vulkanTexture = static_cast<VulkanTexture2D*>(tex);
         const int32_t width = static_cast<int32_t>(tex->GetWidth());
         const int32_t height = static_cast<int32_t>(tex->GetHeight());
-        const int32_t rowPitch = static_cast<int32_t>(vulkanTexture->GetPitch());
+        const VkDeviceMemory dstImageMemory = vulkanTexture->GetTextureImageMemory();
+        VkImageSubresource subresource { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
+        VkSubresourceLayout subresourceLayout;
+        vkGetImageSubresourceLayout(m_Instance.device, vulkanTexture->GetImage(), &subresource, &subresourceLayout);
+        const int32_t rowPitch = static_cast<int32_t>(subresourceLayout.rowPitch);
 
-        VkDeviceMemory textureImageMemory = vulkanTexture->GetTextureImageMemory();
-        void* data = nullptr;
-
-        if (vkMapMemory(m_Instance.device, textureImageMemory, 0, VK_WHOLE_SIZE, 0, &data) != VK_SUCCESS)
+        void* data;
+        std::vector<uint8_t> dst;
+        dst.resize(vulkanTexture->GetTextureImageMemorySize());
+        const VkResult result = vkMapMemory(m_Instance.device, dstImageMemory, 0, VK_WHOLE_SIZE, 0, &data);
+        if (result != VK_SUCCESS)
+        {
+            RTC_LOG(LS_INFO) << "vkMapMemory failed.";
             return nullptr;
+        }
+        std::memcpy(static_cast<void*>(dst.data()), data, dst.size());
+
+        vkUnmapMemory(m_Instance.device, dstImageMemory);
 
         // convert format to i420
         rtc::scoped_refptr<webrtc::I420Buffer> i420Buffer = webrtc::I420Buffer::Create(width, height);
         libyuv::ARGBToI420(
-            (const uint8_t*)data,
+            dst.data(),
             rowPitch,
             i420Buffer->MutableDataY(),
             i420Buffer->StrideY(),
@@ -456,7 +394,7 @@ namespace webrtc
             i420Buffer->StrideV(),
             width,
             height);
-        vkUnmapMemory(m_Instance.device, textureImageMemory);
+
         return i420Buffer;
     }
 
@@ -495,7 +433,6 @@ namespace webrtc
 
     bool VulkanGraphicsDevice::UpdateState()
     {
-#if VULKAN_USE_CRS
         if (m_unityVulkan)
         {
             std::unique_lock<std::mutex> lock(m_LastStateMtx);
@@ -507,14 +444,10 @@ namespace webrtc
         }
         m_LastState = {};
         return false;
-#else
-        return true;
-#endif
     }
 
     bool VulkanGraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
     {
-#if VULKAN_USE_CRS
         if (!m_unityVulkan)
             return true;
 
@@ -526,50 +459,13 @@ namespace webrtc
                 return vulkanTexture->currentFrameNumber <= m_LastState.safeFrameNumber;
             });
         return ret;
-#else
-        const VulkanTexture2D* vulkanTexture = static_cast<const VulkanTexture2D*>(texture);
-        VkFence fence = vulkanTexture->GetFence();
-        VkResult result = vkWaitForFences(m_Instance.device, 1, &fence, true, nsTimeout);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_INFO) << "vkWaitForFences failed. result:" << result;
-            return false;
-        }
-        return true;
-#endif
     }
 
     bool VulkanGraphicsDevice::ResetSync(const ITexture2D* texture)
     {
-#if VULKAN_USE_CRS
         const VulkanTexture2D* vulkanTexture = static_cast<const VulkanTexture2D*>(texture);
         vulkanTexture->ResetFrameNumber();
         return true;
-#else
-        const VulkanTexture2D* vulkanTexture = static_cast<const VulkanTexture2D*>(texture);
-        VkCommandBuffer commandBuffer = vulkanTexture->GetCommandBuffer();
-        VkFence fence = vulkanTexture->GetFence();
-
-        VkResult result = vkGetFenceStatus(m_Instance.device, fence);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_INFO) << "vkGetFenceStatus failed. result:" << result;
-            return false;
-        }
-        result = vkResetFences(m_Instance.device, 1, &fence);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_INFO) << "vkResetFences failed. result:" << result;
-            return false;
-        }
-        result = vkResetCommandBuffer(commandBuffer, 0);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_INFO) << "vkResetCommandBuffer failed. result:" << result;
-            return false;
-        }
-        return true;
-#endif
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -70,6 +70,7 @@ namespace webrtc
 
         UnityGraphicsVulkan* m_unityVulkan;
         UnityVulkanInstance m_Instance;
+        bool m_hasHostCachedMemory;
 
         // No access to VkFence internals through rendering plugin, track safe frame numbers
         UnityVulkanRecordingState m_LastState;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -7,7 +7,6 @@
 #include <vulkan/vulkan.h>
 
 #include "PlatformBase.h"
-#include "VulkanUtility.h"
 
 #if CUDA_PLATFORM
 #include "GraphicsDevice/Cuda/CudaContext.h"
@@ -22,7 +21,6 @@ namespace webrtc
     using namespace ::webrtc;
 
     class UnityGraphicsVulkan;
-    class VulkanTexture2D;
     class VulkanGraphicsDevice : public IGraphicsDevice
     {
     public:
@@ -35,24 +33,24 @@ namespace webrtc
         ~VulkanGraphicsDevice() override = default;
         bool InitV() override;
         void ShutdownV() override;
-
-#if CUDA_PLATFORM
-        void* GetEncodeDevicePtrV() override { return reinterpret_cast<void*>(m_cudaContext.GetContext()); }
-#else
-        void* GetEncodeDevicePtrV() override { return nullptr; }
-#endif
-
+        inline void* GetEncodeDevicePtrV() override;
         ITexture2D* CreateDefaultTextureV(
             const uint32_t w, const uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
         ITexture2D*
         CreateCPUReadTextureV(uint32_t width, uint32_t height, UnityRenderingExtTextureFormat textureFormat) override;
 
-        bool CopyTexture(void* dst, void* src, uint32_t width, uint32_t height);
+        std::unique_ptr<UnityVulkanImage> AccessTexture(void* ptr) const;
+
         bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="dest"></param>
+        /// <param name="nativeTexturePtr"> a pointer of UnityVulkanImage </param>
+        /// <returns></returns>
         bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
-
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
-
         bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
         bool ResetSync(const ITexture2D* texture) override;
         bool WaitIdleForTest() override;
@@ -65,16 +63,14 @@ namespace webrtc
         NV_ENC_BUFFER_FORMAT GetEncodeBufferFormat() override { return NV_ENC_BUFFER_FORMAT_ARGB; }
 #endif
     private:
-        bool LookupUnityVulkanImage(VkImage src, UnityVulkanImage* outImage, bool* setLayout, VkImageLayout layout);
+        const UnityProfilerMarkerDesc* m_maker;
 
-        VkCommandBuffer GetCommandBuffer(VulkanTexture2D* texture);
-        void SubmitCommandBuffer(VulkanTexture2D* texture);
+        VkCommandBuffer GetCommandBuffer();
+        void SubmitCommandBuffer();
 
         UnityGraphicsVulkan* m_unityVulkan;
         UnityVulkanInstance m_Instance;
-        bool m_hasHostCachedMemory;
 
-#if VULKAN_USE_CRS
         // No access to VkFence internals through rendering plugin, track safe frame numbers
         UnityVulkanRecordingState m_LastState;
         std::mutex m_LastStateMtx;
@@ -84,10 +80,6 @@ namespace webrtc
         VkCommandPool m_commandPool;
         VkCommandBuffer m_commandBuffer;
         VkFence m_fence;
-#else
-        VkResult CreateCommandPool();
-        VkCommandPool m_commandPool;
-#endif
 
 #if CUDA_PLATFORM
         bool InitCudaContext();
@@ -96,6 +88,14 @@ namespace webrtc
 #endif
     };
 
+    void* VulkanGraphicsDevice::GetEncodeDevicePtrV()
+    {
+#if CUDA_PLATFORM
+        return reinterpret_cast<void*>(m_cudaContext.GetContext());
+#else
+        return nullptr;
+#endif
+    }
 } // end namespace webrtc
 
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -33,7 +33,13 @@ namespace webrtc
         ~VulkanGraphicsDevice() override = default;
         bool InitV() override;
         void ShutdownV() override;
-        inline void* GetEncodeDevicePtrV() override;
+
+#if CUDA_PLATFORM
+        void* GetEncodeDevicePtrV() override { return reinterpret_cast<void*>(m_cudaContext.GetContext()); }
+#else
+        void* GetEncodeDevicePtrV() override { return nullptr; }
+#endif
+
         ITexture2D* CreateDefaultTextureV(
             const uint32_t w, const uint32_t h, UnityRenderingExtTextureFormat textureFormat) override;
         ITexture2D*
@@ -88,15 +94,5 @@ namespace webrtc
         bool m_isCudaSupport;
 #endif
     };
-
-    void* VulkanGraphicsDevice::GetEncodeDevicePtrV()
-    {
-#if CUDA_PLATFORM
-        return reinterpret_cast<void*>(m_cudaContext.GetContext());
-#else
-        return nullptr;
-#endif
-    }
 } // end namespace webrtc
-
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include "GraphicsDevice/Vulkan/VulkanUtility.h"
 #include "VulkanTexture2D.h"
 
 namespace unity
@@ -8,13 +9,7 @@ namespace webrtc
 {
     VulkanTexture2D::VulkanTexture2D(const uint32_t w, const uint32_t h)
         : ITexture2D(w, h)
-#if !VULKAN_USE_CRS
-        , m_commandPool(VK_NULL_HANDLE)
-        , m_commandBuffer(VK_NULL_HANDLE)
-        , m_fence(VK_NULL_HANDLE)
-#endif
         , m_textureFormat(VK_FORMAT_B8G8R8A8_UNORM)
-        , m_rowPitch(w * 4)
     {
     }
 
@@ -22,8 +17,6 @@ namespace webrtc
 
     void VulkanTexture2D::Shutdown()
     {
-        RemoveTextureBinding(GetImage());
-
         if (m_unityVulkanImage.image != VK_NULL_HANDLE)
         {
             vkDestroyImage(m_Instance.device, m_unityVulkanImage.image, m_allocator);
@@ -34,62 +27,13 @@ namespace webrtc
             vkFreeMemory(m_Instance.device, m_unityVulkanImage.memory.memory, m_allocator);
             m_unityVulkanImage.memory.memory = VK_NULL_HANDLE;
         }
-#if !VULKAN_USE_CRS
-        if (m_commandBuffer != VK_NULL_HANDLE)
-        {
-            vkFreeCommandBuffers(m_Instance.device, m_commandPool, 1, &m_commandBuffer);
-            m_commandBuffer = VK_NULL_HANDLE;
-        }
-        if (m_fence != VK_NULL_HANDLE)
-        {
-            vkDestroyFence(m_Instance.device, m_fence, nullptr);
-            m_fence = VK_NULL_HANDLE;
-        }
-        m_commandPool = VK_NULL_HANDLE;
-#endif
         m_unityVulkanImage.memory.size = 0;
         m_Instance.device = nullptr;
     }
 
-#if !VULKAN_USE_CRS
-    bool VulkanTexture2D::CreateFence()
-    {
-        // Create a command buffer to copy
-        VkCommandBufferAllocateInfo allocInfo = {};
-        allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-        allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        allocInfo.commandPool = m_commandPool;
-        allocInfo.commandBufferCount = 1;
-
-        VkResult result = vkAllocateCommandBuffers(m_Instance.device, &allocInfo, &m_commandBuffer);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_INFO) << "vkAllocateCommandBuffers failed. result:" << result;
-            return false;
-        }
-
-        VkFenceCreateInfo createInfo = {};
-        createInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-        createInfo.pNext = nullptr;
-        createInfo.flags = 0;
-        result = vkCreateFence(m_Instance.device, &createInfo, nullptr, &m_fence);
-        if (result != VK_SUCCESS)
-        {
-            RTC_LOG(LS_INFO) << "vkCreateFence failed. result:" << result;
-            return false;
-        }
-        return true;
-    }
-#endif
-
-    bool VulkanTexture2D::Init(const UnityVulkanInstance* instance, const VkCommandPool commandPool)
+    bool VulkanTexture2D::Init(const UnityVulkanInstance* instance)
     {
         m_Instance = *instance;
-#if !VULKAN_USE_CRS
-        m_commandPool = commandPool;
-        if (!CreateFence())
-            return false;
-#endif
 
         const bool EXPORT_HANDLE = true;
         VkResult result = VulkanUtility::CreateImage(
@@ -109,27 +53,12 @@ namespace webrtc
             return false;
         }
 
-        BindTexture(GetImage(), this);
         return true;
     }
 
-    bool VulkanTexture2D::InitStaging(
-        const UnityVulkanInstance* instance, const VkCommandPool commandPool, bool writable, bool hasHostCachedMemory)
+    bool VulkanTexture2D::InitCpuRead(const UnityVulkanInstance* instance)
     {
         m_Instance = *instance;
-#if !VULKAN_USE_CRS
-        m_commandPool = commandPool;
-        if (!CreateFence())
-            return false;
-#endif
-
-        VkMemoryPropertyFlags properties = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-
-        if (writable)
-            properties |= VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-        else
-            properties |=
-                (hasHostCachedMemory ? VK_MEMORY_PROPERTY_HOST_CACHED_BIT : VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
         const bool EXPORT_HANDLE = false;
         VkResult result = VulkanUtility::CreateImage(
@@ -138,8 +67,8 @@ namespace webrtc
             m_width,
             m_height,
             VK_IMAGE_TILING_LINEAR,
-            (writable ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : VK_IMAGE_USAGE_TRANSFER_DST_BIT),
-            properties,
+            VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
             m_textureFormat,
             &m_unityVulkanImage,
             EXPORT_HANDLE);
@@ -149,14 +78,7 @@ namespace webrtc
             return false;
         }
 
-        VkImageSubresource subresource { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
-        VkSubresourceLayout subresourceLayout;
-        vkGetImageSubresourceLayout(m_Instance.device, m_unityVulkanImage.image, &subresource, &subresourceLayout);
-        m_rowPitch = static_cast<size_t>(subresourceLayout.rowPitch);
-
-        BindTexture(GetImage(), this);
         return true;
     }
-
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
@@ -86,6 +86,11 @@ namespace webrtc
             return false;
         }
 
+        VkImageSubresource subresource { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
+        VkSubresourceLayout subresourceLayout;
+        vkGetImageSubresourceLayout(m_Instance.device, m_unityVulkanImage.image, &subresource, &subresourceLayout);
+        m_rowPitch = static_cast<size_t>(subresourceLayout.rowPitch);
+
         return true;
     }
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.cpp
@@ -56,9 +56,17 @@ namespace webrtc
         return true;
     }
 
-    bool VulkanTexture2D::InitCpuRead(const UnityVulkanInstance* instance)
+    bool VulkanTexture2D::InitStaging(const UnityVulkanInstance* instance, bool writable, bool hasHostCachedMemory)
     {
         m_Instance = *instance;
+
+        VkMemoryPropertyFlags properties = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+
+        if (writable)
+            properties |= VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        else
+            properties |=
+                (hasHostCachedMemory ? VK_MEMORY_PROPERTY_HOST_CACHED_BIT : VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
         const bool EXPORT_HANDLE = false;
         VkResult result = VulkanUtility::CreateImage(
@@ -67,8 +75,8 @@ namespace webrtc
             m_width,
             m_height,
             VK_IMAGE_TILING_LINEAR,
-            VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+            (writable ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : VK_IMAGE_USAGE_TRANSFER_DST_BIT),
+            properties,
             m_textureFormat,
             &m_unityVulkanImage,
             EXPORT_HANDLE);

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
@@ -14,7 +14,7 @@ namespace webrtc
         virtual ~VulkanTexture2D() override;
 
         bool Init(const UnityVulkanInstance* instance);
-        bool InitCpuRead(const UnityVulkanInstance* instance);
+        bool InitStaging(const UnityVulkanInstance* instance, bool writable, bool hasHostCachedMemory);
         void Shutdown();
 
         inline virtual void* GetNativeTexturePtrV() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
@@ -27,12 +27,15 @@ namespace webrtc
         inline VkDeviceSize GetTextureImageMemorySize() const;
         inline VkFormat GetTextureFormat() const;
 
+        size_t GetPitch() const { return m_rowPitch; }
+
         void ResetFrameNumber() const { currentFrameNumber = 0; }
         mutable unsigned long long currentFrameNumber = 0;
 
     private:
         UnityVulkanInstance m_Instance = {};
         VkFormat m_textureFormat;
+        size_t m_rowPitch;
         UnityVulkanImage m_unityVulkanImage = {};
         const VkAllocationCallbacks* m_allocator = nullptr;
     };

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
@@ -17,8 +17,8 @@ namespace webrtc
         bool InitStaging(const UnityVulkanInstance* instance, bool writable, bool hasHostCachedMemory);
         void Shutdown();
 
-        void* GetNativeTexturePtrV() override { return m_unityVulkanImage.image; }
-        const void* GetNativeTexturePtrV() const override { return m_unityVulkanImage.image; };
+        void* GetNativeTexturePtrV() override { return &m_unityVulkanImage; }
+        const void* GetNativeTexturePtrV() const override { return &m_unityVulkanImage; };
         void* GetEncodeTexturePtrV() override { return nullptr; }
         const void* GetEncodeTexturePtrV() const override { return nullptr; }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
@@ -2,7 +2,6 @@
 
 #include "GraphicsDevice/ITexture2D.h"
 #include "IUnityGraphicsVulkan.h"
-#include "VulkanUtility.h"
 
 namespace unity
 {
@@ -14,47 +13,39 @@ namespace webrtc
         VulkanTexture2D(const uint32_t w, const uint32_t h);
         virtual ~VulkanTexture2D() override;
 
-        bool Init(const UnityVulkanInstance* instance, const VkCommandPool commandPool);
-        bool InitStaging(
-            const UnityVulkanInstance* instance,
-            const VkCommandPool commandPool,
-            bool writable,
-            bool hasHostCachedMemory);
+        bool Init(const UnityVulkanInstance* instance);
+        bool InitCpuRead(const UnityVulkanInstance* instance);
         void Shutdown();
 
-        void* GetNativeTexturePtrV() override { return m_unityVulkanImage.image; }
-        const void* GetNativeTexturePtrV() const override { return m_unityVulkanImage.image; };
-        void* GetEncodeTexturePtrV() override { return nullptr; }
-        const void* GetEncodeTexturePtrV() const override { return nullptr; }
+        inline virtual void* GetNativeTexturePtrV() override;
+        inline virtual const void* GetNativeTexturePtrV() const override;
+        inline virtual void* GetEncodeTexturePtrV() override;
+        inline virtual const void* GetEncodeTexturePtrV() const override;
 
-        UnityVulkanImage* GetUnityVulkanImage() { return &m_unityVulkanImage; }
-        VkImage GetImage() const { return m_unityVulkanImage.image; }
-        VkDeviceMemory GetTextureImageMemory() const { return m_unityVulkanImage.memory.memory; }
-        VkDeviceSize GetTextureImageMemorySize() const { return m_unityVulkanImage.memory.size; }
-        VkFormat GetTextureFormat() const { return m_textureFormat; }
+        inline VkImage GetImage() const;
+        inline VkDeviceMemory GetTextureImageMemory() const;
+        inline VkDeviceSize GetTextureImageMemorySize() const;
+        inline VkFormat GetTextureFormat() const;
 
-        size_t GetPitch() const { return m_rowPitch; }
-
-#if VULKAN_USE_CRS
         void ResetFrameNumber() const { currentFrameNumber = 0; }
         mutable unsigned long long currentFrameNumber = 0;
-#else
-        bool CreateFence();
-        VkFence GetFence() const { return m_fence; }
-        VkCommandBuffer GetCommandBuffer() const { return m_commandBuffer; }
-
-        VkCommandPool m_commandPool;
-        VkCommandBuffer m_commandBuffer;
-        VkFence m_fence;
-#endif
 
     private:
         UnityVulkanInstance m_Instance = {};
         VkFormat m_textureFormat;
-        size_t m_rowPitch;
         UnityVulkanImage m_unityVulkanImage = {};
         const VkAllocationCallbacks* m_allocator = nullptr;
     };
+
+    void* VulkanTexture2D::GetNativeTexturePtrV() { return &m_unityVulkanImage; }
+    const void* VulkanTexture2D::GetNativeTexturePtrV() const { return &m_unityVulkanImage; };
+    void* VulkanTexture2D::GetEncodeTexturePtrV() { return nullptr; }
+    const void* VulkanTexture2D::GetEncodeTexturePtrV() const { return nullptr; }
+
+    VkImage VulkanTexture2D::GetImage() const { return m_unityVulkanImage.image; }
+    VkDeviceMemory VulkanTexture2D::GetTextureImageMemory() const { return m_unityVulkanImage.memory.memory; }
+    VkDeviceSize VulkanTexture2D::GetTextureImageMemorySize() const { return m_unityVulkanImage.memory.size; }
+    VkFormat VulkanTexture2D::GetTextureFormat() const { return m_textureFormat; }
 
 } // end namespace unity
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanTexture2D.h
@@ -17,15 +17,16 @@ namespace webrtc
         bool InitStaging(const UnityVulkanInstance* instance, bool writable, bool hasHostCachedMemory);
         void Shutdown();
 
-        inline virtual void* GetNativeTexturePtrV() override;
-        inline virtual const void* GetNativeTexturePtrV() const override;
-        inline virtual void* GetEncodeTexturePtrV() override;
-        inline virtual const void* GetEncodeTexturePtrV() const override;
+        void* GetNativeTexturePtrV() override { return m_unityVulkanImage.image; }
+        const void* GetNativeTexturePtrV() const override { return m_unityVulkanImage.image; };
+        void* GetEncodeTexturePtrV() override { return nullptr; }
+        const void* GetEncodeTexturePtrV() const override { return nullptr; }
 
-        inline VkImage GetImage() const;
-        inline VkDeviceMemory GetTextureImageMemory() const;
-        inline VkDeviceSize GetTextureImageMemorySize() const;
-        inline VkFormat GetTextureFormat() const;
+        UnityVulkanImage* GetUnityVulkanImage() { return &m_unityVulkanImage; }
+        VkImage GetImage() const { return m_unityVulkanImage.image; }
+        VkDeviceMemory GetTextureImageMemory() const { return m_unityVulkanImage.memory.memory; }
+        VkDeviceSize GetTextureImageMemorySize() const { return m_unityVulkanImage.memory.size; }
+        VkFormat GetTextureFormat() const { return m_textureFormat; }
 
         size_t GetPitch() const { return m_rowPitch; }
 
@@ -39,16 +40,6 @@ namespace webrtc
         UnityVulkanImage m_unityVulkanImage = {};
         const VkAllocationCallbacks* m_allocator = nullptr;
     };
-
-    void* VulkanTexture2D::GetNativeTexturePtrV() { return &m_unityVulkanImage; }
-    const void* VulkanTexture2D::GetNativeTexturePtrV() const { return &m_unityVulkanImage; };
-    void* VulkanTexture2D::GetEncodeTexturePtrV() { return nullptr; }
-    const void* VulkanTexture2D::GetEncodeTexturePtrV() const { return nullptr; }
-
-    VkImage VulkanTexture2D::GetImage() const { return m_unityVulkanImage.image; }
-    VkDeviceMemory VulkanTexture2D::GetTextureImageMemory() const { return m_unityVulkanImage.memory.memory; }
-    VkDeviceSize VulkanTexture2D::GetTextureImageMemorySize() const { return m_unityVulkanImage.memory.size; }
-    VkFormat VulkanTexture2D::GetTextureFormat() const { return m_textureFormat; }
 
 } // end namespace unity
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.cpp
@@ -262,22 +262,13 @@ namespace webrtc
 
     VkResult VulkanUtility::DoImageLayoutTransition(
         const VkCommandBuffer commandBuffer,
-        UnityVulkanImage* unityImage,
+        const VkImage image,
+        const VkFormat format,
         const VkImageLayout oldLayout,
         const VkPipelineStageFlags oldStage,
         const VkImageLayout newLayout,
-        const VkPipelineStageFlags newStage,
-        bool saveLayout)
+        const VkPipelineStageFlags newStage)
     {
-        if (unityImage == nullptr)
-            return VK_NOT_READY;
-
-        if (oldStage == newStage && oldLayout == newLayout)
-            return VK_SUCCESS;
-
-        if (saveLayout)
-            unityImage->layout = newLayout;
-
         VkImageMemoryBarrier barrier = {};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
         barrier.oldLayout = oldLayout;
@@ -285,7 +276,7 @@ namespace webrtc
         barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // for transferring queue family ownership
         barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 
-        barrier.image = unityImage->image;
+        barrier.image = image;
         barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         barrier.subresourceRange.baseMipLevel = 0;
         barrier.subresourceRange.levelCount = 1; // No mip map

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanUtility.h
@@ -1,8 +1,5 @@
 #pragma once
 
-// Texture synchronization against IUnityGraphicsVulkan::CommandRecordingState
-#define VULKAN_USE_CRS 0
-
 #include <array>
 
 #include <IUnityGraphicsVulkan.h>
@@ -51,12 +48,12 @@ namespace webrtc
 
         static VkResult DoImageLayoutTransition(
             const VkCommandBuffer commandBuffer,
-            UnityVulkanImage* unityImage,
+            const VkImage image,
+            const VkFormat format,
             const VkImageLayout oldLayout,
             const VkPipelineStageFlags oldStage,
             const VkImageLayout newLayout,
-            const VkPipelineStageFlags newStage,
-            bool saveLayout = false);
+            const VkPipelineStageFlags newStage);
 
         static VkResult CopyImage(
             const VkCommandBuffer commandBuffer,

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -3,6 +3,7 @@
 #include "Context.h"
 #include "GpuMemoryBufferPool.h"
 #include "GraphicsDevice/GraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "ProfilerMarkerFactory.h"
 #include "ScopedProfiler.h"
 #include "UnityProfilerInterfaceFunctions.h"
@@ -11,7 +12,6 @@
 
 #if defined(SUPPORT_VULKAN)
 #include "GraphicsDevice/Vulkan/UnityVulkanInitCallback.h"
-#include "GraphicsDevice/Vulkan/VulkanUtility.h"
 #include "UnityVulkanInterfaceFunctions.h"
 #endif
 
@@ -102,15 +102,10 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             /// Configure the event on the rendering thread called from CommandBuffer::IssuePluginEventAndData method in
             /// managed code.
             UnityVulkanPluginEventConfig batchUpdateEventConfig;
-#if VULKAN_USE_CRS
             batchUpdateEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
             batchUpdateEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
-            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
-#else
-            batchUpdateEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_Allow;
-            batchUpdateEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
-            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission;
-#endif
+            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
 
             vulkan->ConfigureEvent(s_batchUpdateEventID, &batchUpdateEventConfig);
         }
@@ -276,6 +271,7 @@ static void UNITY_INTERFACE_API OnBatchUpdateEvent(int eventID, void* data)
     }
 
     IGraphicsDevice* device = Plugin::GraphicsDevice();
+    UnityGfxRenderer gfxRenderer = device->GetGfxRenderer();
     Timestamp timestamp = s_clock->CurrentTime();
 
     if (!device->UpdateState())
@@ -303,6 +299,12 @@ static void UNITY_INTERFACE_API OnBatchUpdateEvent(int eventID, void* data)
             }
 
             timestamp = s_clock->CurrentTime();
+            void* ptr = GraphicsUtility::TextureHandleToNativeGraphicsPtr(trackData->texture, device, gfxRenderer);
+            if (!ptr)
+            {
+                RTC_LOG(LS_ERROR) << "GraphicsUtility::TextureHandleToNativeGraphicsPtr returns nullptr.";
+                return;
+            }
             unity::webrtc::Size size(trackData->width, trackData->height);
 
             if (s_bufferPool->bufferCount() < kLimitBufferCount)
@@ -311,7 +313,7 @@ static void UNITY_INTERFACE_API OnBatchUpdateEvent(int eventID, void* data)
                 if (s_ProfilerMarkerFactory)
                     profiler = s_ProfilerMarkerFactory->CreateScopedProfiler(*s_MarkerEncode);
 
-                auto frame = s_bufferPool->CreateFrame(trackData->texture, size, trackData->format, timestamp);
+                auto frame = s_bufferPool->CreateFrame(ptr, size, trackData->format, timestamp);
                 source->OnFrameCaptured(std::move(frame));
             }
         }

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -104,8 +104,7 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             UnityVulkanPluginEventConfig batchUpdateEventConfig;
             batchUpdateEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
             batchUpdateEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
-            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
-                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
+            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
 
             vulkan->ConfigureEvent(s_batchUpdateEventID, &batchUpdateEventConfig);
         }

--- a/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
+++ b/Plugin~/WebRTCPlugin/UnityRenderEvent.cpp
@@ -104,7 +104,8 @@ static void UNITY_INTERFACE_API OnGraphicsDeviceEvent(UnityGfxDeviceEventType ev
             UnityVulkanPluginEventConfig batchUpdateEventConfig;
             batchUpdateEventConfig.graphicsQueueAccess = kUnityVulkanGraphicsQueueAccess_DontCare;
             batchUpdateEventConfig.renderPassPrecondition = kUnityVulkanRenderPass_EnsureOutside;
-            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
+            batchUpdateEventConfig.flags = kUnityVulkanEventConfigFlag_EnsurePreviousFrameSubmission |
+                kUnityVulkanEventConfigFlag_ModifiesCommandBuffersState;
 
             vulkan->ConfigureEvent(s_batchUpdateEventID, &batchUpdateEventConfig);
         }

--- a/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoDecoderFactory.cpp
@@ -5,7 +5,7 @@
 #include <modules/video_coding/include/video_error_codes.h>
 
 #include "Codec/CreateVideoCodecFactory.h"
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "ProfilerMarkerFactory.h"
 #include "ScopedProfiler.h"
 #include "UnityVideoDecoderFactory.h"

--- a/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoEncoderFactory.cpp
@@ -6,7 +6,7 @@
 #include <tuple>
 
 #include "Codec/CreateVideoCodecFactory.h"
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "ProfilerMarkerFactory.h"
 #include "ScopedProfiler.h"
 #include "UnityVideoEncoderFactory.h"

--- a/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
+++ b/Plugin~/WebRTCPlugin/UnityVideoRenderer.cpp
@@ -91,15 +91,14 @@ namespace webrtc
         if (!frame)
             return tempBuffer.data();
 
-        rtc::scoped_refptr<webrtc::I420BufferInterface> i420_buffer;
-        if (width == frame->width() && height == frame->height())
-        {
-            i420_buffer = frame->ToI420();
-        }
-        else
+        rtc::scoped_refptr<webrtc::I420BufferInterface> i420_buffer = frame->ToI420();
+        if (!i420_buffer)
+            return tempBuffer.data();
+
+        if (width != frame->width() || height != frame->height())
         {
             auto temp = webrtc::I420Buffer::Create(width, height);
-            temp->ScaleFrom(*frame->ToI420());
+            temp->ScaleFrom(*i420_buffer);
             i420_buffer = temp;
         }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -3,7 +3,7 @@
 #include "Context.h"
 #include "CreateSessionDescriptionObserver.h"
 #include "EncodedStreamTransformer.h"
-#include "GraphicsDevice/IGraphicsDevice.h"
+#include "GraphicsDevice/GraphicsUtility.h"
 #include "MediaStreamObserver.h"
 #include "PeerConnectionObject.h"
 #include "SetLocalDescriptionObserver.h"


### PR DESCRIPTION
related PR #975.

This PR is reverted this #967. I'm sorry to revert this which is efforted by @aet.

We are currently in the QA phase of package development and have tested and confirmed the issue under the following conditions:

- Use the Vulkan Graphic API
- Set Graphics Job enabled in Player Settings Window
- Build the native plugin for Release, not Debug
- Turn off Development Build in Build Settings Window

When testing video streaming with the PeerConnection sample, no video is received.

This issue is occurring since the https://github.com/Unity-Technologies/com.unity.webrtc/commit/665ad1ff2a9d6f113fda95d630249e29cae0970e. We have also confirmed that enabling **VULKAN_USE_CRS** resolves the issue. However, there is another problem when VULKAN_USE_CRS is enabled: performance may be degraded when using VSync. This performance issue is discussed #967.
