### PR TITLE
feat: add configurable graphics sync timeout

### DIFF
--- a/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
+++ b/Plugin~/WebRTCPlugin/GpuMemoryBuffer.cpp
@@ -79,8 +79,7 @@ namespace webrtc
     rtc::scoped_refptr<I420BufferInterface> GpuMemoryBufferFromUnity::ToI420()
     {
         using namespace std::chrono_literals;
-        const std::chrono::nanoseconds timeout(60ms); // 60ms
-        if (!device_->WaitSync(textureCpuRead_.get(), timeout.count()))
+        if (!device_->WaitSync(textureCpuRead_.get()))
         {
             RTC_LOG(LS_INFO) << "WaitSync failed.";
             return nullptr;
@@ -91,8 +90,7 @@ namespace webrtc
     const GpuMemoryBufferHandle* GpuMemoryBufferFromUnity::handle() const
     {
         using namespace std::chrono_literals;
-        const std::chrono::nanoseconds timeout(60ms); // 60ms
-        if (!device_->WaitSync(texture_.get(), timeout.count()))
+        if (!device_->WaitSync(texture_.get()))
         {
             RTC_LOG(LS_INFO) << "WaitSync failed.";
             return nullptr;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.cpp
@@ -220,7 +220,7 @@ namespace webrtc
         return GpuMemoryBufferCudaHandle::CreateHandle(GetCUcontext(), resource);
     }
 
-    bool D3D11GraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    bool D3D11GraphicsDevice::WaitSync(const ITexture2D* texture)
     {
         const D3D11Texture2D* d3d11Texture = static_cast<const D3D11Texture2D*>(texture);
         const uint64_t value = d3d11Texture->GetSyncCount();
@@ -237,8 +237,7 @@ namespace webrtc
                 RTC_LOG(LS_INFO) << "ID3D11Fence::SetEventOnCompletion failed. error:" << hr;
                 return false;
             }
-            auto nanoseconds = std::chrono::nanoseconds(nsTimeout);
-            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(nanoseconds).count();
+            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(m_syncTimeout).count();
             DWORD ret = WaitForSingleObject(fenceEvent, static_cast<DWORD>(milliseconds));
             CloseHandle(fenceEvent);
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D11/D3D11GraphicsDevice.h
@@ -31,7 +31,7 @@ namespace webrtc
         virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool WaitSync(const ITexture2D* texture) override;
         bool ResetSync(const ITexture2D* texture) override;
         void Enter() override;
         void Leave() override;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.cpp
@@ -231,7 +231,7 @@ namespace webrtc
         return new D3D12Texture2D(w, h, resource, handle);
     }
 
-    bool D3D12GraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    bool D3D12GraphicsDevice::WaitSync(const ITexture2D* texture)
     {
         const D3D12Texture2D* d3d12Texture = static_cast<const D3D12Texture2D*>(texture);
         const uint64_t value = d3d12Texture->GetSyncCount();
@@ -248,8 +248,7 @@ namespace webrtc
                 RTC_LOG(LS_INFO) << "ID3D12Fence::SetEventOnCompletion failed. error:" << hr;
                 return false;
             }
-            auto nanoseconds = std::chrono::nanoseconds(nsTimeout);
-            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(nanoseconds).count();
+            auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(m_syncTimeout).count();
             DWORD ret = WaitForSingleObject(fenceEvent, static_cast<DWORD>(milliseconds));
             CloseHandle(fenceEvent);
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/D3D12/D3D12GraphicsDevice.h
@@ -76,7 +76,7 @@ namespace webrtc
         virtual bool CopyResourceV(ITexture2D* dest, ITexture2D* src) override;
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool WaitSync(const ITexture2D* texture) override;
         bool ResetSync(const ITexture2D* texture) override;
         bool WaitIdleForTest() override;
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/GraphicsDevice.cpp
@@ -63,7 +63,7 @@ namespace webrtc
             RTC_DCHECK_NOTREACHED();
             return nullptr;
         }
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override
+        bool WaitSync(const ITexture2D* texture) override
         {
             RTC_DCHECK_NOTREACHED();
             return true;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/IGraphicsDevice.h
@@ -30,6 +30,7 @@ namespace webrtc
         IGraphicsDevice(UnityGfxRenderer renderer, ProfilerMarkerFactory* profiler)
             : m_gfxRenderer(renderer)
             , m_profiler(profiler)
+            , m_syncTimeout(std::chrono::milliseconds(60))
         {
         }
 #if CUDA_PLATFORM
@@ -46,8 +47,10 @@ namespace webrtc
         virtual bool CopyResourceFromNativeV(ITexture2D* dest, NativeTexPtr nativeTexturePtr) = 0;
         virtual UnityGfxRenderer GetGfxRenderer() const { return m_gfxRenderer; }
         virtual std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) = 0;
-        virtual bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) { return true; }
+        virtual bool WaitSync(const ITexture2D* texture) { return true; }
         virtual bool ResetSync(const ITexture2D* texture) { return true; }
+        virtual void SetSyncTimeout(std::chrono::nanoseconds nsTimeout) { m_syncTimeout = nsTimeout; }
+        virtual std::chrono::nanoseconds GetSyncTimeout() const { return m_syncTimeout; }
         virtual bool WaitIdleForTest() { return true; }
         virtual void Enter() { }
         virtual void Leave() { }
@@ -62,6 +65,7 @@ namespace webrtc
     protected:
         UnityGfxRenderer m_gfxRenderer;
         ProfilerMarkerFactory* m_profiler;
+        std::chrono::nanoseconds m_syncTimeout;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.h
@@ -31,7 +31,7 @@ namespace webrtc
         bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         rtc::scoped_refptr<I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override { return nullptr; }
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool WaitSync(const ITexture2D* texture) override;
         bool ResetSync(const ITexture2D* texture) override;
 
     private:

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Metal/MetalGraphicsDevice.mm
@@ -106,12 +106,12 @@ namespace webrtc
         return true;
     }
 
-    bool MetalGraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    bool MetalGraphicsDevice::WaitSync(const ITexture2D* texture)
     {
         const MetalTexture2D* texture2D = static_cast<const MetalTexture2D*>(texture);
         dispatch_semaphore_t semaphore = texture2D->GetSemaphore();
 
-        intptr_t value = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, nsTimeout));
+        intptr_t value = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, m_syncTimeout.count()));
         if (value != 0)
         {
             RTC_LOG(LS_INFO) << "The timeout occurred.";

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.cpp
@@ -277,7 +277,7 @@ namespace webrtc
 #endif
     }
 
-    bool OpenGLGraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    bool OpenGLGraphicsDevice::WaitSync(const ITexture2D* texture)
     {
         if (!OpenGLContext::CurrentContext())
             contexts_.push_back(OpenGLContext::CreateGLContext(mainContext_.get()));
@@ -289,7 +289,7 @@ namespace webrtc
             RTC_LOG(LS_INFO) << "The sync object is already reset.";
             return true;
         }
-        GLenum ret = glClientWaitSync(sync, GL_SYNC_FLUSH_COMMANDS_BIT, nsTimeout);
+        GLenum ret = glClientWaitSync(sync, GL_SYNC_FLUSH_COMMANDS_BIT, m_syncTimeout.count());
         GLenum error = glGetError();
         if (error != GL_NO_ERROR)
         {

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/OpenGL/OpenGLGraphicsDevice.h
@@ -37,7 +37,7 @@ namespace webrtc
         rtc::scoped_refptr<webrtc::I420Buffer> ConvertRGBToI420(ITexture2D* tex) override;
         bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool WaitSync(const ITexture2D* texture) override;
         bool ResetSync(const ITexture2D* texture) override;
 
 #if CUDA_PLATFORM

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -460,9 +460,9 @@ namespace webrtc
         std::unique_lock<std::mutex> lock(m_LastStateMtx);
 
         bool ret = m_LastStateCond.wait_until(
-            lock, std::chrono::system_clock::now() + m_syncTimeout, [vulkanTexture, this] {
-                return vulkanTexture->currentFrameNumber <= m_LastState.safeFrameNumber;
-            });
+            lock,
+            std::chrono::system_clock::now() + m_syncTimeout,
+            [vulkanTexture, this] { return vulkanTexture->currentFrameNumber <= m_LastState.safeFrameNumber; });
         return ret;
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -459,10 +459,10 @@ namespace webrtc
         const VulkanTexture2D* vulkanTexture = static_cast<const VulkanTexture2D*>(texture);
         std::unique_lock<std::mutex> lock(m_LastStateMtx);
 
-        bool ret = m_LastStateCond.wait_until(
-            lock,
-            std::chrono::system_clock::now() + m_syncTimeout,
-            [vulkanTexture, this] { return vulkanTexture->currentFrameNumber <= m_LastState.safeFrameNumber; });
+        bool ret =
+            m_LastStateCond.wait_until(lock, std::chrono::system_clock::now() + m_syncTimeout, [vulkanTexture, this] {
+                return vulkanTexture->currentFrameNumber <= m_LastState.safeFrameNumber;
+            });
         return ret;
     }
 

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.cpp
@@ -451,7 +451,7 @@ namespace webrtc
         return false;
     }
 
-    bool VulkanGraphicsDevice::WaitSync(const ITexture2D* texture, uint64_t nsTimeout)
+    bool VulkanGraphicsDevice::WaitSync(const ITexture2D* texture)
     {
         if (!m_unityVulkan)
             return true;
@@ -460,7 +460,7 @@ namespace webrtc
         std::unique_lock<std::mutex> lock(m_LastStateMtx);
 
         bool ret = m_LastStateCond.wait_until(
-            lock, std::chrono::system_clock::now() + std::chrono::nanoseconds(nsTimeout), [vulkanTexture, this] {
+            lock, std::chrono::system_clock::now() + m_syncTimeout, [vulkanTexture, this] {
                 return vulkanTexture->currentFrameNumber <= m_LastState.safeFrameNumber;
             });
         return ret;

--- a/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
+++ b/Plugin~/WebRTCPlugin/GraphicsDevice/Vulkan/VulkanGraphicsDevice.h
@@ -57,7 +57,7 @@ namespace webrtc
         /// <returns></returns>
         bool CopyResourceFromNativeV(ITexture2D* dest, void* nativeTexturePtr) override;
         std::unique_ptr<GpuMemoryBufferHandle> Map(ITexture2D* texture) override;
-        bool WaitSync(const ITexture2D* texture, uint64_t nsTimeout = 0) override;
+        bool WaitSync(const ITexture2D* texture) override;
         bool ResetSync(const ITexture2D* texture) override;
         bool WaitIdleForTest() override;
         bool UpdateState() override;

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1388,11 +1388,9 @@ extern "C"
             return nullptr;
 
         std::vector<::RtpSource> result;
-        std::transform(
-            sources.begin(),
-            sources.end(),
-            std::back_inserter(result),
-            [](webrtc::RtpSource source) { return source; });
+        std::transform(sources.begin(), sources.end(), std::back_inserter(result), [](webrtc::RtpSource source) {
+            return source;
+        });
         return ConvertArray(result, length);
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1388,9 +1388,11 @@ extern "C"
             return nullptr;
 
         std::vector<::RtpSource> result;
-        std::transform(sources.begin(), sources.end(), std::back_inserter(result), [](webrtc::RtpSource source) {
-            return source;
-        });
+        std::transform(
+            sources.begin(),
+            sources.end(),
+            std::back_inserter(result),
+            [](webrtc::RtpSource source) { return source; });
         return ConvertArray(result, length);
     }
 
@@ -1582,7 +1584,7 @@ extern "C"
     UNITY_INTERFACE_EXPORT void SetGraphicsSyncTimeout(uint64_t nSecTimeout)
     {
         auto graphicsDevice = Plugin::GraphicsDevice();
-        graphicsDevice->SetSyncTimeout(std::chrono::nanoseconds(nSecTimeout));   
+        graphicsDevice->SetSyncTimeout(std::chrono::nanoseconds(nSecTimeout));
     }
 #pragma clang diagnostic pop
 }

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1578,5 +1578,11 @@ extern "C"
     {
         frame->SetData(rtc::ArrayView<const uint8_t>(data, size));
     }
+
+    UNITY_INTERFACE_EXPORT void SetGraphicsSyncTimeout(uint64_t nSecTimeout)
+    {
+        auto graphicsDevice = Plugin::GraphicsDevice();
+        graphicsDevice->SetSyncTimeout(std::chrono::nanoseconds(nSecTimeout));   
+    }
 #pragma clang diagnostic pop
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -772,6 +772,17 @@ namespace Unity.WebRTC
             }
         }
 
+        /// <summary>
+        /// Sets the graphics sync timeout.
+        /// Graphics sync timeout determines how long the graphics device will wait on the frame copy for encoding before timing out.
+        /// By default timeout is set to 60 milliseconds.
+        /// </summary>
+        /// <param name="nSecTimeout">The timeout value specified in nanoseconds.</param>
+        public static void SetGraphicsSyncTimeout(uint nSecTimeout)
+        {
+            NativeMethods.SetGraphicsSyncTimeout(nSecTimeout);
+        }
+
         internal static void DisposeInternal()
         {
             if (s_context != null)
@@ -1615,6 +1626,9 @@ namespace Unity.WebRTC
         public static extern bool VideoFrameIsKeyFrame(IntPtr frame);
         [DllImport(WebRTC.Lib)]
         public static extern void FrameTransformerSendFrameToSink(IntPtr transform, IntPtr frame);
+
+        [DllImport(WebRTC.Lib)]
+        public static extern void SetGraphicsSyncTimeout(uint nSecTimeout);
 
     }
 

--- a/Tests/Runtime/WebRTCTest.cs
+++ b/Tests/Runtime/WebRTCTest.cs
@@ -131,5 +131,12 @@ namespace Unity.WebRTC.RuntimeTest
 
             Assert.That(() => WebRTC.Logger = Debug.unityLogger, Throws.Nothing);
         }
+
+        [Test]
+        public void SyncTimeout()
+        {
+            Assert.DoesNotThrow(() => WebRTC.SetGraphicsSyncTimeout(1));
+            Assert.DoesNotThrow(() => WebRTC.SetGraphicsSyncTimeout(60 * 1000 * 1000));
+        }
     }
 }


### PR DESCRIPTION
Description of changes:

- Added configurable graphics sync timeout to allow consumers to specify timeout.

How this was tested:

- Tested by running the WebRTC package tests & Native tests.
- Ran through the package samples to ensure it's working properly.