### PR TITLE
Fix: Crash on the device that does not support NvEnc API .

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/CreateVideoCodecFactory.cpp
@@ -54,13 +54,16 @@ namespace webrtc
         if (impl == kNvCodecImpl)
         {
 #if CUDA_PLATFORM
-            if (gfxDevice && gfxDevice->IsCudaSupport() && NvEncoder::IsSupported())
+            if (gfxDevice && gfxDevice->IsCudaSupport())
             {
                 CUcontext context = gfxDevice->GetCUcontext();
-                NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();
-                std::unique_ptr<VideoEncoderFactory> factory =
-                    std::make_unique<NvEncoderFactory>(context, format, profiler);
-                return CreateSimulcastEncoderFactory(std::move(factory));
+                if (NvEncoder::IsSupported(context))
+                {
+                    NV_ENC_BUFFER_FORMAT format = gfxDevice->GetEncodeBufferFormat();
+                    std::unique_ptr<VideoEncoderFactory> factory =
+                        std::make_unique<NvEncoderFactory>(context, format, profiler);
+                    return CreateSimulcastEncoderFactory(std::move(factory));
+                }
             }
 #endif
         }

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -156,8 +156,8 @@ namespace webrtc
             return false;
         }
 
-        // Check if this device can get the function list of nvencoder API
-        #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+// Check if this device can get the function list of nvencoder API
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
         NV_ENCODE_API_FUNCTION_LIST funclist = { NV_ENCODE_API_FUNCTION_LIST_VER };
         result = NvEncodeAPICreateInstance(&funclist);
         if (result != NV_ENC_SUCCESS || funclist.nvEncOpenEncodeSession == nullptr)
@@ -165,8 +165,8 @@ namespace webrtc
             return false;
         }
 
-        // Check if this device can open encode session
-        #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+// Check if this device can open encode session
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
         NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS encodeSessionExParams = { NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER };
         encodeSessionExParams.device = context;
         encodeSessionExParams.deviceType = NV_ENC_DEVICE_TYPE_CUDA;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -169,7 +169,7 @@ namespace webrtc
         encodeSessionExParams.device = context;
         encodeSessionExParams.deviceType = NV_ENC_DEVICE_TYPE_CUDA;
         encodeSessionExParams.apiVersion = NVENCAPI_VERSION;
-        void *hEncoder = nullptr;
+        void* hEncoder = nullptr;
         result = funclist.nvEncOpenEncodeSessionEx(&encodeSessionExParams, &hEncoder);
         if (result != NV_ENC_SUCCESS || hEncoder == nullptr)
         {

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.cpp
@@ -157,6 +157,7 @@ namespace webrtc
         }
 
         // Check if this device can get the function list of nvencoder API
+        #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
         NV_ENCODE_API_FUNCTION_LIST funclist = { NV_ENCODE_API_FUNCTION_LIST_VER };
         result = NvEncodeAPICreateInstance(&funclist);
         if (result != NV_ENC_SUCCESS || funclist.nvEncOpenEncodeSession == nullptr)
@@ -165,6 +166,7 @@ namespace webrtc
         }
 
         // Check if this device can open encode session
+        #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
         NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS encodeSessionExParams = { NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER };
         encodeSessionExParams.device = context;
         encodeSessionExParams.deviceType = NV_ENC_DEVICE_TYPE_CUDA;

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvCodec.h
@@ -35,7 +35,7 @@ namespace webrtc
             CUmemorytype memoryType,
             NV_ENC_BUFFER_FORMAT format,
             ProfilerMarkerFactory* profiler);
-        static bool IsSupported();
+        static bool IsSupported(CUcontext context);
         ~NvEncoder() override { }
     };
 

--- a/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
+++ b/Plugin~/WebRTCPluginTest/NvCodec/NvCodecTest.cpp
@@ -36,10 +36,11 @@ namespace webrtc
                 GTEST_SKIP() << "The graphics driver is not installed on the device.";
             if (!device_->IsCudaSupport())
                 GTEST_SKIP() << "CUDA is not supported on this device.";
-            if (!NvEncoder::IsSupported())
-                GTEST_SKIP() << "Current Driver Version does not support this NvEncodeAPI version.";
 
             context_ = device_->GetCUcontext();
+
+            if (!NvEncoder::IsSupported(context_))
+                GTEST_SKIP() << "Current Driver Version does not support this NvEncodeAPI version.";
 
             VideoCodecTest::SetUp();
         }


### PR DESCRIPTION
Even on Nvidia devices that support CUDA, NvEncAPI may not be available. (ex MX450)
refer https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new

On those devices, the DLLs (nvcuda.dll, nvencodeAPI.dll) can be found, but an error will occur when calling the open session API.
Therefore, check whether you can open Session and determine whether NvEnc can be used on that device.

I think fix this https://github.com/Unity-Technologies/com.unity.webrtc/issues/806
maybe fix this https://github.com/Unity-Technologies/com.unity.webrtc/issues/1006