### PR TITLE
ci: Support debug build native plugins with arguments of build scripts 

### DIFF
--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -83,7 +83,7 @@ build_types:
 {% for platform in build_platforms %}
 {% for build_type in build_types %}
 build_{{ platform.name }}_{{ build_type }}:
-  name: Build native plugin for {{ platform.name }}
+  name: Build {{ platform.name }} native plugin for {{ build_type }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}

--- a/.yamato/nativeplugin.yml
+++ b/.yamato/nativeplugin.yml
@@ -74,21 +74,27 @@ test_platforms:
     type: Unity::mobile::shield
     image: mobile/android-package-ci-win:v0.1.4-1212670
     flavor: b1.large
+
+build_types:
+  - debug
+  - release
 ---
 
 {% for platform in build_platforms %}
-build_{{ platform.name }}:
+{% for build_type in build_types %}
+build_{{ platform.name }}_{{ build_type }}:
   name: Build native plugin for {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   commands:
-    - {{ platform.build_command }}
+    - {{ platform.build_command }} {{ build_type }}
   artifacts:
     {{ platform.name }}_plugin:
       paths:
         - {{ platform.plugin_path }}
+{% endfor %} 
 
 build_testrunner_{{ platform.name }}:
   name: Build test runner for native plugin {{ platform.name }}
@@ -199,5 +205,5 @@ push_plugin:
     - git push origin HEAD:$GIT_BRANCH
   dependencies:
     {% for platform in build_platforms %}
-    - .yamato/nativeplugin.yml#build_{{ platform.name }}
+    - .yamato/nativeplugin.yml#build_{{ platform.name }}_release
     {% endfor %}

--- a/.yamato/upm-ci-webrtc-packages.yml
+++ b/.yamato/upm-ci-webrtc-packages.yml
@@ -208,7 +208,7 @@ pack_{{ package.name }}:
         - "upm-ci~/packages/**/*"
   dependencies:
     {% for platform in plugin_platforms %}
-    - .yamato/nativeplugin.yml#build_{{ platform }}
+    - .yamato/nativeplugin.yml#build_{{ platform }}_release
     {% endfor %}
 
 {% for editor in editors %}

--- a/BuildScripts~/build_plugin_android.sh
+++ b/BuildScripts~/build_plugin_android.sh
@@ -4,6 +4,13 @@ export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.we
 export SOLUTION_DIR=$(pwd)/Plugin~
 export PLUGIN_DIR=$(pwd)/Runtime/Plugins/Android
 
+BUILD_TYPE="${1:-release}"
+if [ "$BUILD_TYPE" = "debug" ]; then
+  CMAKE_BUILD_TYPE="Debug"
+else
+  CMAKE_BUILD_TYPE="Release"
+fi
+
 # Download LibWebRTC 
 curl -L $LIBWEBRTC_DOWNLOAD_URL > webrtc.zip
 unzip -d $SOLUTION_DIR/webrtc webrtc.zip 
@@ -20,7 +27,7 @@ do
     -D CMAKE_ANDROID_API=24 \
     -D CMAKE_ANDROID_ARCH_ABI=$ARCH_ABI \
     -D CMAKE_ANDROID_NDK=$ANDROID_NDK \
-    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
     -D CMAKE_ANDROID_STL_TYPE=c++_static
 
   cmake \

--- a/BuildScripts~/build_plugin_ios.sh
+++ b/BuildScripts~/build_plugin_ios.sh
@@ -6,6 +6,13 @@ export WEBRTC_FRAMEWORK_DIR=$(pwd)/Runtime/Plugins/iOS
 export WEBRTC_ARCHIVE_DIR=build/webrtc.xcarchive
 export WEBRTC_SIM_ARCHIVE_DIR=build/webrtc-sim.xcarchive
 
+BUILD_TYPE="${1:-release}"
+if [ "$BUILD_TYPE" = "debug" ]; then
+  CMAKE_BUILD_TYPE="Debug"
+else
+  CMAKE_BUILD_TYPE="Release"
+fi
+
 # Install cmake
 export HOMEBREW_NO_AUTO_UPDATE=1
 brew install cmake
@@ -21,6 +28,7 @@ cmake . \
   -D CMAKE_SYSTEM_NAME=iOS \
   -D "CMAKE_OSX_ARCHITECTURES=arm64;x86_64" \
   -D CMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO \
+  -D CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
   -B build
 
 xcodebuild \

--- a/BuildScripts~/build_plugin_linux.sh
+++ b/BuildScripts~/build_plugin_linux.sh
@@ -5,6 +5,13 @@ export SOLUTION_DIR=$(pwd)/Plugin~
 export OUTPUT_FILEPATH=$(pwd)/Runtime/Plugins/x86_64/libwebrtc.so
 export LIBCXX_BUILD_DIR=$(pwd)/llvm-project/build
 
+BUILD_TYPE="${1:-release}"
+if [ "$BUILD_TYPE" = "debug" ]; then
+  CMAKE_BUILD_TYPE="Debug"
+else
+  CMAKE_BUILD_TYPE="Release"
+fi
+
 source ~/.profile
 
 # Download LibWebRTC 
@@ -13,7 +20,7 @@ unzip -d $SOLUTION_DIR/webrtc webrtc.zip
 
 # Build UnityRenderStreaming Plugin 
 pushd "$SOLUTION_DIR"
-cmake --preset=x86_64-linux -DCMAKE_VERBOSE_MAKEFILE=1
+cmake --preset=x86_64-linux -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
 cmake --build --preset=release-linux --target WebRTCPlugin
 popd
 

--- a/BuildScripts~/build_plugin_mac.sh
+++ b/BuildScripts~/build_plugin_mac.sh
@@ -4,6 +4,13 @@ export LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.we
 export SOLUTION_DIR=$(pwd)/Plugin~
 export DYLIB_FILE=$(pwd)/Runtime/Plugins/macOS/libwebrtc.dylib
 
+BUILD_TYPE="${1:-release}"
+if [ "$BUILD_TYPE" = "debug" ]; then
+  CMAKE_BUILD_TYPE="Debug"
+else
+  CMAKE_BUILD_TYPE="Release"
+fi
+
 # Install cmake
 export HOMEBREW_NO_AUTO_UPDATE=1
 brew install cmake
@@ -17,5 +24,5 @@ rm -rf "$DYLIB_FILE"
 
 # Build UnityRenderStreaming Plugin
 cd "$SOLUTION_DIR"
-cmake --preset=macos
+cmake --preset=macos -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
 cmake --build --preset=release-macos --target=WebRTCPlugin

--- a/BuildScripts~/build_plugin_win.cmd
+++ b/BuildScripts~/build_plugin_win.cmd
@@ -3,6 +3,14 @@
 set LIBWEBRTC_DOWNLOAD_URL=https://github.com/Unity-Technologies/com.unity.webrtc/releases/download/M116-20250805/webrtc-win.zip
 set SOLUTION_DIR=%cd%\Plugin~
 
+set "BUILD_TYPE=%~1"
+if "%BUILD_TYPE%"=="" set "BUILD_TYPE=release"
+if /i "%BUILD_TYPE%"=="debug" (
+  set CMAKE_BUILD_TYPE=Debug
+) else (
+  set CMAKE_BUILD_TYPE=Release
+)
+
 echo Download LibWebRTC
 
 if not exist %SOLUTION_DIR%\webrtc (
@@ -17,5 +25,5 @@ rem https://gitlab.kitware.com/cmake/cmake/-/issues/20776
 rem This program use CUDA kernel to change the video resolution when using NVIDIA Video Codec.
 
 cd %SOLUTION_DIR%
-cmake --preset=x64-windows-msvc
+cmake --preset=x64-windows-msvc -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%
 cmake --build --preset=release-windows-msvc --target=WebRTCPlugin


### PR DESCRIPTION
This pull request introduces support for building native plugins in both debug and release modes across all supported platforms. The build scripts and CI configuration files have been updated to allow specifying the build type, and dependencies have been adjusted to use the correct build artifacts for packaging and deployment.

**Build System Enhancements:**

* Added support for both debug and release build types in the CI configuration (`.yamato/nativeplugin.yml`). Each platform now builds both variants, and build jobs are parameterized by build type.
* Updated CI dependencies in `.yamato/nativeplugin.yml` and `.yamato/upm-ci-webrtc-packages.yml` to reference only the release build artifacts for packaging and plugin publishing steps. [[1]](diffhunk://#diff-4d0f25cd38a2104c4c44e5da20142fdd0f9b8ec45504532553cbf78bd207cc6eL202-R208) [[2]](diffhunk://#diff-cb5c500161b641e7ca6f180e7880e70ca8750c3d6a83ca8fd77fe0baa8f0c8c7L211-R211)

**Platform Build Script Updates:**

* Modified all platform build scripts (`build_plugin_android.sh`, `build_plugin_ios.sh`, `build_plugin_linux.sh`, `build_plugin_mac.sh`, `build_plugin_win.cmd`) to accept an optional build type argument (defaulting to release), and to set the appropriate `CMAKE_BUILD_TYPE` for CMake invocations. [[1]](diffhunk://#diff-4a98374f79ddf856438fec7f0ba5ca3588230f7688d199de45c2b63259109de0R7-R13) [[2]](diffhunk://#diff-4a98374f79ddf856438fec7f0ba5ca3588230f7688d199de45c2b63259109de0L23-R30) [[3]](diffhunk://#diff-512fa629068086d3899bf936b863f91c64bbad9bb4a9fa014c3e70160e85d1ddR9-R15) [[4]](diffhunk://#diff-512fa629068086d3899bf936b863f91c64bbad9bb4a9fa014c3e70160e85d1ddR31) [[5]](diffhunk://#diff-692181316357171803f7f6e6d2a5272819886a5760e36f2e4462b684096acf7cR8-R14) [[6]](diffhunk://#diff-692181316357171803f7f6e6d2a5272819886a5760e36f2e4462b684096acf7cL16-R23) [[7]](diffhunk://#diff-cc78bea96d7d04ab9d93ecaa4d672cbc568a656ba1c380b1bf2d37456830e9c1R7-R13) [[8]](diffhunk://#diff-cc78bea96d7d04ab9d93ecaa4d672cbc568a656ba1c380b1bf2d37456830e9c1L20-R27) [[9]](diffhunk://#diff-7c97bc9acea480015d906b0739874383ed02017d76df152ca1e9eb0c3a144a68R6-R13) [[10]](diffhunk://#diff-7c97bc9acea480015d906b0739874383ed02017d76df152ca1e9eb0c3a144a68L20-R28)