### PR TITLE
chore: Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update minimum Unity version.
 - Upgrade libwebrtc to support 16kb pagesizes for Android.
+- Change Info.plist format for iOS native plugin.
+- Change a license as a Unity Companion License.
+
+### Fixed
+- VideoStreamTrack fails to start streaming on Android.
 
 ## [3.0.0-pre.8] - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update minimum Unity version.
 - Upgrade libwebrtc to support 16kb pagesizes for Android.
 - Change Info.plist format for iOS native plugin.
-- Change a license as a Unity Companion License.
+- Change license to Unity Companion License.
 
 ### Fixed
 - VideoStreamTrack fails to start streaming on Android.


### PR DESCRIPTION
This pull request updates the changelog to reflect several recent changes and fixes. The most notable updates include changes to the iOS native plugin format, a license update, and a fix for Android video streaming.

Notable updates:

**iOS and licensing changes:**
* Changed the `Info.plist` format for the iOS native plugin.
* Changed a license to the Unity Companion License.

**Bug fixes:**
* Fixed an issue where `VideoStreamTrack` fails to start streaming on Android.