### PR TITLE
fix: h264 level selection algorithm

### DIFF
--- a/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
+++ b/Plugin~/WebRTCPlugin/Codec/H264ProfileLevelId.h
@@ -11,10 +11,10 @@ namespace webrtc
 
     // Returns the minumum level which can supports given parameters.
     // webrtc::H264SupportedLevel function is defined in libwebrtc, but that is for decoder.
-    absl::optional<H264Level> H264SupportedLevel(int maxFramePixelCount, int maxFramerate, int maxBitrate);
+    absl::optional<H264Level> H264SupportedLevel(int maxFrameWidthPixelCount, int maxFrameHeightPixelCount, int maxFramerate, int maxBitrate);
 
-    // Returns the max framerate that calclated by maxFramePixelCount.
-    int SupportedMaxFramerate(H264Level level, int maxFramePixelCount);
+    // Returns the max framerate that calclated by maxFrameWidthPixelCount and maxFrameHeightPixelCount.
+    int SupportedMaxFramerate(H264Level level, int maxFrameWidthPixelCount, int maxFrameHeightPixelCount);
 
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
+++ b/Plugin~/WebRTCPlugin/Codec/NvCodec/NvEncoderImpl.cpp
@@ -60,9 +60,8 @@ namespace webrtc
     inline absl::optional<NV_ENC_LEVEL>
     NvEncRequiredLevel(const VideoCodec& codec, std::vector<SdpVideoFormat>& formats, const GUID& guid)
     {
-        int pixelCount = codec.width * codec.height;
         auto requiredLevel = unity::webrtc::H264SupportedLevel(
-            pixelCount, static_cast<int>(codec.maxFramerate), static_cast<int>(codec.maxBitrate));
+            codec.width, codec.height, static_cast<int>(codec.maxFramerate), static_cast<int>(codec.maxBitrate));
 
         if (!requiredLevel)
         {
@@ -223,7 +222,7 @@ namespace webrtc
             // workaround
             // Use supported max framerate that calculated by h264 level define.
             m_codec.maxFramerate = static_cast<uint32_t>(
-                SupportedMaxFramerate(s_maxSupportedH264Level.value(), m_codec.width * m_codec.height));
+                SupportedMaxFramerate(s_maxSupportedH264Level.value(), m_codec.width, m_codec.height));
             requiredLevel = NvEncRequiredLevel(m_codec, s_formats, m_profileGuid);
             if (!requiredLevel)
             {
@@ -567,7 +566,7 @@ namespace webrtc
             // workaround
             // Use supported max framerate that calculated by h264 level define.
             m_codec.maxFramerate = static_cast<uint32_t>(
-                SupportedMaxFramerate(s_maxSupportedH264Level.value(), m_codec.width * m_codec.height));
+                SupportedMaxFramerate(s_maxSupportedH264Level.value(), m_codec.width, m_codec.height));
             requiredLevel = NvEncRequiredLevel(m_codec, s_formats, m_profileGuid);
             if (!requiredLevel)
             {

--- a/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
+++ b/Plugin~/WebRTCPluginTest/H264ProfileLevelIdTest.cpp
@@ -9,25 +9,25 @@ namespace webrtc
 
     TEST(H264ProfileLevelId, TestSupportedLevel)
     {
-        EXPECT_EQ(H264Level::kLevel2_1, *H264SupportedLevel(320 * 240, 25, 4000 * 1200));
-        EXPECT_EQ(H264Level::kLevel3_1, *H264SupportedLevel(1280 * 720, 30, 14000 * 1200));
-        EXPECT_EQ(H264Level::kLevel4_2, *H264SupportedLevel(1920 * 1080, 60, 50000 * 1200));
-        EXPECT_EQ(H264Level::kLevel5_2, *H264SupportedLevel(3840 * 2160, 60, 50000 * 1200));
+        EXPECT_EQ(H264Level::kLevel2_1, *H264SupportedLevel(320, 240, 25, 4000 * 1200));
+        EXPECT_EQ(H264Level::kLevel3_1, *H264SupportedLevel(1280, 720, 30, 14000 * 1200));
+        EXPECT_EQ(H264Level::kLevel4_2, *H264SupportedLevel(1920, 1080, 60, 50000 * 1200));
+        EXPECT_EQ(H264Level::kLevel5_2, *H264SupportedLevel(3840, 2160, 60, 50000 * 1200));
     }
 
     TEST(H264ProfileLevelId, TestSupportedLevelInvalid)
     {
-        EXPECT_FALSE(H264SupportedLevel(0, 0, 0));
-        EXPECT_FALSE(H264SupportedLevel(3840 * 2160, 90, 50000 * 1200));
+        EXPECT_FALSE(H264SupportedLevel(0, 0, 0, 0));
+        EXPECT_FALSE(H264SupportedLevel(3840, 2160, 90, 50000 * 1200));
     }
 
     TEST(H264ProfileLevelId, TestSupportedFramerate)
     {
-        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel2_1, 320 * 240), 25);
-        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel3_1, 1280 * 720), 30);
-        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel4_2, 1920 * 1080), 60);
-        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel5_2, 2560 * 1440), 90);
-        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel5_2, 3840 * 2160), 60);
+        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel2_1, 320, 240), 25);
+        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel3_1, 1280, 720), 30);
+        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel4_2, 1920, 1080), 60);
+        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel5_2, 2560, 1440), 90);
+        EXPECT_GE(SupportedMaxFramerate(H264Level::kLevel5_2, 3840, 2160), 60);
     }
 
     const char kProfileLevelId[] = "profile-level-id";


### PR DESCRIPTION
There seems to be a slight issue in the h264 level selection algorithm. Widths and heights of frames and h264 macroblocks should be taken into account when doing the calculation, not only the pixel counts.
This issue can cause encoder invalid param error on certain resolution ranges.

For example, a 1922x1080 30fps video stream:

The correct algorithm should be
```
macroblocksPerFrame = Ceil( pixelsFrameWidth / pixelsMacroblockSide ) * Ceil( pixelsFrameHeight / pixelsMacroblockSide )
= Ceil( 1922 / 16 ) * Ceil( 1080 / 16 )
= 8228
```
Which resides in level 4.2.

However, according to current algorithm

```
macroblocksPerFrame = Ceil( pixelsPerFrame / pixelsPerMacroblock )
= Ceil( 1922 * 1080 / (16 * 16) )
= 8109
```
Thus, the algorithm would select level 4, and cause encoder invalid param error.