### PR TITLE
fix: Add a patch to fix Android crash when stopping video track

### DIFF
--- a/BuildScripts~/build_libwebrtc_android.sh
+++ b/BuildScripts~/build_libwebrtc_android.sh
@@ -45,9 +45,11 @@ patch -N "src/build/android/gyp/turbine.py" < "$COMMAND_DIR/patches/downgradeJDK
 # Fix SetRawImagePlanes() in LibvpxVp8Encoder
 patch -N "src/modules/video_coding/codecs/vp8/libvpx_vp8_encoder.cc" < "$COMMAND_DIR/patches/libvpx_vp8_encoder.patch"
 
-# Fix AdaptedVideoTrackSource::video_adapter()
 pushd src
+# Fix AdaptedVideoTrackSource::video_adapter()
 patch -p1 < "$COMMAND_DIR/patches/fix_adaptedvideotracksource.patch"
+# Fix Android video encoder 
+patch -p1 < "$COMMAND_DIR/patches/fix_android_videoencoder.patch"
 popd
 
 mkdir -p "$ARTIFACTS_DIR/lib"

--- a/BuildScripts~/patches/fix_android_videoencoder.patch
+++ b/BuildScripts~/patches/fix_android_videoencoder.patch
@@ -1,0 +1,32 @@
+diff --git a/sdk/android/src/jni/video_encoder_wrapper.cc b/sdk/android/src/jni/video_encoder_wrapper.cc
+index 3912ede048..c4f19bbce8 100644
+--- a/sdk/android/src/jni/video_encoder_wrapper.cc
++++ b/sdk/android/src/jni/video_encoder_wrapper.cc
+@@ -170,6 +170,10 @@ int32_t VideoEncoderWrapper::Encode(
+   }
+ 
+   ScopedJavaLocalRef<jobject> j_frame = NativeToJavaVideoFrame(jni, frame);
++  if (j_frame.is_null()) {
++    RTC_LOG(LS_INFO) << "Video frame is null.";
++    return WEBRTC_VIDEO_CODEC_ERROR;	  
++  }
+   ScopedJavaLocalRef<jobject> ret =
+       Java_VideoEncoder_encode(jni, encoder_, j_frame, encode_info);
+   ReleaseJavaVideoFrame(jni, j_frame);
+diff --git a/sdk/android/src/jni/video_frame.cc b/sdk/android/src/jni/video_frame.cc
+index 121b34fa94..754a992788 100644
+--- a/sdk/android/src/jni/video_frame.cc
++++ b/sdk/android/src/jni/video_frame.cc
+@@ -303,8 +303,11 @@ ScopedJavaLocalRef<jobject> NativeToJavaVideoFrame(JNIEnv* jni,
+         static_cast<jlong>(frame.timestamp_us() *
+                            rtc::kNumNanosecsPerMicrosec));
+   } else {
++    auto i420_buffer = buffer->ToI420();
++    if (!i420_buffer)
++      return ScopedJavaLocalRef<jobject>(nullptr);
+     return Java_VideoFrame_Constructor(
+-        jni, WrapI420Buffer(jni, buffer->ToI420()),
++        jni, WrapI420Buffer(jni, i420_buffer),
+         static_cast<jint>(frame.rotation()),
+         static_cast<jlong>(frame.timestamp_us() *
+                            rtc::kNumNanosecsPerMicrosec));


### PR DESCRIPTION
This patch fixes the crash of [`NativeToJavaVideoFrame`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/sdk/android/src/jni/video_frame.cc;l=291?q=NativeToJavaVideoFrame&ss=chromium%2Fchromium%2Fsrc) in `video_frame.cc`.

```
#00 pc 0000000000394d9c  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::jni::WrapI420Buffer(_JNIEnv*, rtc::scoped_refptr<webrtc::I420BufferInterface> const&)+60)
#01 pc 00000000003941ac  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::jni::NativeToJavaVideoFrame(_JNIEnv*, webrtc::VideoFrame const&)+108)
#02 pc 0000000000391240  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::jni::VideoEncoderWrapper::Encode(webrtc::VideoFrame const&, std::__ndk1::vector<webrtc::VideoFrameType, std::__ndk1::allocator<webrtc::VideoFrameType> > const*)+348)
#03 pc 000000000012b7d4  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (unity::webrtc::UnityVideoEncoder::Encode(webrtc::VideoFrame const&, std::__ndk1::vector<webrtc::VideoFrameType, std::__ndk1::allocator<webrtc::VideoFrameType> > const*)+84)
#04 pc 000000000054998c  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::VideoStreamEncoder::EncodeVideoFrame(webrtc::VideoFrame const&, long)+1676)
#05 pc 0000000000548e04  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::VideoStreamEncoder::MaybeEncodeVideoFrame(webrtc::VideoFrame const&, long)+1400)
#06 pc 00000000005483e0  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::VideoStreamEncoder::OnFrame(webrtc::Timestamp, int, webrtc::VideoFrame const&)+656)
#07 pc 000000000053fe04  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (void absl::internal_any_invocable::RemoteInvoker<false, void, webrtc::(anonymous namespace)::FrameCadenceAdapterImpl::OnFrame(webrtc::VideoFrame const&)::$_0&&>(absl::internal_any_invocable::TypeErasedState*)+220)
#08 pc 0000000000368dd4  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (webrtc::(anonymous namespace)::TaskQueueLibevent::OnWakeup(int, short, void*)+240)
#09 pc 000000000036ab40  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (event_base_loop+1176)
#10 pc 0000000000369644  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (std::__ndk1::__function::__func<webrtc::(anonymous namespace)::TaskQueueLibevent::TaskQueueLibevent(std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char> >, rtc::ThreadPriority)::$_0, std::__ndk1::allocator<webrtc::(anonymous namespace)::TaskQueueLibevent::TaskQueueLibevent(std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char> >, rtc::ThreadPriority)::$_0>, void ()>::operator()()+76)
#11 pc 000000000040f870  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (std::__ndk1::__function::__func<rtc::PlatformThread::SpawnThread(std::__ndk1::function<void ()>, std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char> >, rtc::ThreadAttributes, bool)::$_0, std::__ndk1::allocator<rtc::PlatformThread::SpawnThread(std::__ndk1::function<void ()>, std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char> >, rtc::ThreadAttributes, bool)::$_0>, void ()>::operator()()+220)
#12 pc 000000000040f678  /data/app/com.DefaultCompany.sample-bK3oa2WEYI7iWytdp1Ujlw==/lib/arm64/libwebrtc.so (rtc::(anonymous namespace)::RunPlatformThread(void*)+20)
#13 pc 0000000000069b00  /system/lib64/libc.so (__pthread_start(void*)+36) (BuildId: f01907f9292ce7f34b800afcd8753d5c)
#14 pc 000000000001f958  /system/lib64/libc.so (__start_thread+68) (BuildId: f01907f9292ce7f34b800afcd8753d5c)
```

The cause of this issue is VideoFrameBuffer::ToI420 method often returns nullptr. however,  `NativeToJavaVideoFrame` doesn't check nullptr. Therefore it occrrs crashes by null pointer access.