### PR TITLE
fix: remove static libstdc++ linking on Linux to prevent potential crashes

### DIFF
--- a/Plugin~/CMakeLists.txt
+++ b/Plugin~/CMakeLists.txt
@@ -51,12 +51,9 @@ if(XCODE)
   endif()
 endif()
 
-# Use lld linker instead of GNU ld. Link glibc++ statically because of
-# compatibility of lower version of GLIBCXX. This package must support Ubuntu
-# version 16.04, 18.04, 20.04.
+# Use lld linker instead of GNU ld.
 if(Linux)
-  set(CMAKE_CXX_FLAG "${CMAKE_CXX_FLAG} -static-libstdc++")
-  add_link_options(-static-libstdc++ -fuse-ld=lld-11)
+  add_link_options(-fuse-ld=lld-11)
 endif()
 
 # enable debug output


### PR DESCRIPTION
fix #1079 

Unity on Linux is dynamically linked against the system's libstdc++.so. Statically linking libstdc++ in a native plugin caused runtime mismatches, leading to crashes when destroying C++ standard library objects.

This was observed with local std::stringstream instances, but likely affects other STL types relying on shared runtime state (e.g. std::locale, iostreams, allocators).

Switched to dynamic linking of libstdc++ to ensure compatibility with Unity’s runtime environment.